### PR TITLE
🚨 Fix: 배민 크롤러 0건 방어 — 파싱 항목 격리 + fetch 견고화

### DIFF
--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -55,27 +55,53 @@ public class CrawlerCommonService {
         this.personalHistoryEnsemble = personalHistoryEnsemble;
     }
 
+    // 봇 차단(WAF)에 걸리지 않도록 브라우저처럼 보이는 User-Agent. 일부 채용 API(우아한형제들 등)는
+    // 기본 Java User-Agent 나 헤더 부재를 차단해 로컬은 되는데 서버에서만 실패하는 경우가 있다.
+    private static final String BROWSER_USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36";
+    private static final int CONNECT_TIMEOUT_MS = 5000;
+    private static final int READ_TIMEOUT_MS = 10000;
+
     public String fetchApiResponse(String apiUrl) {
 
         try {
             URL url = new URL(apiUrl);
             HttpURLConnection conn = (HttpURLConnection)url.openConnection();
             conn.setRequestMethod("GET");
+            conn.setRequestProperty("User-Agent", BROWSER_USER_AGENT);
+            conn.setRequestProperty("Accept", "application/json, text/plain, */*");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS); // 무한 대기 방지
+            conn.setReadTimeout(READ_TIMEOUT_MS);
 
-            StringBuilder response = new StringBuilder();
-            try (BufferedReader in = new BufferedReader(
-                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
-                String inputLine;
-                while ((inputLine = in.readLine()) != null) {
-                    response.append(inputLine);
-                }
+            int status = conn.getResponseCode();
+            if (status < 200 || status >= 300) {
+                // 4xx/5xx 는 getInputStream 이 예외를 던져 차단 사유가 사라진다.
+                // errorStream 을 읽어 상태코드와 본문 앞부분을 남겨 원인(차단/변경)을 진단 가능하게 한다.
+                String errBody = readStream(conn.getErrorStream());
+                log.error("API 응답 실패 status={} url={} body(앞부분)={}",
+                    status, apiUrl, errBody.substring(0, Math.min(300, errBody.length())));
+                throw new ApiException("Failed to fetch API response (status=" + status + ")");
             }
 
-            return response.toString();
+            return readStream(conn.getInputStream());
+        } catch (ApiException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Error occurred while fetching API response: {}", e.getMessage(), e);
             throw new ApiException("Failed to fetch API response");  // 커스텀 예외 던지기
         }
+    }
+
+    private String readStream(java.io.InputStream is) throws IOException {
+        if (is == null) return "";
+        StringBuilder response = new StringBuilder();
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            String inputLine;
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+        }
+        return response.toString();
     }
 
     public String fetchApiResponsePost(String apiUrl, String body) {

--- a/src/main/java/com/nklcbdty/api/crawler/service/BaeminJobCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/BaeminJobCrawlerService.java
@@ -48,68 +48,78 @@ public class BaeminJobCrawlerService implements JobCrawler{
 			String resultJSONStr = crawlerCommonService.fetchApiResponse(apiUrl);
 			
 			JSONObject jsonObj = new JSONObject(resultJSONStr);
-			JSONArray jsonArr = jsonObj.getJSONObject("data").getJSONArray("list");
-			
+			JSONObject data = jsonObj.optJSONObject("data");
+			JSONArray jsonArr = data == null ? null : data.optJSONArray("list");
+
+			if (jsonArr == null) {
+				// 응답 envelope 변경/차단 페이지 등으로 list 를 못 찾은 경우. 통째로 실패하지 않고 로그만 남긴다.
+				log.error("배민 크롤 응답에서 data.list 를 찾지 못함. 응답 앞부분: {}",
+					resultJSONStr == null ? "null" : resultJSONStr.substring(0, Math.min(300, resultJSONStr.length())));
+				return CompletableFuture.completedFuture(crawlerCommonService.getNotSaveJobItem("BAEMIN", list));
+			}
+
 			for(int i = 0; i < jsonArr.length(); i++) {
-				Job_mst job_mst = new Job_mst();
-				
-				JSONObject item = jsonArr.getJSONObject(i);
-				String annoId = item.get("recruitSeq").toString();
-				String recruitNumber = item.get("recruitNumber").toString();
-				String annoSubject = item.get("recruitName").toString();
-				
-				JSONObject employmentType = item.getJSONObject("employmentType");
-				String empTypeCdNm = baeminConvertCodeToEmpType(employmentType);
-				
-                job_mst.setAnnoId(annoId);
-				job_mst.setJobDetailLink("https://career.woowahan.com/recruitment/" + recruitNumber + "/detail?jobCodes=&employmentTypeCodes=&serviceSectionCodes=&careerPeriod=&category=jobGroupCodes%3ABA005001");
-				job_mst.setEmpTypeCdNm(empTypeCdNm);
-				job_mst.setAnnoSubject(annoSubject);
-                job_mst.setStartDate(item.getString("recruitOpenDate"));
-                job_mst.setEndDate(item.getString("recruitCloseDate"));
-                Object from = item.get("careerRestrictionMinYears");
-                if (from instanceof Integer) {
-                    long fromLong = ((Integer)from).longValue();
-                    if (fromLong == -1) {
-                        fromLong = 0; // -1은 경력제한 없음으로 간주
-                    }
-                    job_mst.setPersonalHistory(fromLong);
-                }
-                Object to = item.get("careerRestrictionMaxYears");
-                if (to instanceof Integer) {
-                    long endLong = ((Integer)to).longValue();
-                    if (endLong == -1) {
-                        endLong = 0; // -1은 경력제한 없음으로 간주
-                    }
-                    job_mst.setPersonalHistoryEnd(endLong);
-                }
-				list.add(job_mst);
+				try {
+					JSONObject item = jsonArr.getJSONObject(i);
+
+					// 우아한형제들 API 는 공고 상태(예약/상시/드래프트 등)에 따라 일부 필드를 null 로 내려준다.
+					// getString/getJSONObject 는 null 에서 예외를 던져 루프 전체를 중단시키므로 opt* 로 안전하게 읽는다.
+					String annoId = item.opt("recruitSeq") == null ? null : item.get("recruitSeq").toString();
+					String recruitNumber = item.optString("recruitNumber", "");
+					String annoSubject = item.optString("recruitName", "");
+
+					if (annoId == null || annoId.isBlank() || annoSubject.isBlank()) {
+						log.warn("배민 공고 필수값 누락으로 건너뜀 (index={}, recruitSeq={}, recruitName='{}')", i, annoId, annoSubject);
+						continue;
+					}
+
+					Job_mst job_mst = new Job_mst();
+
+					JSONObject employmentType = item.optJSONObject("employmentType");
+					String empTypeCdNm = baeminConvertCodeToEmpType(employmentType);
+
+	                job_mst.setAnnoId(annoId);
+					job_mst.setJobDetailLink("https://career.woowahan.com/recruitment/" + recruitNumber + "/detail?jobCodes=&employmentTypeCodes=&serviceSectionCodes=&careerPeriod=&category=jobGroupCodes%3ABA005001");
+					job_mst.setEmpTypeCdNm(empTypeCdNm);
+					job_mst.setAnnoSubject(annoSubject);
+	                job_mst.setStartDate(item.optString("recruitOpenDate", null));
+	                job_mst.setEndDate(item.optString("recruitCloseDate", null));
+	                job_mst.setPersonalHistory(normalizeCareerYears(item.opt("careerRestrictionMinYears")));
+	                job_mst.setPersonalHistoryEnd(normalizeCareerYears(item.opt("careerRestrictionMaxYears")));
+					list.add(job_mst);
+				} catch (Exception itemEx) {
+					// 한 공고 파싱 실패가 전체 크롤을 무너뜨리지 않도록 항목 단위로 격리한다.
+					log.error("배민 공고 파싱 실패 (index={}): {}", i, itemEx.getMessage(), itemEx);
+				}
 			}
 
             for (Job_mst item : list) {
-                if (item.getAnnoSubject().contains("프론트엔드 개발자")) {
+                // 공고명 형식이 "백엔드 개발자" → "Server(배차시스템)", "데이터엔지니어링(마케팅플랫폼)" 처럼
+                // 바뀌어 기존 키워드가 거의 안 맞았다. 공백 제거 + 대문자화 후 포함 검사로 완화한다.
+                // (최종 분류는 컨트롤러의 Gemini 보정이 담당하며, 이건 보조/폴백 규칙이다.)
+                final String subject = item.getAnnoSubject();
+                final String norm = subject.replace(" ", "").toUpperCase();
+
+                if (norm.contains("프론트엔드") || norm.contains("FRONTEND") || norm.contains("FRONT-END")) {
                     item.setSubJobCdNm(JobEnums.FrontEnd.getTitle());
-                } else if (item.getAnnoSubject().contains("백엔드 개발자") ||
-                    item.getAnnoSubject().contains("서버 개발자") ||
-                    item.getAnnoSubject().contains("백엔드 시스템 개발자") ||
-                    item.getAnnoSubject().contains("SRE 개발자")
+                } else if (norm.contains("백엔드") || norm.contains("BACKEND") || norm.contains("BACK-END") ||
+                    norm.contains("서버") || norm.contains("SERVER") || norm.contains("SRE") ||
+                    norm.contains("플랫폼엔지니어") || norm.contains("플랫폼엔지니어링")
                 ) {
                     item.setSubJobCdNm(JobEnums.BackEnd.getTitle());
-                } else if (item.getAnnoSubject().contains("데이터분석가") ||
-                    item.getAnnoSubject().contains("데이터과학자")
+                } else if (norm.contains("데이터분석") || norm.contains("데이터과학") || norm.contains("데이터사이언")
                 ) {
                     item.setSubJobCdNm(JobEnums.DataAnalyst.getTitle());
-                } else if (item.getAnnoSubject().contains("데이터엔지니어") ||
-                    item.getAnnoSubject().contains("데이터베이스엔지니어")
+                } else if (norm.contains("데이터엔지니어") || norm.contains("데이터베이스엔지니어")
                 ) {
                     item.setSubJobCdNm(JobEnums.DataEngineering.getTitle());
-                } else if (item.getAnnoSubject().contains("QA Engineer") ||
-                    item.getAnnoSubject().contains("Test Engineer")
+                } else if (norm.contains("QAENGINEER") || norm.contains("TESTENGINEER") ||
+                    norm.contains("QA") || norm.contains("테스트엔지니어")
                 ) {
                     item.setSubJobCdNm(JobEnums.QA.getTitle());
-                } else if (item.getAnnoSubject().contains("보안 시스템 및 솔루션 운영자")) {
+                } else if (norm.contains("보안") || norm.contains("SECURITY") || norm.contains("기술보안")) {
                     item.setSubJobCdNm(JobEnums.Security.getTitle());
-                } else if (item.getAnnoSubject().contains("ML엔지니어")) {
+                } else if (norm.contains("ML엔지니어") || norm.contains("머신러닝") || norm.contains("MLENGINEER")) {
                     item.setSubJobCdNm(JobEnums.ML.getTitle());
                 }
 
@@ -133,10 +143,11 @@ public class BaeminJobCrawlerService implements JobCrawler{
 	 * */
 	private String baeminConvertCodeToEmpType(JSONObject employmentType) {
 		String resStr = "";
-		String recruitItemCode = employmentType.get("recruitItemCode").toString();
-		
-		if (recruitItemCode.isBlank() || recruitItemCode == null) return resStr;
-		
+		if (employmentType == null) return resStr; // 고용형태 미제공 공고 대비
+		String recruitItemCode = employmentType.optString("recruitItemCode", "");
+
+		if (recruitItemCode.isBlank()) return resStr;
+
 		switch (recruitItemCode.toUpperCase()) {
 		case "BA002001":
 			resStr = "정규";
@@ -149,5 +160,16 @@ public class BaeminJobCrawlerService implements JobCrawler{
 			break;
 		}	
 		return resStr;
+	}
+
+	/**
+	 * careerRestrictionMin/MaxYears 를 long 으로 정규화한다.
+	 * org.json 은 정수를 Integer 또는 Long 으로 담을 수 있고, -1 은 "경력제한 없음"이라 0 으로 본다.
+	 * null/비정상 값은 0 으로 처리한다.
+	 */
+	private long normalizeCareerYears(Object value) {
+		if (!(value instanceof Number)) return 0L;
+		long years = ((Number) value).longValue();
+		return years == -1 ? 0L : years;
 	}
 }


### PR DESCRIPTION
## 문제
배민(우아한형제들) 크롤러가 0건을 반환.

## 원인
- 우아한형제들 API는 공고 상태(예약/상시/드래프트)에 따라 `recruitOpenDate`·`recruitCloseDate`·`employmentType` 등을 `null`로 내려주는데, 기존 코드는 `getString`/`getJSONObject`를 사용해 **필드 하나만 null이어도 예외가 발생하고 for 루프 전체가 중단** → 앞쪽 공고가 걸리면 0건.
- `fetchApiResponse`에 타임아웃·User-Agent가 없고 4xx/5xx 시 에러 본문을 버려, 운영 환경의 조용한 실패 원인을 알 수 없었음.

## 변경
- **파싱 격리**: 공고 단위 `try/catch` + `opt*` 안전 추출. 한 건 실패가 전체를 무너뜨리지 않음.
- **envelope 방어**: `data.list` 미존재 시 예외 대신 응답 앞부분 로그 후 빈 결과 반환.
- **분류 키워드 갱신**: 현재 공고명 형식(`Server(배차시스템)`, `데이터엔지니어링(...)`, `기술보안(SOC)` 등)에 맞게 완화.
- **fetch 견고화**: 브라우저 User-Agent + Accept, connect(5s)/read(10s) 타임아웃, 4xx/5xx 시 errorStream 본문 로깅.

## 검증
수정한 fetch+파싱 로직을 실제 org.json으로 라이브 배민 API에 실행 → `status=200`, **11/11 공고 파싱 성공**, 분류도 정상 매칭 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crawler reliability when APIs return errors, incomplete responses, or unexpected job data.
  * Prevented a single malformed job listing from interrupting the processing of remaining listings.
  * Improved handling of missing employment type and career requirement information.
  * Expanded recognition of sub-job categories across additional title formats.
  * Added clearer diagnostics for failed API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->