### PR TITLE
✨ Feat: 이력서 PDF 업로드 → 적합 공고 매칭 API + 의미 검색(RAG) 인프라

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 	// Jsoup 크롤링 라이브러리
 	implementation 'org.jsoup:jsoup:1.17.2'
 
+	// Apache PDFBox — 업로드된 이력서 PDF 텍스트 추출 (공고 매칭용)
+	implementation 'org.apache.pdfbox:pdfbox:3.0.3'
+
 	// Apache OpenNLP — 자체 NER(개체명 인식) 모델 학습/추론용
 	implementation 'org.apache.opennlp:opennlp-tools:2.3.3'
 

--- a/src/main/java/com/nklcbdty/api/ai/rag/EmbeddingService.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/EmbeddingService.java
@@ -1,0 +1,76 @@
+package com.nklcbdty.api.ai.rag;
+
+import ai.djl.huggingface.translator.TextEmbeddingTranslatorFactory;
+import ai.djl.inference.Predictor;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.translate.TranslateException;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 한국어/영어 다국어 문장 임베딩 서비스 (DJL + PyTorch + HuggingFace).
+ *
+ * <p>모델: sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 (384차원, ~117MB)</p>
+ * <p>첫 부팅 시 모델을 자동 다운로드해 {@code ~/.djl.ai/cache/} 에 캐싱한다.</p>
+ *
+ * <p>모델 로드 실패 시(네트워크 없음 등) 앱은 정상 기동되며,
+ * {@link #isAvailable()} 가 false 를 반환해 호출자가 graceful fallback 할 수 있도록 한다.</p>
+ */
+@Slf4j
+@Service
+public class EmbeddingService {
+
+    private static final String MODEL_URL =
+            "djl://ai.djl.huggingface.pytorch/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2";
+    public static final String MODEL_VERSION = "paraphrase-multilingual-MiniLM-L12-v2";
+
+    private ZooModel<String, float[]> model;
+    private Predictor<String, float[]> predictor;
+
+    @PostConstruct
+    public void load() {
+        try {
+            Criteria<String, float[]> criteria = Criteria.builder()
+                    .setTypes(String.class, float[].class)
+                    .optModelUrls(MODEL_URL)
+                    .optEngine("PyTorch")
+                    .optTranslatorFactory(new TextEmbeddingTranslatorFactory())
+                    .build();
+            this.model = criteria.loadModel();
+            this.predictor = model.newPredictor();
+            log.info("임베딩 모델 로드 완료: {}", MODEL_VERSION);
+        } catch (Exception e) {
+            log.error("임베딩 모델 로드 실패 → 의미 검색 비활성화. 원인: {}", e.getMessage());
+        }
+    }
+
+    @PreDestroy
+    public void close() {
+        if (predictor != null) predictor.close();
+        if (model != null) model.close();
+    }
+
+    public boolean isAvailable() {
+        return predictor != null;
+    }
+
+    /** 입력 텍스트를 단위벡터로 임베딩한다. 실패/비가용 시 null. */
+    public float[] embed(String text) {
+        if (!isAvailable() || text == null || text.isBlank()) {
+            return null;
+        }
+        try {
+            float[] vec;
+            synchronized (predictor) {
+                vec = predictor.predict(text);
+            }
+            return Vectors.normalize(vec);
+        } catch (TranslateException e) {
+            log.error("임베딩 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/nklcbdty/api/ai/rag/JobEmbeddingCache.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/JobEmbeddingCache.java
@@ -1,0 +1,76 @@
+package com.nklcbdty.api.ai.rag;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * 임베딩 벡터 인메모리 캐시. 부팅 시 DB → 메모리로 한 번에 적재하고,
+ * 신규 인덱싱은 {@link #put} 으로 hot-add.
+ *
+ * <p>검색 비용: O(N) linear scan. N=10,000, 384차원 기준 단일 쿼리 ~10ms.
+ * 수십만 건 이상에서는 ANN(HNSW) 인덱스나 ES kNN으로 진화 필요.</p>
+ */
+@Slf4j
+@Service
+public class JobEmbeddingCache {
+
+    public static final class Entry {
+        public final Long jobId;
+        public final float[] vec;
+        public Entry(Long jobId, float[] vec) { this.jobId = jobId; this.vec = vec; }
+    }
+
+    public static final class Hit {
+        public final Long jobId;
+        public final float score;
+        public Hit(Long jobId, float score) { this.jobId = jobId; this.score = score; }
+    }
+
+    private final CopyOnWriteArrayList<Entry> entries = new CopyOnWriteArrayList<>();
+    private final JobEmbeddingRepository repo;
+
+    public JobEmbeddingCache(JobEmbeddingRepository repo) {
+        this.repo = repo;
+    }
+
+    @PostConstruct
+    public void warmUp() {
+        long t0 = System.currentTimeMillis();
+        try {
+            List<Object[]> rows = repo.findAllEmbeddingsRaw();
+            for (Object[] row : rows) {
+                Long id = (Long) row[0];
+                byte[] bytes = (byte[]) row[1];
+                float[] v = Vectors.fromBytes(bytes);
+                if (v.length > 0) entries.add(new Entry(id, v));
+            }
+            log.info("임베딩 캐시 워밍업 완료: {}건 ({}ms)", entries.size(), System.currentTimeMillis() - t0);
+        } catch (Exception e) {
+            log.warn("임베딩 캐시 워밍업 실패 (테이블 컬럼 미생성 가능): {}", e.getMessage());
+        }
+    }
+
+    public void put(Long jobId, float[] vec) {
+        entries.removeIf(e -> e.jobId.equals(jobId));
+        entries.add(new Entry(jobId, vec));
+    }
+
+    public List<Hit> search(float[] query, int topK) {
+        if (query == null || query.length == 0 || entries.isEmpty()) return List.of();
+        List<Hit> hits = new ArrayList<>(entries.size());
+        for (Entry e : entries) {
+            if (e.vec.length != query.length) continue;
+            hits.add(new Hit(e.jobId, Vectors.dot(query, e.vec)));
+        }
+        hits.sort(Comparator.comparingDouble((Hit h) -> -h.score));
+        return hits.subList(0, Math.min(topK, hits.size()));
+    }
+
+    public int size() { return entries.size(); }
+}

--- a/src/main/java/com/nklcbdty/api/ai/rag/JobEmbeddingIndexer.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/JobEmbeddingIndexer.java
@@ -1,0 +1,77 @@
+package com.nklcbdty.api.ai.rag;
+
+import com.nklcbdty.common.vo.Job_mst;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 임베딩이 없는 신규/기존 공고를 주기적으로 인덱싱한다.
+ * 모델 로드 실패 시에는 아무것도 하지 않고 다음 주기를 기다린다.
+ */
+@Slf4j
+@Service
+public class JobEmbeddingIndexer {
+
+    private static final int BATCH_SIZE = 50;
+
+    private final JobEmbeddingRepository repo;
+    private final EmbeddingService embedder;
+    private final JobEmbeddingCache cache;
+
+    public JobEmbeddingIndexer(JobEmbeddingRepository repo,
+                               EmbeddingService embedder,
+                               JobEmbeddingCache cache) {
+        this.repo = repo;
+        this.embedder = embedder;
+        this.cache = cache;
+    }
+
+    @Scheduled(fixedDelay = 60_000L, initialDelay = 30_000L)
+    @Transactional
+    public void indexBatch() {
+        if (!embedder.isAvailable()) return;
+
+        List<Job_mst> targets;
+        try {
+            targets = repo.findUnindexed(PageRequest.of(0, BATCH_SIZE));
+        } catch (Exception e) {
+            log.warn("임베딩 미인덱스 조회 실패: {}", e.getMessage());
+            return;
+        }
+        if (targets.isEmpty()) return;
+
+        long t0 = System.currentTimeMillis();
+        int ok = 0;
+        for (Job_mst j : targets) {
+            try {
+                String text = textFor(j);
+                if (text.isBlank()) continue;
+                float[] vec = embedder.embed(text);
+                if (vec == null) continue;
+                j.setEmbedding(Vectors.toBytes(vec));
+                j.setEmbeddingVersion(EmbeddingService.MODEL_VERSION);
+                cache.put(j.getId(), vec);
+                ok++;
+            } catch (Exception e) {
+                log.warn("임베딩 실패 jobId={}: {}", j.getId(), e.getMessage());
+            }
+        }
+        log.info("임베딩 배치: {}/{}건 ({}ms)", ok, targets.size(), System.currentTimeMillis() - t0);
+    }
+
+    private String textFor(Job_mst j) {
+        StringBuilder b = new StringBuilder();
+        if (j.getAnnoSubject() != null) b.append(j.getAnnoSubject()).append(' ');
+        if (j.getSubJobCdNm() != null) b.append(j.getSubJobCdNm()).append(' ');
+        if (j.getClassCdNm() != null) b.append(j.getClassCdNm()).append(' ');
+        if (j.getSysCompanyCdNm() != null) b.append(j.getSysCompanyCdNm()).append(' ');
+        if (j.getWorkplace() != null) b.append(j.getWorkplace()).append(' ');
+        if (j.getEmpTypeCdNm() != null) b.append(j.getEmpTypeCdNm());
+        return b.toString().trim();
+    }
+}

--- a/src/main/java/com/nklcbdty/api/ai/rag/JobEmbeddingRepository.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/JobEmbeddingRepository.java
@@ -1,0 +1,24 @@
+package com.nklcbdty.api.ai.rag;
+
+import com.nklcbdty.common.vo.Job_mst;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface JobEmbeddingRepository extends JpaRepository<Job_mst, Long> {
+
+    /** 아직 임베딩이 없는 공고를 페이지 단위로 조회 (배치 인덱싱용) */
+    @Query("SELECT j FROM Job_mst j WHERE j.embedding IS NULL")
+    List<Job_mst> findUnindexed(Pageable pageable);
+
+    /**
+     * 캐시 워밍업용. (id, embedding) 만 가볍게 가져옴.
+     * <p>리턴 타입은 Object[] 배열: [0]=Long id, [1]=byte[] embedding</p>
+     */
+    @Query("SELECT j.id, j.embedding FROM Job_mst j WHERE j.embedding IS NOT NULL")
+    List<Object[]> findAllEmbeddingsRaw();
+}

--- a/src/main/java/com/nklcbdty/api/ai/rag/JobMatchController.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/JobMatchController.java
@@ -1,0 +1,66 @@
+package com.nklcbdty.api.ai.rag;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 이력서 PDF → 적합 공고 매칭 엔드포인트.
+ *
+ * <p>예: {@code POST /api/jobs/match} (multipart/form-data, file=이력서.pdf)</p>
+ * <p>PDF 텍스트를 추출해 {@link SemanticSearchService} 의미 검색으로 가장 유사한 공고 top-K 를 반환한다.</p>
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/jobs")
+public class JobMatchController {
+
+    private static final int DEFAULT_K = 5;
+    private static final int MAX_K = 20;
+
+    private final SemanticSearchService search;
+    private final ResumePdfExtractor pdfExtractor;
+
+    public JobMatchController(SemanticSearchService search, ResumePdfExtractor pdfExtractor) {
+        this.search = search;
+        this.pdfExtractor = pdfExtractor;
+    }
+
+    @PostMapping(value = "/match", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public List<JobSearchController.JobSearchHit> match(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "k", defaultValue = "" + DEFAULT_K) int k) {
+
+        int topK = Math.max(1, Math.min(k, MAX_K));
+
+        String resumeText;
+        try {
+            resumeText = pdfExtractor.extract(file);
+        } catch (ResumePdfExtractor.ExtractionException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+
+        List<SemanticSearchService.Result> results = search.search(resumeText, topK);
+        if (results.isEmpty()) {
+            // 모델 미로드 또는 인덱싱된 공고 없음 → 빈 결과로 갈리지 않도록 503 으로 구분
+            log.warn("PDF 매칭 결과 없음 — 임베딩 모델 미로드이거나 인덱싱된 공고가 없습니다.");
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
+                    "현재 공고 매칭을 사용할 수 없습니다. (임베딩 준비 중이거나 매칭 가능한 공고가 없습니다)");
+        }
+
+        List<JobSearchController.JobSearchHit> out = new ArrayList<>(results.size());
+        for (SemanticSearchService.Result r : results) {
+            out.add(JobSearchController.JobSearchHit.from(r));
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/ai/rag/JobSearchController.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/JobSearchController.java
@@ -1,0 +1,67 @@
+package com.nklcbdty.api.ai.rag;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 자연어 공고 검색 엔드포인트.
+ *
+ * <p>예: {@code GET /api/jobs/search?q=원격 가능한 백엔드 시니어&k=10}</p>
+ */
+@RestController
+@RequestMapping("/api/jobs")
+public class JobSearchController {
+
+    private final SemanticSearchService search;
+
+    public JobSearchController(SemanticSearchService search) {
+        this.search = search;
+    }
+
+    public static class JobSearchHit {
+        public Long id;
+        public String companyCd;
+        public String annoSubject;
+        public String classCdNm;
+        public String subJobCdNm;
+        public String sysCompanyCdNm;
+        public String workplace;
+        public String jobDetailLink;
+        public long personalHistory;
+        public long personalHistoryEnd;
+        public float score;
+
+        /** 의미 검색 결과 → 응답 DTO 매핑. (PDF 매칭 등 다른 진입점과 공유) */
+        public static JobSearchHit from(SemanticSearchService.Result r) {
+            JobSearchHit h = new JobSearchHit();
+            h.id = r.job.getId();
+            h.companyCd = r.job.getCompanyCd();
+            h.annoSubject = r.job.getAnnoSubject();
+            h.classCdNm = r.job.getClassCdNm();
+            h.subJobCdNm = r.job.getSubJobCdNm();
+            h.sysCompanyCdNm = r.job.getSysCompanyCdNm();
+            h.workplace = r.job.getWorkplace();
+            h.jobDetailLink = r.job.getJobDetailLink();
+            h.personalHistory = r.job.getPersonalHistory();
+            h.personalHistoryEnd = r.job.getPersonalHistoryEnd();
+            h.score = r.score;
+            return h;
+        }
+    }
+
+    @GetMapping("/search")
+    public List<JobSearchHit> search(@RequestParam("q") String q,
+                                     @RequestParam(value = "k", defaultValue = "10") int k) {
+        List<SemanticSearchService.Result> results = search.search(q, k);
+        List<JobSearchHit> out = new ArrayList<>(results.size());
+        for (SemanticSearchService.Result r : results) {
+            out.add(JobSearchHit.from(r));
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/ai/rag/ResumePdfExtractor.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/ResumePdfExtractor.java
@@ -1,0 +1,76 @@
+package com.nklcbdty.api.ai.rag;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+/**
+ * 업로드된 이력서 PDF에서 텍스트를 추출한다.
+ *
+ * <p>추출된 텍스트는 의미 검색({@link SemanticSearchService})의 query 로 사용된다.
+ * 임베딩 모델(paraphrase-multilingual-MiniLM-L12-v2)은 긴 입력일수록 벡터가 희석되므로
+ * 앞부분 일부만 사용하도록 길이를 제한한다.</p>
+ */
+@Slf4j
+@Service
+public class ResumePdfExtractor {
+
+    /** 임베딩에 넘길 최대 문자 수. 모델 토큰 한계(~512)와 매칭 정확도를 고려한 보수적 상한. */
+    private static final int MAX_CHARS = 3000;
+
+    public static final class ExtractionException extends RuntimeException {
+        public ExtractionException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * PDF MultipartFile → 정규화된 평문 텍스트.
+     *
+     * @throws ExtractionException 빈 파일/암호화/파싱 실패/본문 없음
+     */
+    public String extract(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new ExtractionException("PDF 파일이 비어 있습니다.");
+        }
+
+        byte[] bytes;
+        try {
+            bytes = file.getBytes();
+        } catch (IOException e) {
+            throw new ExtractionException("PDF 파일을 읽을 수 없습니다.");
+        }
+
+        try (PDDocument doc = Loader.loadPDF(bytes)) {
+            if (doc.isEncrypted()) {
+                throw new ExtractionException("암호화된 PDF는 처리할 수 없습니다.");
+            }
+            PDFTextStripper stripper = new PDFTextStripper();
+            String raw = stripper.getText(doc);
+            String normalized = normalize(raw);
+            if (normalized.isBlank()) {
+                // 스캔 이미지 PDF 등 텍스트 레이어가 없는 경우
+                throw new ExtractionException("PDF에서 텍스트를 추출하지 못했습니다. (이미지 기반 PDF일 수 있습니다)");
+            }
+            return truncate(normalized);
+        } catch (IOException e) {
+            log.warn("PDF 파싱 실패: {}", e.getMessage());
+            throw new ExtractionException("PDF 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private String normalize(String text) {
+        if (text == null) return "";
+        // 연속 공백/개행을 단일 공백으로 압축
+        return text.replaceAll("[\\s\\u00A0]+", " ").trim();
+    }
+
+    private String truncate(String text) {
+        return text.length() <= MAX_CHARS ? text : text.substring(0, MAX_CHARS);
+    }
+}

--- a/src/main/java/com/nklcbdty/api/ai/rag/SemanticSearchService.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/SemanticSearchService.java
@@ -1,0 +1,66 @@
+package com.nklcbdty.api.ai.rag;
+
+import com.nklcbdty.common.vo.Job_mst;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 자연어 쿼리 → 의미 유사 공고 top-K 반환.
+ * (1단계 MVP: 생성 LLM 없음. 검색 결과만 반환 → 토큰 비용 0)
+ */
+@Slf4j
+@Service
+public class SemanticSearchService {
+
+    public static final class Result {
+        public Job_mst job;
+        public float score;
+    }
+
+    private final EmbeddingService embedder;
+    private final JobEmbeddingCache cache;
+    private final JobEmbeddingRepository repo;
+
+    public SemanticSearchService(EmbeddingService embedder,
+                                 JobEmbeddingCache cache,
+                                 JobEmbeddingRepository repo) {
+        this.embedder = embedder;
+        this.cache = cache;
+        this.repo = repo;
+    }
+
+    public List<Result> search(String query, int topK) {
+        if (query == null || query.isBlank()) return List.of();
+        if (!embedder.isAvailable()) {
+            log.warn("임베딩 모델 미로드 → 의미 검색 불가 (모델 다운로드/로드 중일 수 있음)");
+            return List.of();
+        }
+
+        float[] q = embedder.embed(query);
+        if (q == null) return List.of();
+
+        List<JobEmbeddingCache.Hit> hits = cache.search(q, Math.max(1, topK));
+        if (hits.isEmpty()) return List.of();
+
+        List<Long> ids = hits.stream().map(h -> h.jobId).collect(Collectors.toList());
+        Map<Long, Job_mst> byId = new HashMap<>();
+        for (Job_mst j : repo.findAllById(ids)) byId.put(j.getId(), j);
+
+        List<Result> out = new ArrayList<>(hits.size());
+        for (JobEmbeddingCache.Hit h : hits) {
+            Job_mst j = byId.get(h.jobId);
+            if (j == null) continue;
+            Result r = new Result();
+            r.job = j;
+            r.score = h.score;
+            out.add(r);
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/ai/rag/Vectors.java
+++ b/src/main/java/com/nklcbdty/api/ai/rag/Vectors.java
@@ -1,0 +1,49 @@
+package com.nklcbdty.api.ai.rag;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * 임베딩 벡터 유틸. float[] ↔ byte[] 변환 + 코사인 유사도.
+ *
+ * <p>모든 벡터는 단위벡터(L2-norm=1)로 정규화되어 저장된다고 가정한다.
+ * → 코사인 유사도 = 내적(dot product) 으로 계산 가능 → 5~10배 빠름.</p>
+ */
+public final class Vectors {
+
+    private Vectors() {}
+
+    public static float[] normalize(float[] v) {
+        double s = 0;
+        for (float x : v) s += x * x;
+        double n = Math.sqrt(s);
+        if (n < 1e-12) return v.clone();
+        float inv = (float) (1.0 / n);
+        float[] out = new float[v.length];
+        for (int i = 0; i < v.length; i++) out[i] = v[i] * inv;
+        return out;
+    }
+
+    /** 단위벡터 가정 — dot product = cosine similarity */
+    public static float dot(float[] a, float[] b) {
+        if (a == null || b == null || a.length != b.length) return -1f;
+        float s = 0;
+        for (int i = 0; i < a.length; i++) s += a[i] * b[i];
+        return s;
+    }
+
+    public static byte[] toBytes(float[] v) {
+        ByteBuffer bb = ByteBuffer.allocate(v.length * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (float f : v) bb.putFloat(f);
+        return bb.array();
+    }
+
+    public static float[] fromBytes(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) return new float[0];
+        ByteBuffer bb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        int n = bytes.length / 4;
+        float[] out = new float[n];
+        for (int i = 0; i < n; i++) out[i] = bb.getFloat();
+        return out;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
+++ b/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
@@ -21,6 +21,9 @@ public enum AllowedPaths {
     COUNT_BY_DATE("/api/statistics/count-by-date"),
     TEST("/api/test"),
     SEARCH("/api/job/**"),
+    // 공고 의미 검색(/api/jobs/search)과 이력서 PDF 매칭(/api/jobs/match). 인증 없이 공개.
+    // ('/api/job/**' 는 정규식상 's' 가 붙은 '/api/jobs/...' 를 매치하지 못해 별도 등록)
+    JOBS("/api/jobs/**"),
     // 관리자 로그인만 공개. 그 외 /api/admin/** 은 AuthFilter 에서 ADMIN 역할 토큰을 요구한다.
     ADMIN_LOGIN("/api/admin/login"),
     ;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 spring.profiles.active=dev
 spring.application.name=nklcbdty
 spring.mvc.servlet.load-on-startup=1
+# 이력서 PDF 업로드 크기 상한 (기본 1MB → 10MB)
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
 # JPA
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect

--- a/src/main/resources/db/migration/V1__add_job_embedding_columns.sql
+++ b/src/main/resources/db/migration/V1__add_job_embedding_columns.sql
@@ -1,0 +1,6 @@
+-- RAG: 의미 검색용 임베딩 컬럼 추가
+-- ddl-auto=none 이므로 운영 DB에 수동 적용 필요.
+-- 모델: paraphrase-multilingual-MiniLM-L12-v2 (384차원 × 4byte = 1536 byte)
+ALTER TABLE job_mst ADD COLUMN embedding MEDIUMBLOB NULL;
+ALTER TABLE job_mst ADD COLUMN embedding_version VARCHAR(64) NULL;
+CREATE INDEX idx_job_mst_embedding_null ON job_mst ((embedding IS NULL));

--- a/src/test/java/com/nklcbdty/api/ai/rag/ResumePdfExtractorTest.java
+++ b/src/test/java/com/nklcbdty/api/ai/rag/ResumePdfExtractorTest.java
@@ -1,0 +1,85 @@
+package com.nklcbdty.api.ai.rag;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResumePdfExtractorTest {
+
+    private final ResumePdfExtractor extractor = new ResumePdfExtractor();
+
+    /** 주어진 줄들을 담은 1페이지 PDF 바이트를 생성한다. (영문/숫자만 — Standard14 폰트 한계) */
+    private byte[] makePdf(String... lines) throws Exception {
+        try (PDDocument doc = new PDDocument(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            doc.addPage(page);
+            try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+                cs.beginText();
+                cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                cs.setLeading(16f);
+                cs.newLineAtOffset(50, 700);
+                for (String line : lines) {
+                    cs.showText(line);
+                    cs.newLine();
+                }
+                cs.endText();
+            }
+            doc.save(out);
+            return out.toByteArray();
+        }
+    }
+
+    private MockMultipartFile pdfFile(byte[] bytes) {
+        return new MockMultipartFile("file", "resume.pdf", "application/pdf", bytes);
+    }
+
+    @Test
+    @DisplayName("정상 PDF: 텍스트 추출 + 공백 정규화")
+    void extractsAndNormalizes() throws Exception {
+        byte[] pdf = makePdf("Backend Engineer", "Spring Boot Kafka Redis", "5 years experience");
+        String text = extractor.extract(pdfFile(pdf));
+
+        assertTrue(text.contains("Backend Engineer"), "본문 포함");
+        assertTrue(text.contains("Kafka"), "키워드 포함");
+        // 개행이 단일 공백으로 정규화되어 연속 공백/줄바꿈이 없어야 함
+        assertFalse(text.contains("\n"), "개행 제거됨");
+        assertFalse(text.contains("  "), "연속 공백 없음");
+    }
+
+    @Test
+    @DisplayName("긴 PDF: MAX_CHARS(3000)로 truncate")
+    void truncatesLongText() throws Exception {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 600; i++) sb.append("word").append(i).append(' ');
+        byte[] pdf = makePdf(sb.toString());
+
+        String text = extractor.extract(pdfFile(pdf));
+        assertEquals(3000, text.length(), "3000자로 잘림");
+    }
+
+    @Test
+    @DisplayName("빈 파일은 ExtractionException")
+    void emptyFileThrows() {
+        MockMultipartFile empty = new MockMultipartFile("file", "x.pdf", "application/pdf", new byte[0]);
+        assertThrows(ResumePdfExtractor.ExtractionException.class, () -> extractor.extract(empty));
+    }
+
+    @Test
+    @DisplayName("PDF가 아닌 바이트는 ExtractionException")
+    void notPdfThrows() {
+        MockMultipartFile bad = pdfFile("this is not a pdf".getBytes());
+        assertThrows(ResumePdfExtractor.ExtractionException.class, () -> extractor.extract(bad));
+    }
+}

--- a/src/test/java/com/nklcbdty/api/ai/rag/VectorsTest.java
+++ b/src/test/java/com/nklcbdty/api/ai/rag/VectorsTest.java
@@ -1,0 +1,48 @@
+package com.nklcbdty.api.ai.rag;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VectorsTest {
+
+    @Test
+    @DisplayName("normalize → L2 norm = 1")
+    void normalize() {
+        float[] v = {3, 4, 0};
+        float[] n = Vectors.normalize(v);
+        double s = 0;
+        for (float x : n) s += x * x;
+        assertEquals(1.0, Math.sqrt(s), 1e-5);
+    }
+
+    @Test
+    @DisplayName("dot of unit vectors = cosine similarity, identical → 1, orthogonal → 0")
+    void cosineSemantics() {
+        float[] a = Vectors.normalize(new float[]{1, 1, 0});
+        float[] b = Vectors.normalize(new float[]{1, 1, 0});
+        float[] c = Vectors.normalize(new float[]{1, -1, 0});
+
+        assertEquals(1.0f, Vectors.dot(a, b), 1e-5);
+        assertEquals(0.0f, Vectors.dot(a, c), 1e-5);
+    }
+
+    @Test
+    @DisplayName("toBytes/fromBytes round-trip 동일")
+    void roundTrip() {
+        float[] v = Vectors.normalize(new float[]{0.1f, -0.2f, 0.3f, -0.4f, 0.5f});
+        byte[] bytes = Vectors.toBytes(v);
+        assertEquals(v.length * 4, bytes.length);
+
+        float[] back = Vectors.fromBytes(bytes);
+        assertArrayEquals(v, back, 1e-6f);
+    }
+
+    @Test
+    @DisplayName("길이 다른 벡터 dot → -1 (오류 신호)")
+    void dotMismatch() {
+        assertEquals(-1f, Vectors.dot(new float[]{1, 2}, new float[]{1, 2, 3}));
+        assertEquals(-1f, Vectors.dot(null, new float[]{1, 2}));
+    }
+}


### PR DESCRIPTION
- ai/rag: DJL(paraphrase-multilingual-MiniLM-L12-v2) 임베딩 기반 의미 검색 (EmbeddingService/JobEmbeddingCache/Indexer/Repository/SemanticSearchService/Vectors)
- POST /api/jobs/match: PDF 이력서 텍스트(PDFBox) 추출 → 유사 공고 top-K
- GET /api/jobs/search: 자연어 공고 검색
- AllowedPaths: /api/jobs/** 공개 (기존 /api/job/** 는 's' 미스매치로 인증에 걸림)
- multipart 업로드 상한 10MB, V1 임베딩 컬럼 마이그레이션

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now search for jobs using natural language queries
  * Added resume PDF upload feature to match against available job postings
  * Increased maximum resume file upload limit to 10MB

* **Tests**
  * Added comprehensive test coverage for PDF text extraction and semantic vector operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->