### PR TITLE
✨ Feat: 이메일+비밀번호 자체 회원가입/로그인 + 토큰 재발급 복구

### DIFF
--- a/src/main/java/com/nklcbdty/api/auth/config/LocalAccountSchemaInitializer.java
+++ b/src/main/java/com/nklcbdty/api/auth/config/LocalAccountSchemaInitializer.java
@@ -1,0 +1,43 @@
+package com.nklcbdty.api.auth.config;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * spring.jpa.hibernate.ddl-auto=none 이므로 local_account 테이블을 직접 생성한다("테이블 없으면 생성").
+ */
+@Slf4j
+@Component
+public class LocalAccountSchemaInitializer implements ApplicationRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public LocalAccountSchemaInitializer(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        final String ddl =
+            "CREATE TABLE IF NOT EXISTS local_account (" +
+            "  id BIGINT NOT NULL AUTO_INCREMENT," +
+            "  email VARCHAR(255) NOT NULL," +
+            "  password_hash VARCHAR(255) NOT NULL," +
+            "  user_id VARCHAR(100) NOT NULL," +
+            "  insert_dts DATETIME NULL," +
+            "  PRIMARY KEY (id)," +
+            "  UNIQUE KEY uk_local_account_email (email)," +
+            "  UNIQUE KEY uk_local_account_user_id (user_id)" +
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+        try {
+            jdbcTemplate.execute(ddl);
+            log.info("[LocalAuth] local_account 테이블 확인/생성 완료");
+        } catch (Exception e) {
+            log.error("[LocalAuth] local_account 테이블 생성 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/nklcbdty/api/auth/controller/LocalAuthController.java
+++ b/src/main/java/com/nklcbdty/api/auth/controller/LocalAuthController.java
@@ -1,0 +1,74 @@
+package com.nklcbdty.api.auth.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nklcbdty.api.auth.dto.LoginRequest;
+import com.nklcbdty.api.auth.dto.SignupRequest;
+import com.nklcbdty.api.auth.service.LocalAuthService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 자체 회원가입/로그인 API. 카카오 로그인(/api/kakaoLogin)과 함께 쓰이며 응답 형태를 맞췄다.
+ * (프론트 로그인 화면: 이메일+비밀번호 폼 → /api/auth/login, "카카오로 로그인" 버튼 → 기존 /api/kakaoLogin)
+ *
+ * - POST /api/auth/signup       : 회원가입(성공 시 곧바로 토큰 발급 = 자동 로그인)
+ * - POST /api/auth/login        : 로그인
+ * - GET  /api/auth/email-exists : 회원가입 화면의 이메일 중복 확인
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+public class LocalAuthController {
+
+    private final LocalAuthService localAuthService;
+
+    public LocalAuthController(LocalAuthService localAuthService) {
+        this.localAuthService = localAuthService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody SignupRequest request) {
+        try {
+            LocalAuthService.AuthResult result =
+                localAuthService.signup(request.getEmail(), request.getPassword(), request.getNickname());
+            return ResponseEntity.ok(toBody(result));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("status", "error", "message", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+        try {
+            LocalAuthService.AuthResult result =
+                localAuthService.login(request.getEmail(), request.getPassword());
+            return ResponseEntity.ok(toBody(result));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(401).body(Map.of("status", "error", "message", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/email-exists")
+    public ResponseEntity<?> emailExists(@RequestParam String email) {
+        return ResponseEntity.ok(Map.of("exists", localAuthService.emailExists(email)));
+    }
+
+    /** kakaoLogin 응답과 같은 키 구성(token/refreshToken/userId/nickname) */
+    private Map<String, Object> toBody(LocalAuthService.AuthResult result) {
+        return Map.of(
+            "token", result.token(),
+            "refreshToken", result.refreshToken(),
+            "userId", result.userId(),
+            "nickname", result.nickname()
+        );
+    }
+}

--- a/src/main/java/com/nklcbdty/api/auth/dto/LoginRequest.java
+++ b/src/main/java/com/nklcbdty/api/auth/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.nklcbdty.api.auth.dto;
+
+import lombok.Data;
+
+/** 자체 로그인(이메일+비밀번호) 요청 */
+@Data
+public class LoginRequest {
+
+    private String email;
+
+    private String password;
+}

--- a/src/main/java/com/nklcbdty/api/auth/dto/SignupRequest.java
+++ b/src/main/java/com/nklcbdty/api/auth/dto/SignupRequest.java
@@ -1,0 +1,15 @@
+package com.nklcbdty.api.auth.dto;
+
+import lombok.Data;
+
+/** 자체 회원가입 요청 */
+@Data
+public class SignupRequest {
+
+    private String email;
+
+    private String password;
+
+    /** 표시용 닉네임. 생략하면 이메일 앞부분을 쓴다. */
+    private String nickname;
+}

--- a/src/main/java/com/nklcbdty/api/auth/repository/LocalAccountRepository.java
+++ b/src/main/java/com/nklcbdty/api/auth/repository/LocalAccountRepository.java
@@ -1,0 +1,14 @@
+package com.nklcbdty.api.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nklcbdty.api.auth.vo.LocalAccount;
+
+public interface LocalAccountRepository extends JpaRepository<LocalAccount, Long> {
+
+    Optional<LocalAccount> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/nklcbdty/api/auth/service/LocalAuthService.java
+++ b/src/main/java/com/nklcbdty/api/auth/service/LocalAuthService.java
@@ -1,0 +1,168 @@
+package com.nklcbdty.api.auth.service;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nklcbdty.api.auth.repository.LocalAccountRepository;
+import com.nklcbdty.api.auth.vo.LocalAccount;
+import com.nklcbdty.api.common.UtilityNklcb;
+import com.nklcbdty.common.user.repository.UserRepository;
+import com.nklcbdty.common.vo.UserVo;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 자체 회원가입/로그인(이메일+비밀번호).
+ * 카카오 로그인(KakaoController)과 같은 토큰 체계를 쓴다:
+ * userId 로 access/refresh JWT 를 발급하고 user 테이블에 프로필 행을 만든다.
+ * 카카오 사용자는 "kakao@{id}", 자체 가입 사용자는 "local@{id}" userId 를 갖는다.
+ */
+@Slf4j
+@Service
+public class LocalAuthService {
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+    private static final int MIN_PASSWORD_LENGTH = 8;
+    private static final int MAX_PASSWORD_LENGTH = 64;
+    private static final int MAX_NICKNAME_LENGTH = 50;
+
+    private final LocalAccountRepository localAccountRepository;
+    private final UserRepository userRepository;
+    private final TokenService tokenService;
+    private final UtilityNklcb utilityNklcb;
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    public LocalAuthService(LocalAccountRepository localAccountRepository, UserRepository userRepository,
+                            TokenService tokenService, UtilityNklcb utilityNklcb) {
+        this.localAccountRepository = localAccountRepository;
+        this.userRepository = userRepository;
+        this.tokenService = tokenService;
+        this.utilityNklcb = utilityNklcb;
+    }
+
+    /**
+     * 회원가입. 성공하면 바로 로그인 상태가 되도록 토큰까지 발급해 돌려준다.
+     */
+    @Transactional
+    public AuthResult signup(String email, String rawPassword, String nickname) {
+        String normalizedEmail = normalizeEmail(email);
+        validatePassword(rawPassword);
+
+        if (localAccountRepository.existsByEmail(normalizedEmail)) {
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+
+        LocalAccount account = new LocalAccount();
+        account.setEmail(normalizedEmail);
+        account.setPasswordHash(passwordEncoder.encode(rawPassword));
+        // 최종 userId(local@{id})는 PK 가 정해져야 알 수 있다.
+        // NOT NULL/UNIQUE 제약을 지키기 위해 임시값으로 INSERT 한 뒤 확정한다.
+        // (이메일을 임시값에 쓰면 user_id VARCHAR(100) 을 넘길 수 있어 길이가 고정된 UUID 를 쓴다)
+        account.setUserId(LocalAccount.USER_ID_PREFIX + "tmp:" + UUID.randomUUID());
+        try {
+            account = localAccountRepository.saveAndFlush(account);
+        } catch (DataIntegrityViolationException e) {
+            // existsByEmail 확인과 INSERT 사이에 같은 이메일이 들어온 경우(UNIQUE 위반)
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+        account.setUserId(LocalAccount.USER_ID_PREFIX + account.getId());
+        account = localAccountRepository.save(account);
+
+        // 카카오 로그인과 공유하는 user 테이블에 프로필 행 생성
+        String resolvedNickname = resolveNickname(nickname, normalizedEmail);
+        userRepository.save(UserVo.builder()
+            .userId(account.getUserId())
+            .username(resolvedNickname)
+            .email(normalizedEmail)
+            .build());
+
+        log.info("[LocalAuth] 회원가입 userId={}", account.getUserId());
+        return issueTokens(account.getUserId(), resolvedNickname);
+    }
+
+    /**
+     * 로그인. 이메일/비밀번호 검증 후 카카오 로그인과 동일한 형태의 토큰을 발급한다.
+     * 실패 사유(이메일 없음/비밀번호 불일치)는 구분해 알려주지 않는다.
+     */
+    public AuthResult login(String email, String rawPassword) {
+        if (email == null || email.isBlank() || rawPassword == null || rawPassword.isBlank()) {
+            throw new IllegalArgumentException("이메일과 비밀번호를 입력해주세요.");
+        }
+
+        Optional<LocalAccount> found = localAccountRepository.findByEmail(normalizeEmail(email));
+        if (found.isEmpty() || !passwordEncoder.matches(rawPassword, found.get().getPasswordHash())) {
+            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        LocalAccount account = found.get();
+        UserVo user = userRepository.findByUserId(account.getUserId());
+        String nickname = user != null ? user.getUsername() : localPart(account.getEmail());
+
+        return issueTokens(account.getUserId(), nickname);
+    }
+
+    /** 회원가입 화면의 중복 확인용 */
+    public boolean emailExists(String email) {
+        if (email == null || email.isBlank()) {
+            return false;
+        }
+        return localAccountRepository.existsByEmail(email.trim().toLowerCase());
+    }
+
+    /** access/refresh 토큰 발급 + refresh 저장. 카카오 로그인과 같은 흐름. */
+    private AuthResult issueTokens(String userId, String nickname) {
+        String accessToken = utilityNklcb.generateToken(userId, false);
+        String refreshToken = utilityNklcb.generateToken(userId, true);
+        tokenService.saveRefreshToken(userId, refreshToken);
+        return new AuthResult(accessToken, refreshToken, userId, nickname);
+    }
+
+    private String normalizeEmail(String email) {
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("이메일을 입력해주세요.");
+        }
+        String normalized = email.trim().toLowerCase();
+        if (!EMAIL_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+        }
+        return normalized;
+    }
+
+    private void validatePassword(String rawPassword) {
+        if (rawPassword == null || rawPassword.isBlank()) {
+            throw new IllegalArgumentException("비밀번호를 입력해주세요.");
+        }
+        if (rawPassword.length() < MIN_PASSWORD_LENGTH || rawPassword.length() > MAX_PASSWORD_LENGTH) {
+            throw new IllegalArgumentException(
+                "비밀번호는 " + MIN_PASSWORD_LENGTH + "~" + MAX_PASSWORD_LENGTH + "자로 입력해주세요.");
+        }
+    }
+
+    private String resolveNickname(String nickname, String email) {
+        String name = nickname == null ? null : nickname.trim();
+        if (name == null || name.isEmpty()) {
+            name = localPart(email);
+        }
+        if (name.length() > MAX_NICKNAME_LENGTH) {
+            throw new IllegalArgumentException("닉네임은 " + MAX_NICKNAME_LENGTH + "자 이하로 입력해주세요.");
+        }
+        return name;
+    }
+
+    /** 이메일의 @ 앞부분 */
+    private String localPart(String email) {
+        int at = email.indexOf('@');
+        return at > 0 ? email.substring(0, at) : email;
+    }
+
+    /** 로그인/회원가입 결과. 응답 형태는 kakaoLogin 과 맞춘다. */
+    public record AuthResult(String token, String refreshToken, String userId, String nickname) {
+    }
+}

--- a/src/main/java/com/nklcbdty/api/auth/vo/LocalAccount.java
+++ b/src/main/java/com/nklcbdty/api/auth/vo/LocalAccount.java
@@ -1,0 +1,47 @@
+package com.nklcbdty.api.auth.vo;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+/**
+ * 이메일+비밀번호 회원 계정(자체 회원가입).
+ * 프로필(닉네임/이메일)은 카카오 로그인과 공유하는 user 테이블(UserVo)에 있고,
+ * 이 테이블은 로그인 자격증명(이메일, 비밀번호 해시)과 user.user_id 연결만 담당한다.
+ * 카카오 사용자의 userId 가 "kakao@{id}" 이듯 자체 가입 사용자는 "local@{id}" 를 쓴다.
+ */
+@Entity
+@Table(name = "local_account")
+@Data
+public class LocalAccount {
+
+    /** userId 접두어. 최종 userId = local@{id} */
+    public static final String USER_ID_PREFIX = "local@";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 로그인 아이디로 쓰는 이메일 */
+    @Column(nullable = false, unique = true, length = 255)
+    private String email;
+
+    /** BCrypt 해시 */
+    @Column(nullable = false, length = 255)
+    private String passwordHash;
+
+    /** user 테이블과 연결되는 값. "local@{id}" */
+    @Column(nullable = false, unique = true, length = 100)
+    private String userId;
+
+    @CreationTimestamp
+    private LocalDateTime insertDts;
+}

--- a/src/main/java/com/nklcbdty/api/common/RedisConfig.java
+++ b/src/main/java/com/nklcbdty/api/common/RedisConfig.java
@@ -27,10 +27,10 @@ public class RedisConfig {
     @Value("${spring.redis.password}")
     private String password;
 
-    // 개발 환경 설정
+    // 기본 설정. dev/prod 모두 단일 Redis 를 쓴다.
+    // (dev = application-dev.properties 의 cloudtype 주소, prod = REDIS_HOST/REDIS_PORT 환경변수)
     @Bean
-    // @Profile("dev")
-    @Profile("prod")
+    @Profile("!cluster")
     public RedisConnectionFactory redisStandaloneConnectionFactory (
         @Value("${spring.redis.host}") String host,
         @Value("${spring.redis.port}") int port) {
@@ -46,10 +46,10 @@ public class RedisConfig {
         return new LettuceConnectionFactory(config, clientConfig);
     }
 
-    // 운영 환경 설정
+    // Redis Cluster 를 쓸 때만 'cluster' 프로파일로 켠다.
+    // 예전 EC2 클러스터(spring.redis.cluster.nodes)는 지금 응답하지 않으므로 기본에서 제외했다.
     @Bean
-    // @Profile("prod")
-    @Profile("dev")
+    @Profile("cluster")
     public RedisConnectionFactory redisClusterConnectionFactory (
         @Value("${spring.redis.cluster.nodes}") String clusterNodes) {
 

--- a/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
+++ b/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
@@ -8,6 +8,10 @@ import lombok.Getter;
 public enum AllowedPaths {
     LOGIN("/login"),
     KAKAO_LOGIN("/api/kakaoLogin"),
+    // 자체 회원가입/로그인. 인증 전 단계이므로 공개.
+    AUTH_SIGNUP("/api/auth/signup"),
+    AUTH_LOGIN("/api/auth/login"),
+    AUTH_EMAIL_EXISTS("/api/auth/email-exists"),
     OAUTH2("/oauth2/**"),
     DETAIL("/detail/**"),
     LOG("/api/log/**"),

--- a/src/main/resources/db/migration/V2__user_id_auto_increment.sql
+++ b/src/main/resources/db/migration/V2__user_id_auto_increment.sql
@@ -1,0 +1,8 @@
+-- user 테이블 id 에 PK + AUTO_INCREMENT 추가
+-- ddl-auto=none 이므로 운영 DB에 수동 적용 필요. (2026-08-01 적용 완료)
+--
+-- UserVo 는 @Id @GeneratedValue(IDENTITY) 인데 실제 테이블에는 PK/auto_increment 가
+-- 없어서 신규 사용자 INSERT 가 항상 아래 오류로 실패했다.
+--   HibernateException: The database returned no natively generated identity value : UserVo
+-- 자체 회원가입뿐 아니라 신규 카카오 사용자의 첫 로그인(UserService.loadUserById)도 같이 막혀 있었다.
+ALTER TABLE user MODIFY id BIGINT NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (id);

--- a/src/test/java/com/nklcbdty/api/auth/controller/LocalAuthControllerTest.java
+++ b/src/test/java/com/nklcbdty/api/auth/controller/LocalAuthControllerTest.java
@@ -1,0 +1,98 @@
+package com.nklcbdty.api.auth.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nklcbdty.api.auth.service.LocalAuthService;
+
+class LocalAuthControllerTest {
+
+    private LocalAuthService localAuthService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        localAuthService = mock(LocalAuthService.class);
+        mockMvc = standaloneSetup(new LocalAuthController(localAuthService)).build();
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/signup: 카카오 로그인과 같은 키(token/refreshToken/userId/nickname)로 응답한다")
+    void signup_returnsKakaoShapedBody() throws Exception {
+        when(localAuthService.signup("test@example.com", "password123", "테스터"))
+            .thenReturn(new LocalAuthService.AuthResult("access", "refresh", "local@7", "테스터"));
+
+        mockMvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"test@example.com\",\"password\":\"password123\",\"nickname\":\"테스터\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.token").value("access"))
+            .andExpect(jsonPath("$.refreshToken").value("refresh"))
+            .andExpect(jsonPath("$.userId").value("local@7"))
+            .andExpect(jsonPath("$.nickname").value("테스터"));
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/signup: 검증 실패는 400 과 메세지를 돌려준다")
+    void signup_invalidInputReturns400() throws Exception {
+        when(localAuthService.signup(anyString(), anyString(), anyString()))
+            .thenThrow(new IllegalArgumentException("이미 가입된 이메일입니다."));
+
+        mockMvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"dup@example.com\",\"password\":\"password123\",\"nickname\":\"x\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value("error"))
+            .andExpect(jsonPath("$.message").value("이미 가입된 이메일입니다."));
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/login: 성공하면 토큰을 돌려준다")
+    void login_returnsTokens() throws Exception {
+        when(localAuthService.login("test@example.com", "password123"))
+            .thenReturn(new LocalAuthService.AuthResult("access", "refresh", "local@7", "테스터"));
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"test@example.com\",\"password\":\"password123\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.token").value("access"))
+            .andExpect(jsonPath("$.userId").value("local@7"));
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/login: 자격증명이 틀리면 401 이다")
+    void login_badCredentialsReturns401() throws Exception {
+        when(localAuthService.login(anyString(), anyString()))
+            .thenThrow(new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다."));
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"test@example.com\",\"password\":\"wrong\"}"))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.status").value("error"))
+            .andExpect(jsonPath("$.message").value("이메일 또는 비밀번호가 올바르지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("GET /api/auth/email-exists: 중복 여부를 exists 로 돌려준다")
+    void emailExists_returnsFlag() throws Exception {
+        when(localAuthService.emailExists("dup@example.com")).thenReturn(true);
+
+        mockMvc.perform(get("/api/auth/email-exists").param("email", "dup@example.com"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.exists").value(true));
+    }
+}

--- a/src/test/java/com/nklcbdty/api/auth/service/LocalAuthServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/auth/service/LocalAuthServiceTest.java
@@ -1,0 +1,195 @@
+package com.nklcbdty.api.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.nklcbdty.api.auth.repository.LocalAccountRepository;
+import com.nklcbdty.api.auth.vo.LocalAccount;
+import com.nklcbdty.api.common.UtilityNklcb;
+import com.nklcbdty.common.user.repository.UserRepository;
+import com.nklcbdty.common.vo.UserVo;
+
+@ExtendWith(MockitoExtension.class)
+class LocalAuthServiceTest {
+
+    @Mock
+    private LocalAccountRepository localAccountRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private UtilityNklcb utilityNklcb;
+
+    @InjectMocks
+    private LocalAuthService service;
+
+    // --------------------------------------------------------------- 회원가입
+
+    @Test
+    void signup_성공하면_local계정과_user프로필을_만들고_토큰을_발급한다() {
+        when(localAccountRepository.existsByEmail("test@example.com")).thenReturn(false);
+        when(localAccountRepository.saveAndFlush(any(LocalAccount.class))).thenAnswer(inv -> {
+            LocalAccount account = inv.getArgument(0);
+            account.setId(7L);
+            return account;
+        });
+        when(localAccountRepository.save(any(LocalAccount.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(utilityNklcb.generateToken("local@7", false)).thenReturn("access-token");
+        when(utilityNklcb.generateToken("local@7", true)).thenReturn("refresh-token");
+
+        LocalAuthService.AuthResult result = service.signup("Test@Example.com", "password123", "테스터");
+
+        assertThat(result.userId()).isEqualTo("local@7");
+        assertThat(result.token()).isEqualTo("access-token");
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        assertThat(result.nickname()).isEqualTo("테스터");
+
+        // 비밀번호는 BCrypt 해시로 저장된다
+        ArgumentCaptor<LocalAccount> accountCaptor = ArgumentCaptor.forClass(LocalAccount.class);
+        verify(localAccountRepository).saveAndFlush(accountCaptor.capture());
+        assertThat(accountCaptor.getValue().getEmail()).isEqualTo("test@example.com");
+        assertThat(new BCryptPasswordEncoder().matches("password123", accountCaptor.getValue().getPasswordHash()))
+            .isTrue();
+
+        // user 테이블 프로필 생성
+        ArgumentCaptor<UserVo> userCaptor = ArgumentCaptor.forClass(UserVo.class);
+        verify(userRepository).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getUserId()).isEqualTo("local@7");
+        assertThat(userCaptor.getValue().getUsername()).isEqualTo("테스터");
+        assertThat(userCaptor.getValue().getEmail()).isEqualTo("test@example.com");
+
+        verify(tokenService, times(1)).saveRefreshToken("local@7", "refresh-token");
+    }
+
+    @Test
+    void signup_닉네임을_생략하면_이메일_앞부분을_쓴다() {
+        when(localAccountRepository.existsByEmail("hong@example.com")).thenReturn(false);
+        when(localAccountRepository.saveAndFlush(any(LocalAccount.class))).thenAnswer(inv -> {
+            LocalAccount account = inv.getArgument(0);
+            account.setId(1L);
+            return account;
+        });
+        when(localAccountRepository.save(any(LocalAccount.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(utilityNklcb.generateToken(anyString(), eq(false))).thenReturn("a");
+        when(utilityNklcb.generateToken(anyString(), eq(true))).thenReturn("r");
+
+        LocalAuthService.AuthResult result = service.signup("hong@example.com", "password123", null);
+
+        assertThat(result.nickname()).isEqualTo("hong");
+    }
+
+    @Test
+    void signup_이미가입된_이메일이면_거절한다() {
+        when(localAccountRepository.existsByEmail("dup@example.com")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.signup("dup@example.com", "password123", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이미 가입된");
+
+        verify(localAccountRepository, never()).saveAndFlush(any(LocalAccount.class));
+    }
+
+    @Test
+    void signup_이메일형식이_틀리면_거절한다() {
+        assertThatThrownBy(() -> service.signup("not-an-email", "password123", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이메일 형식");
+    }
+
+    @Test
+    void signup_비밀번호가_짧으면_거절한다() {
+        assertThatThrownBy(() -> service.signup("test@example.com", "short", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("비밀번호는");
+    }
+
+    // ----------------------------------------------------------------- 로그인
+
+    @Test
+    void login_이메일과_비밀번호가_맞으면_토큰을_발급한다() {
+        LocalAccount account = account(7L, "test@example.com", "password123");
+        when(localAccountRepository.findByEmail("test@example.com")).thenReturn(Optional.of(account));
+        when(userRepository.findByUserId("local@7"))
+            .thenReturn(UserVo.builder().userId("local@7").username("테스터").build());
+        when(utilityNklcb.generateToken("local@7", false)).thenReturn("access-token");
+        when(utilityNklcb.generateToken("local@7", true)).thenReturn("refresh-token");
+
+        LocalAuthService.AuthResult result = service.login("Test@Example.com", "password123");
+
+        assertThat(result.userId()).isEqualTo("local@7");
+        assertThat(result.nickname()).isEqualTo("테스터");
+        verify(tokenService, times(1)).saveRefreshToken("local@7", "refresh-token");
+    }
+
+    @Test
+    void login_비밀번호가_틀리면_사유를_구분하지않고_거절한다() {
+        LocalAccount account = account(7L, "test@example.com", "password123");
+        when(localAccountRepository.findByEmail("test@example.com")).thenReturn(Optional.of(account));
+
+        assertThatThrownBy(() -> service.login("test@example.com", "wrong-password"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이메일 또는 비밀번호");
+
+        verify(tokenService, never()).saveRefreshToken(anyString(), anyString());
+    }
+
+    @Test
+    void login_가입되지않은_이메일이면_같은_메세지로_거절한다() {
+        when(localAccountRepository.findByEmail("none@example.com")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.login("none@example.com", "password123"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("이메일 또는 비밀번호");
+    }
+
+    @Test
+    void login_입력이_비어있으면_거절한다() {
+        assertThatThrownBy(() -> service.login(" ", "password123"))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> service.login("test@example.com", ""))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ------------------------------------------------------------- 중복 확인
+
+    @Test
+    void emailExists_대소문자를_무시하고_확인한다() {
+        when(localAccountRepository.existsByEmail("test@example.com")).thenReturn(true);
+
+        assertThat(service.emailExists("Test@Example.com ")).isTrue();
+        assertThat(service.emailExists(null)).isFalse();
+        assertThat(service.emailExists("  ")).isFalse();
+    }
+
+    // ------------------------------------------------------------------ 헬퍼
+
+    private LocalAccount account(Long id, String email, String rawPassword) {
+        LocalAccount account = new LocalAccount();
+        account.setId(id);
+        account.setEmail(email);
+        account.setPasswordHash(new BCryptPasswordEncoder().encode(rawPassword));
+        account.setUserId(LocalAccount.USER_ID_PREFIX + id);
+        return account;
+    }
+}


### PR DESCRIPTION
카카오 로그인만 있던 인증에 자체 계정(이메일+비밀번호)을 추가합니다.
프론트 작업은 별도 PR: kingle1024/nklcbdty-ui `feat/local-auth-ui`

## 추가된 API

| 엔드포인트 | 설명 |
|---|---|
| `POST /api/auth/signup` | 회원가입 (성공 시 곧바로 토큰 발급 = 자동 로그인) |
| `POST /api/auth/login` | 로그인 |
| `GET /api/auth/email-exists` | 회원가입 화면의 이메일 중복 확인 |

카카오와 **같은 토큰 체계**를 씁니다. 카카오 `kakao@{id}` ↔ 자체가입 `local@{id}`, 응답 키도 `token/refreshToken/userId/nickname`으로 동일해서 프론트가 성공 처리를 한 곳에서 재사용합니다.

자격증명(이메일, BCrypt 해시)은 새 `local_account` 테이블에 두고, 프로필은 카카오와 공유하는 `user` 테이블을 그대로 씁니다. `ddl-auto=none` 이라 테이블은 기동 시 직접 생성합니다.

로그인 실패는 이메일 없음/비밀번호 불일치를 구분하지 않아 계정 존재 여부를 노출하지 않습니다.

## 같이 고친 버그 2건

**1. dev 프로파일이 죽은 Redis 클러스터를 보고 있었습니다.**

`RedisConfig` 의 프로파일이 주석과 반대로 붙어 있어, 활성 프로파일인 `dev` 가 응답하지 않는 예전 EC2 클러스터(`13.125.45.194:6380-6385`)로 붙었습니다. 정작 설정해 둔 cloudtype Redis 는 `prod` 쪽 standalone 팩토리만 읽어서 한 번도 쓰이지 않았습니다.

그 결과 `TokenService` 가 refresh 토큰을 저장하지 못하고(예외를 잡아 로그만 남깁니다) 이후 조회가 null 이 되어 `/api/auth/refresh` 가 **항상 401** 이었습니다. → 카카오든 자체 로그인이든 1시간 뒤 세션이 끊기고 복구되지 않았습니다.

죽은 클러스터를 기본에서 빼고 단일 Redis 를 기본(`@Profile("!cluster")`)으로 뒀습니다. `prod` 는 원래대로 `REDIS_HOST/REDIS_PORT` 환경변수의 standalone 을 계속 씁니다.

**2. `user` 테이블에 PK/AUTO_INCREMENT 가 없었습니다.**

`UserVo` 는 `@GeneratedValue(IDENTITY)` 인데 실제 테이블엔 없어서 신규 사용자 INSERT 가 항상 실패했습니다.

```
HibernateException: The database returned no natively generated identity value : UserVo
```

자체 회원가입뿐 아니라 **신규 카카오 사용자의 첫 로그인**(`UserService.loadUserById`)도 같이 막혀 있었습니다. 기존 사용자는 행이 이미 있어 로그인됐습니다.

> [!IMPORTANT]
> 이 ALTER 는 **운영 DB에 이미 적용했습니다** (2026-08-01, 행 2개·중복 없음 확인 후). 저장소에는 기록용으로 `V2__user_id_auto_increment.sql` 만 추가했습니다 — Flyway 가 없어 자동 실행되지 않습니다.

## 검증

운영 DB(cloudtype MariaDB/Redis)에 실제로 붙여 확인했습니다.

| 케이스 | 결과 |
|---|---|
| `email-exists` 가입 전 / 후 | `false` → `true` |
| 회원가입 | 200, `userId: local@2`, 한글 닉네임 정상 |
| 대문자 이메일로 로그인 | 200 (소문자 정규화 동작) |
| 비밀번호 틀림 / 없는 이메일 | 둘 다 401 + **동일 메시지** |
| 중복 가입 / 짧은 비밀번호 / 이메일 형식 | 400 + 각 안내 메시지 |
| 토큰 재발급 (정상) | Redis 수정 전 401 → **수정 후 200** |
| 재발급: 다른 userId / 위조 토큰 | 401 |

- 단위 테스트 15개 통과 (`LocalAuthServiceTest` 10, `LocalAuthControllerTest` 5)
- 커밋된 트리만으로 컴파일 + 테스트 통과 확인 (같은 워킹트리에 있던 미커밋 게시판 작업분을 치우고 검증)
- `Unable to connect to Redis` 오류 0건 (수정 전에는 매 요청 발생)

## 남겨둔 것

- 테스트 계정 `claude-test-7e81638@example.com` (`local@2`) 이 운영 DB에 남아 있습니다. 지워도 됩니다.
- 같은 워킹트리에 있던 게시판 작업분(`api/board/`, `AllowedPaths` 의 `BOARD` 항목)은 이 PR에 포함하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local email/password signup and login.
  * Added email-existence checks, nickname support, and access/refresh token issuance.
  * Added automatic local account setup and user ID generation.
* **Configuration**
  * Updated authentication access rules and Redis profile behavior.
  * Added database support for automatic user ID generation.
* **Tests**
  * Added coverage for authentication success, validation errors, duplicate accounts, invalid credentials, password security, and email checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->