### PR TITLE
공고 목록 중복 제거 (같은 회사·annoId 하나만)

### DIFF
--- a/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
@@ -4,7 +4,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,6 +37,8 @@ public class JobService {
 
         LocalDateTime now = LocalDateTime.now();
 
+        // 크롤 시 같은 공고(annoId)가 중복 INSERT 될 수 있어, 조회 시 중복은 하나만 노출한다.
+        final Set<String> seenKeys = new HashSet<>();
         List<Job_mst> result = new ArrayList<>();
         for (Job_mst item : items) {
             String endDateStr = item.getEndDate();
@@ -53,7 +57,7 @@ public class JobService {
                 }
             }
 
-            if (shouldAdd) {
+            if (shouldAdd && seenKeys.add(dedupKey(item))) {
                 // 실제 DB PK 유지(삭제요청 등에서 공고 식별에 사용). 과거 랜덤 id 덮어쓰기 제거.
                 result.add(item);
             }
@@ -90,6 +94,23 @@ public class JobService {
     /** 종료기간이 없는 상시채용 공고인지 여부 (종료일 null 또는 "영입종료시") */
     private boolean isAlwaysRecruiting(String endDateStr) {
         return endDateStr == null || "영입종료시".equals(endDateStr);
+    }
+
+    /**
+     * 중복 제거 키. 같은 회사의 같은 공고(annoId)를 동일 건으로 본다.
+     * annoId 가 없으면 회사+제목으로, 그것도 없으면 PK(id)로 폴백해 서로 다른 건이 합쳐지지 않게 한다.
+     */
+    private String dedupKey(Job_mst item) {
+        final String company = item.getCompanyCd() != null ? item.getCompanyCd() : "";
+        final String annoId = item.getAnnoId();
+        if (annoId != null && !annoId.isBlank()) {
+            return company + "|anno|" + annoId;
+        }
+        final String subject = item.getAnnoSubject();
+        if (subject != null && !subject.isBlank()) {
+            return company + "|subj|" + subject;
+        }
+        return "id|" + item.getId();
     }
 
     @Transactional

--- a/src/test/java/com/nklcbdty/api/crawler/service/JobServiceListOrderTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/service/JobServiceListOrderTest.java
@@ -45,4 +45,30 @@ class JobServiceListOrderTest {
         assertThat(result).extracting(Job_mst::getAnnoSubject)
             .containsExactly("마감 빠른 공고", "마감 늦은 공고", "상시채용 A(null)", "상시채용 B(영입종료시)");
     }
+
+    private Job_mst jobFull(String company, String annoId, String subject, String endDate) {
+        Job_mst j = new Job_mst();
+        j.setCompanyCd(company);
+        j.setAnnoId(annoId);
+        j.setAnnoSubject(subject);
+        j.setSubJobCdNm("Data Engineering");
+        j.setEndDate(endDate);
+        return j;
+    }
+
+    @Test
+    void list_같은회사_annoId_중복공고는_하나만_반환한다() {
+        Job_mst dup1 = jobFull("NAVER", "12345", "Product Data Analyst (경력)", "2099-01-01 23:59:00");
+        Job_mst dup2 = jobFull("NAVER", "12345", "Product Data Analyst (경력)", "2099-01-01 23:59:00");
+        Job_mst other = jobFull("NAVER", "99999", "다른 공고", "2099-02-01 23:59:00");
+
+        when(jobRepository.findAllByCompanyCdAndSubJobCdNmIsNotNullOrderByEndDateAsc("NAVER"))
+            .thenReturn(Arrays.asList(dup1, dup2, other));
+
+        JobService service = new JobService(jobRepository);
+        List<Job_mst> result = service.list("NAVER");
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Job_mst::getAnnoId).containsExactlyInAnyOrder("12345", "99999");
+    }
 }


### PR DESCRIPTION
크롤 재실행으로 중복 INSERT 된 동일 annoId 공고가 /api/list 에 여러 건 보이던 문제. 조회 시 회사+annoId 기준 중복 제거. 단위 테스트 포함.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate job listings in search results. Job postings are now deduplicated to ensure each unique listing appears only once when searching by company.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->