### PR TITLE
🚨 Fix: 수동 메일에도 경력 필터링 적용 — 3년 사용자에게 7년 이상 공고 노출 차단, ♻️ Refactor: JobService 의 endDate=\"error\" 처리를 명시적 분기로 분리

### DIFF
--- a/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
@@ -47,9 +47,10 @@ public class JobService {
                 shouldAdd = true;
             } else if ("영입종료시".equals(endDateStr)) {
                 shouldAdd = true;
+            } else if ("error".equals(endDateStr)) {
+                // 크롤러가 파싱 실패 시 "error" 문자열을 그대로 적재 → 손상 데이터로 간주, 조용히 제외 (shouldAdd 는 false 유지)
             } else {
                 LocalDateTime endDate = parseDateTime(endDateStr);
-                // 파싱 불가 ("error" 같은 손상 데이터) 는 EmailService.isLive 와 동일하게 제외.
                 if (endDate != null && endDate.isAfter(now)) {
                     shouldAdd = true;
                 }

--- a/src/main/java/com/nklcbdty/api/email/service/EmailService.java
+++ b/src/main/java/com/nklcbdty/api/email/service/EmailService.java
@@ -125,8 +125,17 @@ public class EmailService {
             for (UserInterestVo job : jobs) {
                 jobStr.add(job.getItemValue());
             }
+            // 자동(batch) 메일과 동일하게 사용자 경력 필터링도 적용. 과거에는 빠져있어
+            // 경력 3년 사용자에게도 7년 이상 공고가 메일로 노출됐다.
+            List<UserInterestVo> careerYear = userInterestRepository.findItemValueByUserIdAndItemType(userId, "career_year");
+            long careerYearNum;
+            if (careerYear.isEmpty()) {
+                careerYearNum = 0;
+            } else {
+                careerYearNum = Long.parseLong(careerYear.get(careerYear.size() - 1).getItemValue());
+            }
             List<Job_mst> allByCompanyCdInAndSubJobCdNmIn
-                = jobRepository.findAllByCompanyCdInAndSubJobCdNmInOrderByEndDateDesc(companysStr, jobStr);
+                = jobRepository.findJobsByDetailedCriteria(companysStr, jobStr, careerYearNum, 0L);
             LocalDate today = LocalDate.now();
             allByCompanyCdInAndSubJobCdNmIn = allByCompanyCdInAndSubJobCdNmIn.stream()
                 .filter(job -> JobMailOrdering.isLive(job, today))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted data by excluding malformed entries from job listings.

* **New Features**
  * Enhanced daily email personalization with career year-based job filtering to deliver more relevant opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->