### PR TITLE
🚨 Fix: 종료된 공고 재노출 차단 — 크롤 reconciliation + 메일 발송 종료 공고 필터

### DIFF
--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -22,9 +22,14 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -101,6 +106,8 @@ public class CrawlerCommonService {
     }
 
     public List<Job_mst> getNotSaveJobItem(String company, List<Job_mst> result) {
+        reconcileEndedJobs(company, result);
+
         List<String> annoIds = result.stream().map(Job_mst::getAnnoId).collect(Collectors.toList());
         List<Job_mst> existingJobs = crawlerRepository.findAllByAnnoIdIn(annoIds);
         List<Job_mst> jobsToSave = new ArrayList<>();
@@ -288,6 +295,56 @@ public class CrawlerCommonService {
 
     public List<Job_mst> saveAll(List<Job_mst> result) {
         return crawlerRepository.saveAll(result);
+    }
+
+    private static final List<DateTimeFormatter> END_DATE_FORMATTERS = Arrays.asList(
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+    );
+
+    // 크롤 결과에 없는 기존 row 는 사이트에서 내려간 것으로 보고 endDate=어제 로 마킹.
+    // 빈 결과는 네트워크 실패일 수 있어 건너뜀.
+    void reconcileEndedJobs(String companyCd, List<Job_mst> currentlyCrawled) {
+        if (companyCd == null || currentlyCrawled == null || currentlyCrawled.isEmpty()) {
+            log.warn("reconcileEndedJobs 스킵: companyCd={}, crawledSize={}",
+                companyCd, currentlyCrawled == null ? 0 : currentlyCrawled.size());
+            return;
+        }
+        Set<String> crawledAnnoIds = currentlyCrawled.stream()
+            .map(Job_mst::getAnnoId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(HashSet::new));
+
+        List<Job_mst> dbRows = crawlerRepository.findAllByCompanyCd(companyCd);
+        LocalDateTime now = LocalDateTime.now();
+        String endedDateStr = now.minusDays(1).format(END_DATE_FORMATTERS.get(0));
+
+        List<Job_mst> toMark = new ArrayList<>();
+        for (Job_mst row : dbRows) {
+            if (row.getAnnoId() == null) continue;
+            if (crawledAnnoIds.contains(row.getAnnoId())) continue;
+            if (!isCurrentlyLive(row.getEndDate(), now)) continue;
+            row.setEndDate(endedDateStr);
+            toMark.add(row);
+        }
+
+        if (!toMark.isEmpty()) {
+            crawlerRepository.saveAll(toMark);
+            log.info("reconcileEndedJobs: companyCd={} 종료 처리 {}건", companyCd, toMark.size());
+        }
+    }
+
+    private boolean isCurrentlyLive(String endDateStr, LocalDateTime now) {
+        if (endDateStr == null || "영입종료시".equals(endDateStr)) {
+            return true;
+        }
+        for (DateTimeFormatter formatter : END_DATE_FORMATTERS) {
+            try {
+                return LocalDateTime.parse(endDateStr, formatter).isAfter(now);
+            } catch (DateTimeParseException ignored) { }
+        }
+        // 파싱 불가는 보수적으로 살아있는 것으로 간주 (reconciliation 대상 제외)
+        return true;
     }
 
     public PersonalHistoryDto extractPersonalHistoryFromJobPage(String url) {

--- a/src/main/java/com/nklcbdty/api/crawler/repository/CrawlerRepository.java
+++ b/src/main/java/com/nklcbdty/api/crawler/repository/CrawlerRepository.java
@@ -12,4 +12,5 @@ public interface CrawlerRepository extends JpaRepository<Job_mst, Long> {
     boolean existsByAnnoId(String annoIdVarchar); // annoId 존재 여부 확인
     Job_mst findByAnnoId(String annoIdVarchar);   // annoId로 Job_mst 조회
     List<Job_mst> findAllByAnnoIdIn(List<String> annoIds); // 모든 annoId 조회
+    List<Job_mst> findAllByCompanyCd(String companyCd);   // reconciliation 용
 }

--- a/src/main/java/com/nklcbdty/api/email/service/EmailService.java
+++ b/src/main/java/com/nklcbdty/api/email/service/EmailService.java
@@ -171,6 +171,20 @@ public class EmailService {
         }
     }
 
+    // null/"영입종료시"/파싱불가 → 살아있음. 파싱 가능한 과거 날짜만 종료.
+    // reconciliation 으로 종료된 공고는 endDate=어제 가 박혀 여기서 걸러진다.
+    private boolean isLive(Job_mst job, LocalDate today) {
+        String endDateStr = job.getEndDate();
+        if (endDateStr == null || "영입종료시".equals(endDateStr)) {
+            return true;
+        }
+        LocalDate endDate = parseEndDate(endDateStr);
+        if (endDate == null) {
+            return true;
+        }
+        return !endDate.isBefore(today);
+    }
+
     public Map<String, String> sendEmail(List<String> userIds) {
         List<UserIdAndEmailDto> userEmailItems = userService.findByUserIdIn(userIds);
         Map<String, String> userEmailMap = new HashMap<>();
@@ -198,6 +212,10 @@ public class EmailService {
             }
             List<Job_mst> allByCompanyCdInAndSubJobCdNmIn
                 = jobRepository.findAllByCompanyCdInAndSubJobCdNmInOrderByEndDateDesc(companysStr, jobStr);
+            LocalDate today = LocalDate.now();
+            allByCompanyCdInAndSubJobCdNmIn = allByCompanyCdInAndSubJobCdNmIn.stream()
+                .filter(job -> isLive(job, today))
+                .collect(java.util.stream.Collectors.toList());
             // 종료일이 현재 시점 기준 1년 초과인 공고(예: 2999-12-31 등 사실상 무기한)는 뒤로 밀어 노이즈를 줄임
             allByCompanyCdInAndSubJobCdNmIn = pushFarFutureEndDateToBottom(allByCompanyCdInAndSubJobCdNmIn);
             log.info("userId: {}, companys: {}, jobs: {}, allByCompanyCdInAndSubJobCdNmIn: {}", userId, companys, jobs, allByCompanyCdInAndSubJobCdNmIn.size());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved job posting status management. The system now properly tracks and reconciles when job postings end. Only active job opportunities are displayed to users in notifications, ensuring you see only currently-open positions. Ended postings are automatically marked with their final dates for accurate record-keeping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->