### PR TITLE
✨ Feat: LLM 기반 경력 연차 보정 — Sr. Manager 등 시니어 직책 오추출 차단

### DIFF
--- a/src/main/java/com/nklcbdty/api/ai/service/GeminiService.java
+++ b/src/main/java/com/nklcbdty/api/ai/service/GeminiService.java
@@ -22,8 +22,10 @@ import com.nklcbdty.common.vo.Job_mst;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono; // 비동기 처리를 위한 Mono 사용
 
+@Slf4j
 @Service
 public class GeminiService {
 
@@ -257,6 +259,90 @@ public class GeminiService {
         promptBuilder.append("\n응답:"); // 모델이 응답을 시작할 부분 명시
 
         return promptBuilder.toString();
+    }
+
+    /**
+     * 제목 기반으로 요구 최소 경력(년) 추정. 정규식 추출이 SPA 본문 누락 등으로 시니어 직무의 minYears 를
+     * 낮게 잡는 케이스(예: "Sr. Manager, Backend Engineering (Payment)" → 10년이 아닌 2년)를 보정한다.
+     * batch 호출이라 의심 케이스만 모아 한 번 호출하는 게 비용 효율적.
+     */
+    public Mono<Map<String, Long>> classifyExperienceLevels(List<Job_mst> jobs) {
+        if (jobs == null || jobs.isEmpty()) {
+            return Mono.just(Collections.emptyMap());
+        }
+        return Mono.<Void>fromRunnable(this::awaitRateLimitSlot)
+                .then(Mono.defer(() -> doClassifyExperience(jobs)));
+    }
+
+    private Mono<Map<String, Long>> doClassifyExperience(List<Job_mst> jobs) {
+        String prompt = buildExperiencePrompt(jobs);
+        Object requestBody = buildGeminiRequestBody(prompt);
+
+        return geminiWebClient.post()
+                .uri(uriBuilder -> uriBuilder.queryParam("key", apiKey).build())
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(String.class)
+                .retryWhen(rateLimitRetrySpec())
+                .map(this::parseGeminiResponse)
+                .map(this::parseExperienceLevelsFromText);
+    }
+
+    private String buildExperiencePrompt(List<Job_mst> jobs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("""
+                아래 채용 공고 제목들의 요구 최소 경력 연차를 정수로 추정해주세요.
+
+                직책별 일반 가이드:
+                - 신입/주니어/Entry/Junior/Associate: 0
+                - 경력/미드/Mid: 3
+                - 시니어/Senior/Sr.: 8
+                - 리드/Lead/Principal/Staff: 10
+                - 매니저/Manager: 10
+                - 디렉터/Director/Head of/VP: 13
+                - C-level(CTO/CPO 등): 15
+
+                응답 형식: '제목 -> 숫자' (각 줄에 하나)
+                숫자 외의 다른 설명/단위 없이 결과만 나열.
+
+                예시:
+                주니어 백엔드 개발자 -> 0
+                Senior Software Engineer -> 8
+                Sr. Manager, Backend Engineering (Payment) -> 10
+                Lead Data Scientist -> 10
+                VP of Engineering -> 13
+
+                ---
+                제목 리스트:
+                """);
+        for (Job_mst job : jobs) {
+            sb.append("- ").append(job.getAnnoSubject()).append("\n");
+        }
+        sb.append("\n응답:");
+        return sb.toString();
+    }
+
+    private Map<String, Long> parseExperienceLevelsFromText(String responseText) {
+        Map<String, Long> result = new HashMap<>();
+        if (responseText == null || responseText.trim().isEmpty()) {
+            return result;
+        }
+        String[] lines = responseText.split("\\r?\\n");
+        for (String line : lines) {
+            String trimmed = line.strip();
+            if (trimmed.isEmpty() || !trimmed.contains("->")) continue;
+            String[] parts = trimmed.split("->", 2);
+            if (parts.length != 2) continue;
+            String title = parts[0].strip();
+            String yearsStr = parts[1].strip().replaceAll("[^0-9]", "");
+            if (title.isEmpty() || yearsStr.isEmpty()) continue;
+            try {
+                result.put(title, Long.parseLong(yearsStr));
+            } catch (NumberFormatException e) {
+                log.warn("LLM 경력 응답 파싱 실패: line='{}'", trimmed);
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
@@ -122,6 +123,8 @@ public class CrawlerCommonService {
             }
         }
 
+        refinePersonalHistoryByLlm(jobsToSave);
+
         // 한 번에 저장
         if (!jobsToSave.isEmpty()) {
             for (Job_mst item : jobsToSave) {
@@ -175,6 +178,53 @@ public class CrawlerCommonService {
             } else if (jobTitle.contains("인재풀 등록")) {
                 job.setSubJobCdNm(null);
             }
+        }
+    }
+
+    // 시니어/리드/매니저 직책 감지용. SPA 본문 누락 등으로 PersonalHistoryExtractor 가 "10년" 을 못 잡고
+    // 부수 표현인 "관리 경험 2년 이상" 만 잡는 케이스(쿠팡 Sr. Manager Payment 등) 보정 대상 식별.
+    private static final Pattern SENIOR_KEYWORD = Pattern.compile(
+        "(?i)\\bSr\\.?\\b|\\bSenior\\b|\\bLead\\b|\\bPrincipal\\b|\\bStaff\\b|\\bDirector\\b|\\bVP\\b|\\bHead of\\b|\\bManager\\b|\\bChief\\b|시니어|디렉터|매니저|책임|수석|팀장|리더"
+    );
+
+    /**
+     * 정규식 기반 PersonalHistoryExtractor 결과가 시니어 직책 공고에 비해 비현실적으로 낮은 경우
+     * LLM 으로 제목 기반 minYears 를 재추정하여 보정. 의심 케이스만 batch 호출.
+     */
+    void refinePersonalHistoryByLlm(List<Job_mst> jobs) {
+        if (jobs == null || jobs.isEmpty()) return;
+
+        List<Job_mst> suspects = jobs.stream()
+            .filter(j -> j.getAnnoSubject() != null)
+            .filter(j -> j.getPersonalHistory() < 5)
+            .filter(j -> SENIOR_KEYWORD.matcher(j.getAnnoSubject()).find())
+            .collect(Collectors.toList());
+
+        if (suspects.isEmpty()) {
+            log.info("LLM 경력 보정 대상 없음 (전체 {}건)", jobs.size());
+            return;
+        }
+        log.info("LLM 경력 보정 시작 — 대상 {}건 / 전체 {}건", suspects.size(), jobs.size());
+
+        try {
+            Map<String, Long> llmMap = geminiService.classifyExperienceLevels(suspects).block();
+            if (llmMap == null || llmMap.isEmpty()) {
+                log.warn("LLM 경력 보정 결과 비어있음");
+                return;
+            }
+            int updated = 0;
+            for (Job_mst job : suspects) {
+                Long llmMin = llmMap.get(job.getAnnoSubject().strip());
+                if (llmMin == null) continue;
+                if (llmMin > job.getPersonalHistory()) {
+                    log.info("경력 보정: '{}' {} → {}", job.getAnnoSubject(), job.getPersonalHistory(), llmMin);
+                    job.setPersonalHistory(llmMin);
+                    updated++;
+                }
+            }
+            log.info("LLM 경력 보정 완료 — {}건 업데이트", updated);
+        } catch (Exception e) {
+            log.error("LLM 경력 보정 실패: {}", e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
쿠팡 'Sr. Manager, Backend Engineering (Payment)' 처럼 본문 SPA 렌더링으로 '10년 이상' 텍스트가 jsoup body.text() 에 안 잡혀 부수 표현 '관리 경험 2년 이상' 만 정규식이 추출하던 케이스 해결.

흐름:
1. GeminiService.classifyExperienceLevels(jobs)
   - 제목별 직책 가이드(시니어=8, 리드/매니저=10, 디렉터/VP=13 등) 기반 minYears 추정
   - 기존 throttle(4.5s) / 429 백오프 재사용
2. CrawlerCommonService.refinePersonalHistoryByLlm(jobsToSave)
   - 의심 케이스만 필터: personalHistory<5 AND 제목에 시니어 키워드(Sr./Senior/Lead/Manager/디렉터/시니어/책임/수석…)
   - 한 번의 batch 호출 → LLM 추정값이 기존값보다 크면 갱신
3. getNotSaveJobItem 마지막 단계에 통합 — 모든 크롤러가 자동으로 보정 받음

비용: 매 크롤마다 의심 케이스 batch 호출 1회(<= 4.5s throttle).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-powered classification to intelligently estimate and categorize required experience levels across different role types
  * Implemented automatic refinement to detect and correct under-estimated experience requirements for senior and management-level roles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->