### PR TITLE
✅ Test: sendJobEmail 테스트를 sendJobDailyEmails 위임 검증으로 수정

### DIFF
--- a/src/test/java/com/nklcbdty/api/admin/service/AdminSubscriptionServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/admin/service/AdminSubscriptionServiceTest.java
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
 import com.nklcbdty.api.admin.dto.AdminSubscriptionDetailDto;
 import com.nklcbdty.api.admin.dto.AdminSubscriptionPageResponse;
 import com.nklcbdty.api.admin.dto.AdminSubscriptionRowDto;
@@ -195,25 +193,20 @@ class AdminSubscriptionServiceTest {
     }
 
     @Test
-    @DisplayName("sendJobEmail: 발송 대상 이메일이 있으면 EmailService.sendEmail로 본문을 발송한다")
+    @DisplayName("sendJobEmail: EmailService.sendJobDailyEmails에 해당 userId를 위임한다")
     void sendJobEmail_dispatchesMail() {
-        when(emailService.sendEmail(eq(List.of("kakao@1"))))
-            .thenReturn(Map.of("user@test.com", "<html>본문</html>"));
-
         service.sendJobEmail("kakao@1");
 
-        verify(emailService).sendEmail(eq("user@test.com"), any(String.class), eq("<html>본문</html>"));
+        verify(emailService).sendJobDailyEmails(eq(List.of("kakao@1")));
     }
 
     @Test
-    @DisplayName("sendJobEmail: 발송할 컨텐츠가 없으면 EmailService.sendEmail(to,...)을 호출하지 않는다")
-    void sendJobEmail_skipsWhenEmpty() {
-        when(emailService.sendEmail(eq(List.of("kakao@1")))).thenReturn(Map.of());
+    @DisplayName("sendJobEmail: 발송 중 예외가 발생해도 전파하지 않는다")
+    void sendJobEmail_swallowsException() {
+        when(emailService.sendJobDailyEmails(eq(List.of("kakao@1"))))
+            .thenThrow(new RuntimeException("smtp down"));
 
         service.sendJobEmail("kakao@1");
-
-        verify(emailService, org.mockito.Mockito.never())
-            .sendEmail(any(String.class), any(String.class), any(String.class));
     }
 
     @Test


### PR DESCRIPTION
## 요약
- `AdminSubscriptionServiceTest.sendJobEmail_dispatchesMail` 이 게시판 기능 추가 이전부터 실패하던 문제 수정
- 서비스 리팩터링으로 발송 로직(대상 조회 → 본문 생성 → 개별 발송 → 빈 대상 스킵)이 `EmailService.sendJobDailyEmails` 로 이동했으나, 테스트는 구 구현(`emailService.sendEmail(to, subject, body)` 직접 호출)을 verify 하고 있었음
- 서비스 구현이 의도된 구조(수동/자동 경로 공통 진입점에 위임)이므로 테스트를 현재 책임에 맞게 수정

## 변경 내용
- `sendJobEmail_dispatchesMail`: `emailService.sendJobDailyEmails(List.of(kakao@1))` 위임을 verify 하도록 변경
- `sendJobEmail_skipsWhenEmpty` → `sendJobEmail_swallowsException` 으로 교체: 빈 대상 스킵 로직은 EmailService 로 이동했으므로, 서비스에 실제 남아 있는 동작인 예외 비전파(로그만 남김)를 검증
- 미사용 `java.util.Map` import 제거

## 테스트
- `./gradlew test --offline --tests com.nklcbdty.api.admin.service.AdminSubscriptionServiceTest` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of scheduled job email processing by suppressing email-service exceptions.
  * Updated validation to confirm delegation to the daily job email delivery service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->