### PR TITLE
🚨 Fix: Gemini 429 retry 한도 초과 시 graceful skip — stack trace 노이즈/메서드 t…

### DIFF
--- a/src/main/java/com/nklcbdty/api/ai/service/GeminiService.java
+++ b/src/main/java/com/nklcbdty/api/ai/service/GeminiService.java
@@ -80,7 +80,13 @@ public class GeminiService {
                 .bodyToMono(String.class)
                 .retryWhen(rateLimitRetrySpec())
                 .map(this::parseGeminiResponse)
-                .map(this::parseClassificationsFromText);
+                .map(this::parseClassificationsFromText)
+                // retry 후에도 429 가 지속되면 throw 되는 대신 빈 결과 반환 → caller 가 정상 흐름 유지.
+                // (직무 분류 누락은 다음 크롤 사이클에서 자연 복구)
+                .onErrorResume(this::isRateLimitExhausted, ex -> {
+                    log.warn("Gemini 429 (classifyJobTitles) — retry 한도 초과, 직무 분류 skip. 다음 사이클에서 재시도.");
+                    return Mono.just(Collections.emptyMap());
+                });
     }
 
     private void awaitRateLimitSlot() {
@@ -285,7 +291,21 @@ public class GeminiService {
                 .bodyToMono(String.class)
                 .retryWhen(rateLimitRetrySpec())
                 .map(this::parseGeminiResponse)
-                .map(this::parseExperienceLevelsFromText);
+                .map(this::parseExperienceLevelsFromText)
+                .onErrorResume(this::isRateLimitExhausted, ex -> {
+                    log.warn("Gemini 429 (classifyExperienceLevels) — retry 한도 초과, 경력 보정 skip.");
+                    return Mono.just(Collections.<String, Long>emptyMap());
+                });
+    }
+
+    private boolean isRateLimitExhausted(Throwable t) {
+        if (t instanceof WebClientResponseException w) {
+            return w.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS;
+        }
+        // reactor 가 retry exhausted 예외로 한 번 더 감싸는 경우 cause 확인
+        Throwable cause = t.getCause();
+        return cause instanceof WebClientResponseException w2
+                && w2.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS;
     }
 
     private String buildExperiencePrompt(List<Job_mst> jobs) {


### PR DESCRIPTION
…hrow 제거

운영 환경에서 retry(3회/20s backoff) 후에도 429 가 지속되면 WebClientResponseException 이 caller 로 throw 되어 JobController.cralwer 까지 stack trace 출력 + 처리 비정상 흐름. 원인은 Gemini 무료 티어 RPM/RPD 한도(15 RPM / 1500 RPD) 초과로 추정.

onErrorResume 으로 429 만 잡아 empty Map 반환:
- classifyJobTitles: 직무 분류 skip → 다음 사이클에서 재시도 (subJobCdNm 일시 미설정)
- classifyExperienceLevels: 경력 보정 skip → 기존 PersonalHistoryExtractor 결과 유지

reactor 가 retry exhausted 시 cause 로 감싸는 케이스도 isRateLimitExhausted 에서 처리.