### PR TITLE
🚨 Fix: 전체 크롤러 견고화 — 항목 격리 + null 안전 + Jsoup 헤더

### DIFF
--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -92,6 +92,14 @@ public class CrawlerCommonService {
         }
     }
 
+    // Jsoup 기반 크롤러(쿠팡/야놀자/카카오 buildName 스크래핑 등)가 공통으로 쓸 커넥션.
+    // 브라우저 User-Agent + 타임아웃을 걸어 WAF 차단/무한 대기를 방지한다.
+    public org.jsoup.Connection jsoupConnect(String url) {
+        return Jsoup.connect(url)
+            .userAgent(BROWSER_USER_AGENT)
+            .timeout(READ_TIMEOUT_MS);
+    }
+
     private String readStream(java.io.InputStream is) throws IOException {
         if (is == null) return "";
         StringBuilder response = new StringBuilder();

--- a/src/main/java/com/nklcbdty/api/crawler/service/CoupangJobCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/CoupangJobCrawlerService.java
@@ -40,19 +40,25 @@ public class CoupangJobCrawlerService {
     @Async
 	public CompletableFuture<List<Job_mst>> crawlJobs() {
         List<Job_mst> resList = new ArrayList<>();
-		String formattedDate = crawlerCommonService.formatCurrentTime(); 
+		String formattedDate = crawlerCommonService.formatCurrentTime();
 		log.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> {}의 크롤러가 {}로 시작됩니다.", this.getClass(), formattedDate);
-		
-		int totalCnt = getCoupangTotalListCnt(apiUrl);
-        int pagesize = 20;
-        double totalLoopCnt = totalCnt % pagesize
-            == 0 ? (double)(totalCnt / pagesize) : Math.ceil((double)totalCnt / pagesize);
 
-		for (int i = 1; i <= (int)totalLoopCnt; i++) {
-			// apiUrl = "https://www.coupang.jobs/kr/jobs?page="+i+"#results";
-			apiUrl = "https://www.coupang.jobs/kr/jobs/?page="+i+"&orderby=0&pagesize=20&radius=100&location=Seoul,%20South%20Korea#results";
-			resList.addAll(coupangParseHtmlData(apiUrl));
-            log.info("{} / {} 크롤링 완료", i, totalLoopCnt);
+		// 기존엔 crawlJobs 에 try/catch 가 없어 쿠팡 실패 시 예외가 controller 의 all 모드까지 전파돼
+		// 전체 회사 크롤 결과가 0건이 됐다. 다른 크롤러처럼 내부에서 격리해 부분 결과를 반환한다.
+		try {
+			int totalCnt = getCoupangTotalListCnt(apiUrl);
+	        int pagesize = 20;
+	        double totalLoopCnt = totalCnt % pagesize
+	            == 0 ? (double)(totalCnt / pagesize) : Math.ceil((double)totalCnt / pagesize);
+
+			for (int i = 1; i <= (int)totalLoopCnt; i++) {
+				// apiUrl = "https://www.coupang.jobs/kr/jobs?page="+i+"#results";
+				apiUrl = "https://www.coupang.jobs/kr/jobs/?page="+i+"&orderby=0&pagesize=20&radius=100&location=Seoul,%20South%20Korea#results";
+				resList.addAll(coupangParseHtmlData(apiUrl));
+	            log.info("{} / {} 크롤링 완료", i, totalLoopCnt);
+			}
+		} catch (Exception e) {
+			log.error("쿠팡 크롤링 실패: {}", e.getMessage(), e);
 		}
 
         return CompletableFuture.completedFuture(crawlerCommonService.getNotSaveJobItem("COUPANG", resList));
@@ -73,6 +79,7 @@ public class CoupangJobCrawlerService {
         	Elements root = doc.select("main#content div#js-job-search-results .card.card-job");
 
         	for (Element cardJobRoot : root) {
+              try {
 				// 근무지
 				String workplace = cardJobRoot.select(".list-inline.job-meta > li").text();
 				if (!"서울".equals(workplace)) {
@@ -94,6 +101,9 @@ public class CoupangJobCrawlerService {
                 job_mst.setPersonalHistory(personalHistoryDto.getFrom());
                 job_mst.setPersonalHistoryEnd(personalHistoryDto.getTo());
                 tempList.add(job_mst);
+              } catch (Exception itemEx) {
+                log.error("쿠팡 공고 카드 파싱 실패: {}", itemEx.getMessage(), itemEx);
+              }
         	}
 
             for (Job_mst item : tempList) {
@@ -218,12 +228,22 @@ public class CoupangJobCrawlerService {
 
     		// 총건수 파싱하기.
     		strTotalCnt = doc.select("main#content div#js-job-search-results").attr("data-results");
-    		
+
         } catch (Exception e) {
             log.error("Error occurred while fetching API response: {}", e.getMessage(), e);
             throw new ApiException("Failed to Jsoup response");  // 커스텀 예외 던지기
         }
-		
-		return Integer.parseInt(strTotalCnt);
+
+		// 쿠키 만료/차단으로 결과 페이지를 못 받으면 data-results 가 비어 parseInt 가 터진다. 방어한다.
+		if (strTotalCnt == null || strTotalCnt.isBlank()) {
+			log.error("쿠팡 총 건수(data-results) 파싱 실패 — 빈 값 (쿠키 만료/차단 의심)");
+			return 0;
+		}
+		try {
+			return Integer.parseInt(strTotalCnt.trim());
+		} catch (NumberFormatException e) {
+			log.error("쿠팡 총 건수 파싱 실패: '{}'", strTotalCnt);
+			return 0;
+		}
     }
 }

--- a/src/main/java/com/nklcbdty/api/crawler/service/DaangnJobCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/DaangnJobCrawlerService.java
@@ -49,47 +49,63 @@ public class DaangnJobCrawlerService {
 			JSONArray allJobPostNodes = jsonObj.getJSONObject("result").getJSONObject("data").getJSONObject("allJobPost").getJSONArray("nodes");
 			
 			for(int i = 0; i < allDepartmentFilteredJobPostNodes.length(); i++) {
-				Job_mst job_mst = new Job_mst();
-				JSONObject item = allDepartmentFilteredJobPostNodes.getJSONObject(i);
-				String classCdNm;
-				String subJobCdNm;
-				
-				String jobDetailLink = item.get("absoluteUrl").toString(); 
-				String annoId = item.get("ghId").toString();
-				String annoSubject = item.get("title").toString();
-				String rowEmploymentType = item.get("employmentType").toString(); // 컨버트 필요.
-				String empTypeCdNm = ConvertCodeToEmpType(rowEmploymentType);
-				
-				String sysCompanyCdNm = allJobPostNodes.getJSONObject(i).get("corporate").toString();
-				
-				JSONArray departmentsNodes = item.getJSONArray("departments");
-				for (int j = 0; j < departmentsNodes.length(); j++) {
-					JSONObject department = departmentsNodes.getJSONObject(j);
-					String rowDepartmentId = department.get("id").toString();
-					String departmentName = convertDepartmentIdToName(rowDepartmentId);
-					if (departmentName.contains(",")) {
-						String[] departmentNames = splitDepartmentName(departmentName);
-						classCdNm = departmentNames[0];
-						subJobCdNm = departmentNames[1];
-						
-						job_mst.setClassCdNm(classCdNm);
-						job_mst.setSubJobCdNm(subJobCdNm.trim());
-					} else {
-						classCdNm = departmentName;
-						job_mst.setClassCdNm(classCdNm);
+				try {
+					Job_mst job_mst = new Job_mst();
+					JSONObject item = allDepartmentFilteredJobPostNodes.getJSONObject(i);
+					String classCdNm;
+					String subJobCdNm;
+
+					String jobDetailLink = item.optString("absoluteUrl", "");
+					String annoId = item.opt("ghId") == null ? null : item.get("ghId").toString();
+					String annoSubject = item.optString("title", "");
+					String rowEmploymentType = item.optString("employmentType", ""); // 컨버트 필요.
+					String empTypeCdNm = ConvertCodeToEmpType(rowEmploymentType);
+
+					if (annoId == null || annoId.isBlank() || annoSubject.isBlank()) {
+						log.warn("당근 공고 필수값 누락으로 건너뜀 (index={}, ghId={})", i, annoId);
+						continue;
 					}
+
+					// allJobPost 와 allDepartmentFilteredJobPost 는 별개 배열이라 길이/순서가 다를 수 있다.
+					// 같은 인덱스로 접근하다 IndexOutOfBounds 로 전체가 죽지 않도록 범위를 확인한다.
+					String sysCompanyCdNm = "";
+					if (i < allJobPostNodes.length()) {
+						sysCompanyCdNm = allJobPostNodes.getJSONObject(i).optString("corporate", "");
+					}
+
+					JSONArray departmentsNodes = item.optJSONArray("departments");
+					if (departmentsNodes != null) {
+						for (int j = 0; j < departmentsNodes.length(); j++) {
+							JSONObject department = departmentsNodes.getJSONObject(j);
+							String rowDepartmentId = department.optString("id", "");
+							String departmentName = convertDepartmentIdToName(rowDepartmentId);
+							if (departmentName.contains(",")) {
+								String[] departmentNames = splitDepartmentName(departmentName);
+								classCdNm = departmentNames[0];
+								subJobCdNm = departmentNames[1];
+
+								job_mst.setClassCdNm(classCdNm);
+								job_mst.setSubJobCdNm(subJobCdNm.trim());
+							} else {
+								classCdNm = departmentName;
+								job_mst.setClassCdNm(classCdNm);
+							}
+						}
+					}
+
+					job_mst.setJobDetailLink(jobDetailLink);
+	                PersonalHistoryDto personalHistoryDto = crawlerCommonService.extractPersonalHistoryFromJobPage(jobDetailLink);
+	                job_mst.setPersonalHistory(personalHistoryDto.getFrom());
+	                job_mst.setPersonalHistoryEnd(personalHistoryDto.getTo());
+	                job_mst.setAnnoId(annoId);
+					job_mst.setAnnoSubject(annoSubject);
+					job_mst.setEmpTypeCdNm(empTypeCdNm);
+					job_mst.setSysCompanyCdNm(sysCompanyCdNm);
+
+					list.add(job_mst);
+				} catch (Exception itemEx) {
+					log.error("당근 공고 파싱 실패 (index={}): {}", i, itemEx.getMessage(), itemEx);
 				}
-				
-				job_mst.setJobDetailLink(jobDetailLink);
-                PersonalHistoryDto personalHistoryDto = crawlerCommonService.extractPersonalHistoryFromJobPage(jobDetailLink);
-                job_mst.setPersonalHistory(personalHistoryDto.getFrom());
-                job_mst.setPersonalHistoryEnd(personalHistoryDto.getTo());
-                job_mst.setAnnoId(annoId);
-				job_mst.setAnnoSubject(annoSubject);
-				job_mst.setEmpTypeCdNm(empTypeCdNm);
-				job_mst.setSysCompanyCdNm(sysCompanyCdNm);
-				
-				list.add(job_mst);
 			}
 
             for (Job_mst item : list) {

--- a/src/main/java/com/nklcbdty/api/crawler/service/KakaoCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/KakaoCrawlerService.java
@@ -337,7 +337,7 @@ public class KakaoCrawlerService {
     private void addRecruitGames(List<Job_mst> kakaoGames) {
         String buildName = "";
         try {
-            Document doc = Jsoup.connect("https://recruit.kakaogames.com/ko/joinjuskr").get();
+            Document doc = crawlerCommonService.jsoupConnect("https://recruit.kakaogames.com/ko/joinjuskr").get();
             Element scriptElement = doc.getElementById("__NEXT_DATA__");
 
             if (scriptElement != null) {
@@ -444,7 +444,7 @@ public class KakaoCrawlerService {
     private void addRecruitHealth(List<Job_mst> kakaopayHealth) {
         String buildName = "";
         try {
-            Document doc = Jsoup.connect("https://recruit.kakaohealthcare.com/recruit").get();
+            Document doc = crawlerCommonService.jsoupConnect("https://recruit.kakaohealthcare.com/recruit").get();
             Elements iconLinkTags = doc.select("link[rel=icon], link[rel=shortcut icon]");
 
             if (!iconLinkTags.isEmpty()) {
@@ -516,7 +516,7 @@ public class KakaoCrawlerService {
 
         try {
             // 웹 페이지에 연결하여 Document 객체 가져오기
-            Document doc = Jsoup.connect("https://career.kakaopaysec.com/job_posting").get();
+            Document doc = crawlerCommonService.jsoupConnect("https://career.kakaopaysec.com/job_posting").get();
 
             // property 속성이 "og:image"인 meta 태그 선택
             Elements metaTags = doc.select("meta[property=og:image]");
@@ -612,6 +612,7 @@ public class KakaoCrawlerService {
             JSONObject paging = root.getJSONObject("paging");
             lastIdx = paging.getInt("totalPages");
             for (int i = 0; i < jobList.length(); i++) {
+              try {
                 JSONObject edge = jobList.getJSONObject(i);
                 Object endDate = edge.get("receiveEndDatetime");
                 if (isCloseDate(endDate)) {
@@ -651,6 +652,9 @@ public class KakaoCrawlerService {
                 item.setPersonalHistory(personalHistory.getFrom());
                 item.setPersonalHistoryEnd(personalHistory.getTo());
                 result.add(item);
+              } catch (Exception itemEx) {
+                log.error("카카오뱅크 공고 파싱 실패 (index={}): {}", i, itemEx.getMessage(), itemEx);
+              }
             }
             idx++;
         }
@@ -714,6 +718,7 @@ public class KakaoCrawlerService {
 
         // edges 배열을 반복
         for (int i = 0; i < jobList.length(); i++) {
+          try {
             JSONObject edge = jobList.getJSONObject(i);
             String title = edge.getString("jobOfferTitle");
             Object endDate = edge.get("endDate");
@@ -767,6 +772,9 @@ public class KakaoCrawlerService {
             item.setPersonalHistoryEnd(personalHistory.getTo());
 
             result.add(item);
+          } catch (Exception itemEx) {
+            log.error("카카오(careers) 공고 파싱 실패 (index={}): {}", i, itemEx.getMessage(), itemEx);
+          }
         }
 
         try {

--- a/src/main/java/com/nklcbdty/api/crawler/service/LineJobCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/LineJobCrawlerService.java
@@ -47,6 +47,7 @@ public class LineJobCrawlerService implements JobCrawler {
 
             // edges 배열을 반복
             for (int i = 0; i < edges.length(); i++) {
+              try {
                 JSONObject edge = edges.getJSONObject(i);
 
 
@@ -99,6 +100,9 @@ public class LineJobCrawlerService implements JobCrawler {
                         result.add(item);
                     }
                 }
+              } catch (Exception itemEx) {
+                log.error("라인 공고 파싱 실패 (index={}): {}", i, itemEx.getMessage(), itemEx);
+              }
             }
 
             for (Job_mst item : result) {
@@ -163,14 +167,17 @@ public class LineJobCrawlerService implements JobCrawler {
             }
 
             for (Job_mst item : result) {
-                if (
-                    item.getSubJobCdNm().contains("Notinuse") ||
-                    item.getSubJobCdNm().contains("notinuse")
-                ) {
-                    item.setSubJobCdNm(null);
+                final String subJobCdNm = item.getSubJobCdNm();
+                if (subJobCdNm == null) {
+                    continue;
                 }
-                final String subJobCdNmReplace = item.getSubJobCdNm().replace(" ", "");
-                item.setSubJobCdNm(subJobCdNmReplace);
+                // Notinuse 는 미사용 코드 → null 처리 후 다음 항목으로. (기존엔 null 로 만든 직후
+                // .replace() 를 호출해 NPE 가 발생, 이후 분류 후처리가 통째로 중단됐다.)
+                if (subJobCdNm.contains("Notinuse") || subJobCdNm.contains("notinuse")) {
+                    item.setSubJobCdNm(null);
+                    continue;
+                }
+                item.setSubJobCdNm(subJobCdNm.replace(" ", ""));
             }
 
         } catch (Exception e) {

--- a/src/main/java/com/nklcbdty/api/crawler/service/NaverJobCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/NaverJobCrawlerService.java
@@ -58,30 +58,40 @@ public class NaverJobCrawlerService {
                 }
 
                 for (int i = 0; i < jobList.length(); i++) {
-                    JSONObject edge = jobList.getJSONObject(i);
+                    try {
+                        JSONObject edge = jobList.getJSONObject(i);
 
-                    Job_mst item = new Job_mst();
-                    item.setAnnoId(edge.get("annoId").toString());
-                    item.setAnnoSubject(edge.getString("annoSubject"));
-                    item.setClassCdNm(edge.getString("classCdNm"));
-                    item.setEmpTypeCdNm(edge.getString("empTypeCdNm"));
-                    item.setSubJobCdNm(edge.getString("subJobCdNm"));
-                    item.setSysCompanyCdNm(edge.getString("sysCompanyCdNm"));
-                    item.setJobDetailLink(edge.getString("jobDetailLink"));
-                    PersonalHistoryDto personalHistoryDto = crawlerCommonService.extractPersonalHistoryFromJobPage(edge.getString("jobDetailLink"));
-                    item.setPersonalHistory(personalHistoryDto.getFrom());
-                    item.setPersonalHistoryEnd(personalHistoryDto.getTo());
-                    if (edge.isNull("staYmdTime")) {
-                        item.setStartDate("영입종료시");
-                    } else {
-                        item.setStartDate(edge.getString("staYmdTime").replace(".", "-"));
+                        // 필드 하나가 null/누락이어도 해당 공고만 건너뛰고 나머지는 수집하도록 격리.
+                        Job_mst item = new Job_mst();
+                        item.setAnnoId(edge.opt("annoId") == null ? null : edge.get("annoId").toString());
+                        item.setAnnoSubject(edge.optString("annoSubject", ""));
+                        item.setClassCdNm(edge.optString("classCdNm", ""));
+                        item.setEmpTypeCdNm(edge.optString("empTypeCdNm", ""));
+                        item.setSubJobCdNm(edge.optString("subJobCdNm", ""));
+                        item.setSysCompanyCdNm(edge.optString("sysCompanyCdNm", ""));
+                        String jobDetailLink = edge.optString("jobDetailLink", "");
+                        if (item.getAnnoId() == null || item.getAnnoId().isBlank() || item.getAnnoSubject().isBlank()) {
+                            log.warn("네이버 공고 필수값 누락으로 건너뜀 (index={}, annoId={})", i, item.getAnnoId());
+                            continue;
+                        }
+                        item.setJobDetailLink(jobDetailLink);
+                        PersonalHistoryDto personalHistoryDto = crawlerCommonService.extractPersonalHistoryFromJobPage(jobDetailLink);
+                        item.setPersonalHistory(personalHistoryDto.getFrom());
+                        item.setPersonalHistoryEnd(personalHistoryDto.getTo());
+                        if (edge.isNull("staYmdTime")) {
+                            item.setStartDate("영입종료시");
+                        } else {
+                            item.setStartDate(edge.getString("staYmdTime").replace(".", "-"));
+                        }
+                        if (edge.isNull("endYmdTime")) {
+                            item.setEndDate("영입종료시");
+                        } else {
+                            item.setEndDate(edge.getString("endYmdTime").replace(".", "-"));
+                        }
+                        result.add(item);
+                    } catch (Exception itemEx) {
+                        log.error("네이버 공고 파싱 실패 (index={}): {}", i, itemEx.getMessage(), itemEx);
                     }
-                    if (edge.isNull("endYmdTime")) {
-                        item.setEndDate("영입종료시");
-                    } else {
-                        item.setEndDate(edge.getString("endYmdTime").replace(".", "-"));
-                    }
-                    result.add(item);
                 }
 
                 idx += 10;

--- a/src/main/java/com/nklcbdty/api/crawler/service/TossJobCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/TossJobCrawlerService.java
@@ -46,18 +46,22 @@ public class TossJobCrawlerService implements JobCrawler {
                 JSONObject edge = edges.getJSONObject(i);
                 JSONArray contents = edge.getJSONArray("jobs");
                 for (int j = 0; j < contents.length(); j++) {
+                  try {
                     JSONObject contentItem = contents.getJSONObject(j);
-                    JSONArray metadata = contentItem.getJSONArray("metadata");
+                    JSONArray metadata = contentItem.optJSONArray("metadata");
+                    if (metadata == null) {
+                        metadata = new JSONArray();
+                    }
                     boolean saveOk = true;
                     Job_mst item = new Job_mst();
                     for (int k = 0; k < metadata.length(); k++) {
                         JSONObject jsonObject = metadata.getJSONObject(k);
-                        String name = jsonObject.getString("name");
-                        Object objectValue = jsonObject.get("value");
-                        String value = objectValue.toString();
-                        if(value == null) {
+                        String name = jsonObject.optString("name", "");
+                        Object objectValue = jsonObject.opt("value");
+                        if (objectValue == null || JSONObject.NULL.equals(objectValue)) {
                             continue;
                         }
+                        String value = objectValue.toString();
                         switch (name) {
                             case "포지션의 소속 자회사를 선택해 주세요.": {
                                 item.setSysCompanyCdNm(value);
@@ -80,9 +84,14 @@ public class TossJobCrawlerService implements JobCrawler {
                             }
                         }
                     }
-                    item.setAnnoId(contentItem.get("id").toString());
-                    item.setAnnoSubject(contentItem.getString("title"));
-                    item.setJobDetailLink(contentItem.getString("absolute_url"));
+                    item.setAnnoId(contentItem.opt("id") == null ? null : contentItem.get("id").toString());
+                    item.setAnnoSubject(contentItem.optString("title", ""));
+                    item.setJobDetailLink(contentItem.optString("absolute_url", ""));
+
+                    if (item.getAnnoId() == null || item.getAnnoId().isBlank() || item.getAnnoSubject().isBlank()) {
+                        log.warn("토스 공고 필수값 누락으로 건너뜀 (jobIndex={}, id={})", j, item.getAnnoId());
+                        continue;
+                    }
 
                     if("null".equals(item.getSysCompanyCdNm())) {
                       saveOk = false;
@@ -91,6 +100,9 @@ public class TossJobCrawlerService implements JobCrawler {
                     if(saveOk) {
                         result.add(item);
                     }
+                  } catch (Exception itemEx) {
+                    log.error("토스 공고 파싱 실패 (jobIndex={}): {}", j, itemEx.getMessage(), itemEx);
+                  }
                 }
             }
 

--- a/src/main/java/com/nklcbdty/api/crawler/service/YanoljaCralwerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/YanoljaCralwerService.java
@@ -38,7 +38,7 @@ public class YanoljaCralwerService {
         List<Job_mst> result = new ArrayList<>();
 
         try {
-            Document doc = Jsoup.connect("https://careers.yanolja.co/home").get();
+            Document doc = commonService.jsoupConnect("https://careers.yanolja.co/home").get();
             Elements scripts = doc.getElementsByTag("script");
             String regex = "/_next/static/(.*?)/_ssgManifest.js";
             Pattern pattern = Pattern.compile(regex);
@@ -73,10 +73,15 @@ public class YanoljaCralwerService {
 
                 JSONArray jsonArray1 = jsonObject.getJSONObject("state").getJSONArray("data");
                 for (int j = 0; j < jsonArray1.length(); j++) {
+                  try {
                     Job_mst item = new Job_mst();
                     JSONObject data = jsonArray1.getJSONObject(j);
-                    item.setAnnoId(data.get("openingId").toString());
-                    item.setAnnoSubject(data.getString("title"));
+                    item.setAnnoId(data.opt("openingId") == null ? null : data.get("openingId").toString());
+                    item.setAnnoSubject(data.optString("title", ""));
+                    if (item.getAnnoId() == null || item.getAnnoId().isBlank() || item.getAnnoSubject().isBlank()) {
+                        log.warn("야놀자 공고 필수값 누락으로 건너뜀 (jobIndex={}, openingId={})", j, item.getAnnoId());
+                        continue;
+                    }
                     if(data.has("job") && !data.isNull("job")) {
                         item.setClassCdNm(data.getString("job"));
                     } else {
@@ -115,6 +120,9 @@ public class YanoljaCralwerService {
                         item.setPersonalHistoryEnd(((Integer) to).longValue());
                     }
                     result.add(item);
+                  } catch (Exception itemEx) {
+                    log.error("야놀자 공고 파싱 실패 (jobIndex={}): {}", j, itemEx.getMessage(), itemEx);
+                  }
                 }
             }
 


### PR DESCRIPTION
## 배경
배민 크롤러에서 발견한 취약점(필드 하나가 `null`/누락이면 파싱 루프 전체가 중단되어 0건)이 **전 크롤러 공통**이라 일괄 점검·하드닝.

## 공통
- `CrawlerCommonService.jsoupConnect()` 추가 — 브라우저 User-Agent + 타임아웃이 걸린 공용 Jsoup 커넥션.

## 크롤러별 변경
| 회사 | 변경 |
|------|------|
| 네이버/토스 | 파싱 루프 항목 단위 `try/catch` + `opt*` 안전 추출 |
| 당근 | 🔴 서로 다른 배열을 같은 인덱스로 접근하던 버그(IndexOutOfBounds) 방어 + 항목 격리 |
| 라인 | 🔴 `subJobCdNm=null` 직후 `.replace()` NPE 버그 수정 + 항목 격리 |
| 야놀자 | Jsoup UA/타임아웃 적용 + 항목 격리 |
| 쿠팡 | 🔴 `crawlJobs` try/catch 부재로 실패 시 all 모드 전체 0건 되던 문제 수정 + `parseInt` 빈값 방어 + 카드 격리 |
| 카카오 | careers.kakao / kakaobank 루프 항목 격리 + buildName 스크래핑 Jsoup 헤더 |

## 검증
- `./gradlew compileJava` 통과
- `./gradlew test --tests "*Crawler*"` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job crawling reliability across multiple recruitment sources.
  * Malformed or incomplete listings are now skipped without interrupting the remaining crawl.
  * Added safer handling for missing job details, invalid data, and unavailable result counts.
  * Crawls can now return successfully collected listings even when individual pages or entries fail.
  * Standardized webpage connection settings for more consistent retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->