### PR TITLE
🚨 Fix: 크롤 시 기존 공고 endDate/subJobCdNm 갱신

### DIFF
--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -168,22 +168,49 @@ public class CrawlerCommonService {
             }
         }
 
-        // 기존 row 의 personalHistory 가 LLM 보정으로 바뀌었다면 update.
-        // 신규(jobsToSave) 는 호출자가 어차피 저장하므로 여기서 다시 다루지 않음.
+        // 기존 row 갱신. 신규(jobsToSave) 는 호출자가 어차피 저장하므로 여기서 다시 다루지 않음.
+        // 크롤 결과에 여전히 존재하는(=살아있는) 공고는 최신 값으로 되살린다:
+        //  1) personalHistory : LLM 경력 보정 결과 반영
+        //  2) endDate        : 마감일 변경/재오픈 반영. 과거 종료 처리(reconcileEndedJobs)나
+        //                       예전 크롤 시점 값으로 endDate 가 과거에 굳어, 살아있는 공고가
+        //                       목록(endDate>now 필터)에서 사라지던 문제를 해결한다.
+        //  3) subJobCdNm     : 비어있을 때만 크롤 값으로 채운다. Gemini 등으로 이미 분류된
+        //                       기존 값은 덮어쓰지 않는다(크롤러 키워드 분류가 null 일 수 있으므로).
         List<Job_mst> existingToUpdate = new ArrayList<>();
         for (Job_mst jobItem : result) {
             Job_mst existing = existingJobs.stream()
                 .filter(e -> e.getAnnoId().equals(jobItem.getAnnoId()))
                 .findFirst().orElse(null);
             if (existing == null) continue;
+
+            boolean changed = false;
+
             if (existing.getPersonalHistory() != jobItem.getPersonalHistory()) {
                 existing.setPersonalHistory(jobItem.getPersonalHistory());
+                changed = true;
+            }
+
+            final String freshEndDate = jobItem.getEndDate();
+            if (freshEndDate != null && !freshEndDate.isBlank()
+                && !freshEndDate.equals(existing.getEndDate())) {
+                existing.setEndDate(freshEndDate);
+                changed = true;
+            }
+
+            final String freshSubJob = jobItem.getSubJobCdNm();
+            if (freshSubJob != null && !freshSubJob.isBlank()
+                && (existing.getSubJobCdNm() == null || existing.getSubJobCdNm().isBlank())) {
+                existing.setSubJobCdNm(freshSubJob);
+                changed = true;
+            }
+
+            if (changed) {
                 existingToUpdate.add(existing);
             }
         }
         if (!existingToUpdate.isEmpty()) {
             crawlerRepository.saveAll(existingToUpdate);
-            log.info("기존 row 경력 보정 update — {}건 (회사={})", existingToUpdate.size(), company);
+            log.info("기존 row 갱신 update — {}건 (회사={})", existingToUpdate.size(), company);
         }
 
         return jobsToSave;


### PR DESCRIPTION
## 문제
`getNotSaveJobItem`이 기존 row의 `personalHistory`만 갱신하고 **`endDate`/`subJobCdNm`은 갱신하지 않았다.**

그래서 과거 종료 처리(`reconcileEndedJobs`)나 예전 크롤 시점 값으로 `endDate`가 과거에 굳으면, **실제로는 살아있는 공고가 목록(`endDate > now` 필터)에서 계속 걸러져 사라졌다.** (배민 상시채용 공고 다수가 이 상태였음 — 저장된 end_date가 크롤 당시 날짜로 굳어 있었음)

## 변경
크롤 결과에 여전히 존재하는(=살아있는) 공고에 대해 기존 row를 갱신:
- **endDate**: 최신 크롤 값과 다르면 갱신 → 과거로 굳은 공고 되살림
- **subJobCdNm**: 기존이 **비어있을 때만** 크롤 값으로 채움 (Gemini 등 기존 분류는 덮어쓰지 않음 — 크롤러 키워드 분류가 null일 수 있으므로)
- **personalHistory**: 기존 LLM 보정 로직 유지

전 회사 공통 개선.

## 검증
- `compileJava` / `test --tests "*Crawler*"` 통과
- **실 DB+API 검증**: 배민 공고 하나를 stale(과거 endDate + subJobCdNm=NULL)로 되돌린 뒤 크롤 1회 실행 → `기존 row 갱신 update — 1건` 로그 + DB에서 `end_date=2999-12-31`, `sub_job_cd_nm=DataEngineering`으로 자동 복구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved updates to existing job records when crawl results contain changed information.
  * Job history, end dates, and missing sub-job details are now refreshed when applicable.
  * Prevented unnecessary updates when no relevant information has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->