### PR TITLE
🚨 Fix: 당근/야놀자 크롤러 복구 + ✨ 회사별 채용 페이지 바로가기 API

### DIFF
--- a/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
+++ b/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
@@ -18,6 +18,8 @@ public enum AllowedPaths {
     LIST("/api/list"),
     LIST_ALL("/api/list/**"),
     CATEGORY_ALL("/api/category/**"),
+    // 회사 목록 + 채용 페이지 주소. 로그인 없이 보는 목록 화면에서 쓰므로 공개.
+    COMPANY_ALL("/api/company/**"),
     EMAIL("/api/email/**"),
     CRALWER("/api/crawler"),
     JOB_DELETE_REQUEST("/api/job-delete-requests"),

--- a/src/main/java/com/nklcbdty/api/crawler/common/CompanyEnums.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CompanyEnums.java
@@ -1,0 +1,38 @@
+package com.nklcbdty.api.crawler.common;
+
+import lombok.Getter;
+
+/**
+ * 크롤링 대상 회사와 각 회사의 채용 페이지 주소.
+ *
+ * <p>코드(companyCd)는 {@code job_mst.company_cd} 및 {@code /api/crawler?company=} 파라미터와 같은 값이다.
+ * 채용 페이지 주소는 "채용 페이지로 가기" 버튼에서 쓰이며, 크롤러가 보는 API 가 아니라
+ * 사람이 보는 목록 페이지를 가리킨다.</p>
+ */
+@Getter
+public enum CompanyEnums {
+
+    NAVER("네이버", "https://recruit.navercorp.com/rcrt/list.do"),
+    KAKAO("카카오", "https://careers.kakao.com/jobs"),
+    LINE("라인", "https://careers.linecorp.com/ko/jobs"),
+    COUPANG("쿠팡", "https://www.coupang.jobs/kr/jobs/"),
+    BAEMIN("배달의민족", "https://career.woowahan.com/"),
+    // 채용 사이트가 about.daangn.com 에서 careers.daangn.com 으로 이전됨
+    DAANGN("당근마켓", "https://careers.daangn.com/jobs/"),
+    TOSS("토스", "https://toss.im/career/jobs"),
+    // careers.yanolja.co 에는 공고 목록이 없다. 지원은 Workday 채용 사이트에서 받는다.
+    YANOLJA("야놀자", "https://yanolja.wd102.myworkdayjobs.com/ko-KR/External_Yanolja"),
+    ;
+
+    private final String companyNm;
+    private final String careerPageUrl;
+
+    CompanyEnums(String companyNm, String careerPageUrl) {
+        this.companyNm = companyNm;
+        this.careerPageUrl = careerPageUrl;
+    }
+
+    public String getCompanyCd() {
+        return name();
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -119,6 +119,10 @@ public class CrawlerCommonService {
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
             conn.setRequestProperty("Accept", "application/json");
+            // GET 경로와 동일하게 브라우저 User-Agent + 타임아웃을 건다. (WAF 차단/무한 대기 방지)
+            conn.setRequestProperty("User-Agent", BROWSER_USER_AGENT);
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
             conn.setDoOutput(true);
 
             try (OutputStream os = conn.getOutputStream()) {

--- a/src/main/java/com/nklcbdty/api/crawler/controller/CompanyController.java
+++ b/src/main/java/com/nklcbdty/api/crawler/controller/CompanyController.java
@@ -1,0 +1,29 @@
+package com.nklcbdty.api.crawler.controller;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nklcbdty.api.crawler.common.CompanyEnums;
+import com.nklcbdty.api.crawler.dto.CompanyDto;
+
+/**
+ * 회사 목록 + 각 회사의 채용 페이지 주소.
+ *
+ * <p>예: {@code GET /api/company/list}</p>
+ */
+@RestController
+@RequestMapping("/api/company")
+public class CompanyController {
+
+    @GetMapping("/list")
+    public List<CompanyDto> list() {
+        return Arrays.stream(CompanyEnums.values())
+                     .map(CompanyDto::new)
+                     .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/dto/CompanyDto.java
+++ b/src/main/java/com/nklcbdty/api/crawler/dto/CompanyDto.java
@@ -1,0 +1,20 @@
+package com.nklcbdty.api.crawler.dto;
+
+import com.nklcbdty.api.crawler.common.CompanyEnums;
+
+import lombok.Getter;
+
+/** 회사 목록 응답. 회사 탭과 "채용 페이지로 가기" 버튼에서 쓴다. */
+@Getter
+public class CompanyDto {
+
+    private final String companyCd;
+    private final String companyNm;
+    private final String careerPageUrl;
+
+    public CompanyDto(CompanyEnums company) {
+        this.companyCd = company.getCompanyCd();
+        this.companyNm = company.getCompanyNm();
+        this.careerPageUrl = company.getCareerPageUrl();
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/service/DaangnJobCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/DaangnJobCrawlerService.java
@@ -3,9 +3,11 @@ package com.nklcbdty.api.crawler.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.jsoup.Jsoup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -13,7 +15,6 @@ import org.springframework.stereotype.Service;
 import com.nklcbdty.api.crawler.common.CrawlerCommonService;
 import com.nklcbdty.api.crawler.common.JobEnums;
 import com.nklcbdty.api.crawler.dto.PersonalHistoryDto;
-import com.nklcbdty.api.crawler.interfaces.JobCrawler;
 import com.nklcbdty.common.vo.Job_mst;
 
 import lombok.extern.slf4j.Slf4j;
@@ -21,86 +22,90 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 public class DaangnJobCrawlerService {
-	
+
 	private final CrawlerCommonService crawlerCommonService;
     private String apiUrl;
-    
+
     @Autowired
     public DaangnJobCrawlerService(CrawlerCommonService crawlerCommonService) {
 		this.crawlerCommonService = crawlerCommonService;
 		this.apiUrl = getApiUrl();
 	}
-    
+
+    /**
+     * 당근 채용 사이트가 about.daangn.com(Gatsby) → careers.daangn.com(Astro) 으로 옮겨가면서
+     * 기존 {@code /page-data/jobs/page-data.json} 이 404 가 되어 크롤이 0건이 됐다.
+     * 새 사이트는 Greenhouse 보드(daangn)를 그대로 렌더링하므로 공개 보드 API 를 직접 호출한다.
+     * {@code content=true} 를 붙이면 departments/offices 와 공고 본문(HTML)까지 한 번에 내려와,
+     * 공고마다 상세 페이지를 다시 긁을 필요가 없다(기존 38회 요청 → 1회).
+     */
     private String getApiUrl() {
-    	return "https://about.daangn.com/page-data/jobs/page-data.json";
+    	return "https://boards-api.greenhouse.io/v1/boards/daangn/jobs?content=true";
     }
-	
+
+    // 공고 상세는 새 채용 사이트의 role 페이지로 연결한다.
+    // (Greenhouse 가 주는 absolute_url 은 about.daangn.com?gh_jid=... 형태라 리다이렉트를 한 번 더 탄다)
+    private static final String JOB_DETAIL_URL_PREFIX = "https://careers.daangn.com/jobs/role/";
+
+    private static final Pattern VALID_THROUGH_PATTERN = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+
     @Async
 	public CompletableFuture<List<Job_mst>> crawlJobs() {
 		List<Job_mst> list = new ArrayList<>();
 		try {
-			
-			String formattedDate = crawlerCommonService.formatCurrentTime(); 
+
+			String formattedDate = crawlerCommonService.formatCurrentTime();
 			log.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> {}의 크롤러가 {}로 시작됩니다.", this.getClass(), formattedDate);
 			String resultJSONStr = crawlerCommonService.fetchApiResponse(apiUrl);
-			
-			JSONObject jsonObj = new JSONObject(resultJSONStr);
-			JSONArray allDepartmentFilteredJobPostNodes = jsonObj.getJSONObject("result").getJSONObject("data").getJSONObject("allDepartmentFilteredJobPost").getJSONArray("nodes");
-			JSONArray allJobPostNodes = jsonObj.getJSONObject("result").getJSONObject("data").getJSONObject("allJobPost").getJSONArray("nodes");
-			
-			for(int i = 0; i < allDepartmentFilteredJobPostNodes.length(); i++) {
-				try {
-					Job_mst job_mst = new Job_mst();
-					JSONObject item = allDepartmentFilteredJobPostNodes.getJSONObject(i);
-					String classCdNm;
-					String subJobCdNm;
 
-					String jobDetailLink = item.optString("absoluteUrl", "");
-					String annoId = item.opt("ghId") == null ? null : item.get("ghId").toString();
+			JSONObject jsonObj = new JSONObject(resultJSONStr);
+			JSONArray jobNodes = jsonObj.optJSONArray("jobs");
+
+			if (jobNodes == null) {
+				// 보드 이관/차단 등으로 jobs 를 못 찾은 경우. 통째로 실패하지 않고 원인 진단이 되게 로그만 남긴다.
+				log.error("당근 크롤 응답에서 jobs 를 찾지 못함. 응답 앞부분: {}",
+					resultJSONStr == null ? "null" : resultJSONStr.substring(0, Math.min(300, resultJSONStr.length())));
+				return CompletableFuture.completedFuture(crawlerCommonService.getNotSaveJobItem("DAANGN", list));
+			}
+
+			for (int i = 0; i < jobNodes.length(); i++) {
+				try {
+					JSONObject item = jobNodes.getJSONObject(i);
+
+					// Greenhouse job id. 구 크롤러의 ghId 와 같은 값이라 기존 DB row 와 그대로 매칭된다.
+					String annoId = item.opt("id") == null ? null : item.get("id").toString();
 					String annoSubject = item.optString("title", "");
-					String rowEmploymentType = item.optString("employmentType", ""); // 컨버트 필요.
-					String empTypeCdNm = ConvertCodeToEmpType(rowEmploymentType);
 
 					if (annoId == null || annoId.isBlank() || annoSubject.isBlank()) {
-						log.warn("당근 공고 필수값 누락으로 건너뜀 (index={}, ghId={})", i, annoId);
+						log.warn("당근 공고 필수값 누락으로 건너뜀 (index={}, id={})", i, annoId);
 						continue;
 					}
 
-					// allJobPost 와 allDepartmentFilteredJobPost 는 별개 배열이라 길이/순서가 다를 수 있다.
-					// 같은 인덱스로 접근하다 IndexOutOfBounds 로 전체가 죽지 않도록 범위를 확인한다.
-					String sysCompanyCdNm = "";
-					if (i < allJobPostNodes.length()) {
-						sysCompanyCdNm = allJobPostNodes.getJSONObject(i).optString("corporate", "");
-					}
+					Job_mst job_mst = new Job_mst();
 
-					JSONArray departmentsNodes = item.optJSONArray("departments");
-					if (departmentsNodes != null) {
-						for (int j = 0; j < departmentsNodes.length(); j++) {
-							JSONObject department = departmentsNodes.getJSONObject(j);
-							String rowDepartmentId = department.optString("id", "");
-							String departmentName = convertDepartmentIdToName(rowDepartmentId);
-							if (departmentName.contains(",")) {
-								String[] departmentNames = splitDepartmentName(departmentName);
-								classCdNm = departmentNames[0];
-								subJobCdNm = departmentNames[1];
-
-								job_mst.setClassCdNm(classCdNm);
-								job_mst.setSubJobCdNm(subJobCdNm.trim());
-							} else {
-								classCdNm = departmentName;
-								job_mst.setClassCdNm(classCdNm);
-							}
-						}
-					}
-
-					job_mst.setJobDetailLink(jobDetailLink);
-	                PersonalHistoryDto personalHistoryDto = crawlerCommonService.extractPersonalHistoryFromJobPage(jobDetailLink);
-	                job_mst.setPersonalHistory(personalHistoryDto.getFrom());
-	                job_mst.setPersonalHistoryEnd(personalHistoryDto.getTo());
-	                job_mst.setAnnoId(annoId);
+					String jobDetailLink = JOB_DETAIL_URL_PREFIX + annoId + "/";
+					job_mst.setAnnoId(annoId);
 					job_mst.setAnnoSubject(annoSubject);
-					job_mst.setEmpTypeCdNm(empTypeCdNm);
-					job_mst.setSysCompanyCdNm(sysCompanyCdNm);
+					job_mst.setJobDetailLink(jobDetailLink);
+					job_mst.setEmpTypeCdNm(ConvertCodeToEmpType(findMetadata(item, "Employment Type")));
+					job_mst.setSysCompanyCdNm(normalizeCorporate(findMetadata(item, "Corporate")));
+
+					// Greenhouse 의 "Valid Through" 는 대부분 빈 값(상시채용)이다. 값이 있을 때만 마감일로 쓴다.
+					// 조회(JobService)가 파싱 못 하는 형식이 들어오면 살아있는 공고가 목록에서 빠지므로,
+					// yyyy-MM-dd 로 확인된 값만 반영하고 나머지는 상시채용(null)으로 둔다.
+					String validThrough = findMetadata(item, "Valid Through");
+					if (VALID_THROUGH_PATTERN.matcher(validThrough).matches()) {
+						job_mst.setEndDate(validThrough + " 23:59:59");
+					} else if (!validThrough.isBlank()) {
+						log.warn("당근 공고 Valid Through 형식이 예상과 달라 무시함 (id={}, value='{}')", annoId, validThrough);
+					}
+
+					applyDepartment(job_mst, item.optJSONArray("departments"));
+
+					// content=true 로 함께 내려온 공고 본문에서 경력을 추출한다(상세 페이지 재요청 불필요).
+					PersonalHistoryDto personalHistoryDto = extractPersonalHistory(item.optString("content", ""));
+					job_mst.setPersonalHistory(personalHistoryDto.getFrom());
+					job_mst.setPersonalHistoryEnd(personalHistoryDto.getTo());
 
 					list.add(job_mst);
 				} catch (Exception itemEx) {
@@ -140,137 +145,110 @@ public class DaangnJobCrawlerService {
                 }
             }
 
-            for (Job_mst item : list) {
-                switch (item.getSysCompanyCdNm()) {
-                    case "KARROT_MARKET": {
-                        item.setSysCompanyCdNm("당근마켓");
-                        break;
-                    }
-
-                    case "KARROT_PAY": {
-                        item.setSysCompanyCdNm("당근페이");
-                        break;
-                    }
-                }
-            }
-
 		} catch (Exception e) {
             log.error("Error occurred while crawling jobs: {}", e.getMessage(), e);
         }
 
         return CompletableFuture.completedFuture(crawlerCommonService.getNotSaveJobItem("DAANGN", list));
 	}
-	
+
+	/**
+	 * <p>Greenhouse 의 metadata 배열(name/value 쌍)에서 이름으로 값을 찾는다.
+	 *    없거나 null 이면 빈 문자열.</p>
+	 * */
+	private String findMetadata(JSONObject item, String name) {
+		JSONArray metadata = item.optJSONArray("metadata");
+		if (metadata == null) return "";
+
+		for (int i = 0; i < metadata.length(); i++) {
+			JSONObject meta = metadata.optJSONObject(i);
+			if (meta == null) continue;
+			if (!name.equals(meta.optString("name", ""))) continue;
+			return meta.optString("value", "");
+		}
+		return "";
+	}
+
+	/**
+	 * <p>departments[0] 의 이름을 직군/직무로 매핑한다.
+	 *    "Software Engineer, Backend" 처럼 ,가 있으면 앞은 classCdNm, 뒤는 subJobCdNm 이다.</p>
+	 * */
+	private void applyDepartment(Job_mst job_mst, JSONArray departments) {
+		if (departments == null || departments.isEmpty()) return;
+
+		JSONObject department = departments.optJSONObject(0);
+		if (department == null) return;
+
+		String departmentName = department.optString("name", "");
+		if (departmentName.isBlank()) return;
+
+		if (departmentName.contains(",")) {
+			String[] departmentNames = departmentName.split(",");
+			job_mst.setClassCdNm(departmentNames[0].trim());
+			job_mst.setSubJobCdNm(departmentNames[1].trim());
+		} else {
+			job_mst.setClassCdNm(departmentName);
+		}
+	}
+
+	/**
+	 * <p>Greenhouse content 는 HTML 이 escape 된 문자열이다.
+	 *    태그를 걷어낸 본문 텍스트에서 경력 연차를 추출한다.</p>
+	 * */
+	private PersonalHistoryDto extractPersonalHistory(String content) {
+		if (content == null || content.isBlank()) return new PersonalHistoryDto();
+
+		try {
+			return crawlerCommonService.getPersonalHistory(Jsoup.parse(content).text());
+		} catch (Exception e) {
+			log.error("당근 공고 본문 경력 추출 실패: {}", e.getMessage());
+			return new PersonalHistoryDto();
+		}
+	}
+
 	/**
 	 * <p>직무형태 코드를 이름으로 바꾼다</p>
 	 * @author David Lee
 	 * */
 	private String ConvertCodeToEmpType(String rowEmploymentType) {
 		String resStr = "";
-		if (rowEmploymentType.isBlank() || rowEmploymentType.isBlank() || rowEmploymentType == null) return resStr;
-		
+		if (rowEmploymentType == null || rowEmploymentType.isBlank()) return resStr;
+
+		// Greenhouse 보드로 옮겨오면서 값이 FULL_TIME/CONTRACTOR 에서 한글(정규직/계약직/인턴)로 바뀌었다.
+		// 예전 표기도 함께 받아 크롤러 교체 전후로 동일한 결과가 나오게 한다.
 		switch (rowEmploymentType.toUpperCase()) {
 		case "FULL_TIME":
+		case "정규직":
 			resStr = "정규";
 			break;
 		case "CONTRACTOR" :
+		case "계약직":
 			resStr = "계약직";
 			break;
 		default:
 			resStr = "인턴";
 			break;
-		}	
+		}
 		return resStr;
 	}
-	
+
 	/**
-	 * <p>정제된 departmentName에 ,가 있으면 스플릿해서 [0]인덱스는 classCdNm을
-	 *    [1]인덱스는 subJobCdNm에 매핑할 것이다.</p>
-	 * @author David Lee
+	 * <p>Corporate 메타데이터를 화면 표기용 회사명으로 정리한다.
+	 *    같은 법인인데도 "당근"/"당근마켓" 두 표기가 섞여 내려와 카드마다 다르게 보이던 것을 하나로 맞춘다.</p>
 	 * */
-	private String[] splitDepartmentName(String departmentName) {
-		
-		if (!departmentName.contains(",")) {	
-			
-		} 
-		String[] resultStrArr = departmentName.split(",");
-		return resultStrArr;
-	}
-	
-	/**
-	 * <p>departmentId를 departmentName으로 정제한다.</p>
-	 * @author David Lee
-	 * */
-	private String convertDepartmentIdToName(String rowDepartmentId) {
-		String resultStr = "";
-		if (rowDepartmentId.isBlank() || rowDepartmentId.isEmpty() || rowDepartmentId == null) return resultStr;
-		
-		switch (rowDepartmentId) {
-			case "885068ee-7068-5e0b-bcc4-93048745888a":
-				resultStr = "Business";
-				break;
-			case "3c9ebf9f-e46c-5652-85ad-9a59a622074":
-				resultStr = "Communications";
-				break;
-			case "04f58fce-ec93-5f23-a5fc-70b30f9bb34e":
-				resultStr = "Content";
-				break;
-			case "ca3db0f1-5de4-5e29-a195-1b6fb3c55d4f":
-				resultStr = "Data";
-				break;
-			case "58b938e1-367e-5a81-ab06-84ad3203e9b7":
-				resultStr = "Database Engineering";
-				break;
-			case "60f61570-40a8-5153-9a70-a690d903b839":
-				resultStr = "Design";
-				break;
-			case "70660a18-95e5-508d-88a2-b77446b0090b":
-				resultStr = "Finance";
-				break;
-			case "c34079f4-6a5f-5c9f-95d3-4d4aaf6375ce":
-				resultStr = "Information Security Manager";
-				break;
-			case "88217783-fa3a-527c-9fd0-651b1fb891bc":
-				resultStr = "Marketing";
-				break;
-			case "f4817a69-9e3a-5415-ae38-6aa13483fe24":
-				resultStr = "Product Manager";
-				break;
-			case "dc6966a8-2515-510b-b8b2-271c08795633":
-				resultStr = "QA";
-				break;
-			case "c71bb9ce-a2bb-576d-8f6f-49f6fe38ddd7":
-				resultStr = "Sales";
-				break;
-			case "dcdbd459-8bfb-58b5-bd02-15edd2c2e312":
-				resultStr = "Security";
-				break;
-			case "3378dc82-535d-5ae1-880c-0994f871ab0a":
-				resultStr = "Security Engineer";
-				break;
-			case "a0e803de-0ddb-5df7-a4e4-9a15017b5c1b":
-				resultStr = "Service Operations";
-				break;
-			case "48b43ceb-f343-512f-bda2-4c4b01ba5436":
-				resultStr = "Site Reliability Engineering";
-				break;
-			case "cf10c6ef-ef9c-59e8-a8b1-12d4743bab5c":
-				resultStr = "Software Engineer, Android";
-				break;
-			case "a2c23853-918c-560e-be7a-81ee256965d7":
-				resultStr = "Software Engineer, Backend";
-				break;
-			case "0928eb77-9ffe-5572-93ae-39d685b19ac0":
-				resultStr = "Software Engineer, Frontend";
-				break;
-			case "98c5efc7-4d92-5909-9454-cd428f42723c":
-				resultStr = "Software Engineer, iOS";
-				break;
+	private String normalizeCorporate(String corporate) {
+		if (corporate == null || corporate.isBlank()) return "당근마켓";
+
+		switch (corporate) {
+			// 구 크롤러(page-data)의 corporate 코드도 그대로 받아준다.
+			case "KARROT_MARKET":
+			case "당근":
+				return "당근마켓";
+			case "KARROT_PAY":
+				return "당근페이";
 			default:
-				resultStr = "Software Engineer, Machine Learning";
-				break;
+				return corporate;
 		}
-		return resultStr;
 	}
 
 }

--- a/src/main/java/com/nklcbdty/api/crawler/service/YanoljaCralwerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/YanoljaCralwerService.java
@@ -3,28 +3,40 @@ package com.nklcbdty.api.crawler.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import com.nklcbdty.api.crawler.common.CrawlerCommonService;
 import com.nklcbdty.api.crawler.common.JobEnums;
+import com.nklcbdty.api.crawler.dto.PersonalHistoryDto;
 import com.nklcbdty.common.vo.Job_mst;
 
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 야놀자 채용 크롤러.
+ *
+ * <p>careers.yanolja.co(그리팅) 의 {@code _next/data} 에서 공고를 긁었지만, 채용 시스템이 Workday 로
+ * 이관되면서 그 페이지는 회사 소개/복지 페이지만 남고 공고 목록이 통째로 빠졌다(openings 항상 0건).
+ * 지금은 Workday 채용 사이트가 유일한 공고 출처라 Workday 의 공개 CxS API 를 직접 호출한다.</p>
+ */
 @Slf4j
 @Service
 public class YanoljaCralwerService {
+
+    private static final String WORKDAY_CXS_BASE =
+        "https://yanolja.wd102.myworkdayjobs.com/wday/cxs/yanolja/External_Yanolja";
+    private static final String WORKDAY_SITE_BASE =
+        "https://yanolja.wd102.myworkdayjobs.com/ko-KR/External_Yanolja";
+
+    private static final int PAGE_SIZE = 20;
+    // 무한 루프 방지용 상한. 야놀자 공고 규모(수십 건)에 비해 충분히 크다.
+    private static final int MAX_PAGES = 20;
 
     private final CrawlerCommonService commonService;
 
@@ -38,91 +50,46 @@ public class YanoljaCralwerService {
         List<Job_mst> result = new ArrayList<>();
 
         try {
-            Document doc = commonService.jsoupConnect("https://careers.yanolja.co/home").get();
-            Elements scripts = doc.getElementsByTag("script");
-            String regex = "/_next/static/(.*?)/_ssgManifest.js";
-            Pattern pattern = Pattern.compile(regex);
-            String buildName = "";
-            for (Element script : scripts) {
-                String src = script.attr("src"); // src 속성 값 가져오기
+            log.info(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> {}의 크롤러가 {}로 시작됩니다.",
+                this.getClass(), commonService.formatCurrentTime());
 
-                // 정규식으로 매칭
-                Matcher matcher = pattern.matcher(src);
-                if (matcher.find()) {
-                    buildName = matcher.group(1); // 첫 번째 그룹 추출
+            int offset = 0;
+            for (int page = 0; page < MAX_PAGES; page++) {
+                String body = new JSONObject()
+                    .put("appliedFacets", new JSONObject())
+                    .put("limit", PAGE_SIZE)
+                    .put("offset", offset)
+                    .put("searchText", "")
+                    .toString();
+
+                String jsonResponse = commonService.fetchApiResponsePost(WORKDAY_CXS_BASE + "/jobs", body);
+                JSONObject pageObj = new JSONObject(jsonResponse);
+                JSONArray postings = pageObj.optJSONArray("jobPostings");
+
+                if (postings == null) {
+                    log.error("야놀자 크롤 응답에서 jobPostings 를 찾지 못함. 응답 앞부분: {}",
+                        jsonResponse == null ? "null" : jsonResponse.substring(0, Math.min(300, jsonResponse.length())));
+                    break;
                 }
-            }
-
-            final String apiUrl = "https://careers.yanolja.co/_next/data/"+buildName+"/ko/home.json?occupations=R%26D&employments=FULL_TIME_WORKER&page=home";
-            final String jsonResponse = commonService.fetchApiResponse(apiUrl);
-
-            // JSON 객체로 변환
-            JSONObject jsonResult = new JSONObject(jsonResponse);
-
-            // edges 배열 가져오기
-            JSONArray jsonArray = jsonResult.getJSONObject("pageProps")
-                .getJSONObject("dehydratedState")
-                .getJSONArray("queries");
-            for (int i = 0; i < jsonArray.length(); i++) {
-                JSONObject jsonObject = jsonArray.getJSONObject(i);
-
-                if (jsonObject.getJSONObject("state") == null ||
-                    jsonObject.getJSONObject("state").get("data") instanceof JSONObject) {
-                    continue;
+                if (postings.isEmpty()) {
+                    // 공고가 실제로 0건일 수 있다(Workday 이관 직후 등). 정상 종료로 본다.
+                    break;
                 }
 
-                JSONArray jsonArray1 = jsonObject.getJSONObject("state").getJSONArray("data");
-                for (int j = 0; j < jsonArray1.length(); j++) {
-                  try {
-                    Job_mst item = new Job_mst();
-                    JSONObject data = jsonArray1.getJSONObject(j);
-                    item.setAnnoId(data.opt("openingId") == null ? null : data.get("openingId").toString());
-                    item.setAnnoSubject(data.optString("title", ""));
-                    if (item.getAnnoId() == null || item.getAnnoId().isBlank() || item.getAnnoSubject().isBlank()) {
-                        log.warn("야놀자 공고 필수값 누락으로 건너뜀 (jobIndex={}, openingId={})", j, item.getAnnoId());
-                        continue;
-                    }
-                    if(data.has("job") && !data.isNull("job")) {
-                        item.setClassCdNm(data.getString("job"));
-                    } else {
-                        item.setClassCdNm("기타");
-                    }
-                    String employmentType = data.getJSONObject("openingJobPosition").getJSONArray("openingJobPositions").getJSONObject(0).getJSONObject("jobPositionEmployment").getString("employmentType");
-                    switch (employmentType) {
-                        case "FULL_TIME_WORKER": {
-                            item.setEmpTypeCdNm("정규");
-                            break;
+                for (int i = 0; i < postings.length(); i++) {
+                    try {
+                        Job_mst item = toJobMst(postings.getJSONObject(i));
+                        if (item != null) {
+                            result.add(item);
                         }
-                        case "CONTRACT_WORKER": {
-                            item.setEmpTypeCdNm("비정규");
-                            break;
-                        }
-                        default: {
-                            item.setEmpTypeCdNm(employmentType);
-                        }
+                    } catch (Exception itemEx) {
+                        log.error("야놀자 공고 파싱 실패 (offset={}, index={}): {}", offset, i, itemEx.getMessage(), itemEx);
                     }
-                    item.setJobDetailLink("https://careers.yanolja.co/o/" + item.getAnnoId());
-                    item.setSubJobCdNm(item.getClassCdNm());
-                    if(data.has("subsidiary") && !data.isNull("subsidiary")) {
-                        item.setSysCompanyCdNm(data.getString("subsidiary"));
-                    } else {
-                        item.setSysCompanyCdNm("야놀자");
-                    }
-                    if (commonService.isCloseDate(data.get("dueDate"))) {
-                        item.setEndDate(data.get("dueDate").toString());
-                    }
-                    Object from = data.getJSONObject("careerInfo").get("from");
-                    if (from instanceof Integer) {
-                        item.setPersonalHistory(((Integer) from).longValue());
-                    }
-                    Object to = data.getJSONObject("careerInfo").get("to");
-                    if (to instanceof Integer) {
-                        item.setPersonalHistoryEnd(((Integer) to).longValue());
-                    }
-                    result.add(item);
-                  } catch (Exception itemEx) {
-                    log.error("야놀자 공고 파싱 실패 (jobIndex={}): {}", j, itemEx.getMessage(), itemEx);
-                  }
+                }
+
+                offset += PAGE_SIZE;
+                if (offset >= pageObj.optInt("total", 0)) {
+                    break;
                 }
             }
 
@@ -138,10 +105,78 @@ public class YanoljaCralwerService {
                 }
             }
 
+            log.info("야놀자 크롤 완료 — {}건", result.size());
         } catch (Exception e) {
             log.error("Error occurred while crawling jobs: {}", e.getMessage(), e);
         }
 
         return CompletableFuture.completedFuture(commonService.getNotSaveJobItem("YANOLJA", result));
+    }
+
+    /** Workday 목록 항목 하나를 Job_mst 로 변환한다. 필수값이 없으면 null. */
+    private Job_mst toJobMst(JSONObject posting) {
+        String annoSubject = posting.optString("title", "");
+        String externalPath = posting.optString("externalPath", "");
+        // bulletFields[0] 이 공고번호(jobReqId). 공고가 수정돼도 유지되는 값이라 annoId 로 쓴다.
+        JSONArray bulletFields = posting.optJSONArray("bulletFields");
+        String annoId = (bulletFields == null || bulletFields.isEmpty()) ? "" : bulletFields.optString(0, "");
+
+        if (annoId.isBlank() || annoSubject.isBlank() || externalPath.isBlank()) {
+            log.warn("야놀자 공고 필수값 누락으로 건너뜀 (title='{}', path='{}', reqId='{}')",
+                annoSubject, externalPath, annoId);
+            return null;
+        }
+
+        Job_mst item = new Job_mst();
+        item.setAnnoId(annoId);
+        item.setAnnoSubject(annoSubject);
+        item.setJobDetailLink(WORKDAY_SITE_BASE + externalPath);
+        item.setSysCompanyCdNm("야놀자");
+        // Workday 공고에는 마감일이 없다(내려갈 때까지 모집). endDate 는 비워 두고
+        // 사이트에서 사라지면 reconcileEndedJobs 가 종료 처리한다.
+
+        applyDetail(item, externalPath);
+        return item;
+    }
+
+    /**
+     * 상세 API 로 고용형태/게시일/경력을 채운다.
+     * 상세 조회가 실패해도 목록에서 얻은 정보만으로 공고는 살린다.
+     */
+    private void applyDetail(Job_mst item, String externalPath) {
+        try {
+            String detailJson = commonService.fetchApiResponse(WORKDAY_CXS_BASE + externalPath);
+            JSONObject info = new JSONObject(detailJson).optJSONObject("jobPostingInfo");
+            if (info == null) {
+                log.warn("야놀자 공고 상세에 jobPostingInfo 없음 (path={})", externalPath);
+                return;
+            }
+
+            item.setEmpTypeCdNm(convertTimeTypeToEmpType(info.optString("timeType", "")));
+            item.setStartDate(info.optString("startDate", null));
+
+            String jobDescription = info.optString("jobDescription", "");
+            if (!jobDescription.isBlank()) {
+                PersonalHistoryDto history = commonService.getPersonalHistory(Jsoup.parse(jobDescription).text());
+                item.setPersonalHistory(history.getFrom());
+                item.setPersonalHistoryEnd(history.getTo());
+            }
+        } catch (Exception e) {
+            log.error("야놀자 공고 상세 조회 실패 (path={}): {}", externalPath, e.getMessage());
+        }
+    }
+
+    /** Workday 의 timeType(Full time/Part time)을 기존 고용형태 표기로 바꾼다. */
+    private String convertTimeTypeToEmpType(String timeType) {
+        if (timeType == null || timeType.isBlank()) return "";
+
+        switch (timeType.replace(" ", "").toUpperCase()) {
+            case "FULLTIME":
+                return "정규";
+            case "PARTTIME":
+                return "비정규";
+            default:
+                return timeType;
+        }
     }
 }

--- a/src/test/java/com/nklcbdty/api/crawler/service/DaangnJobCrawlerServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/service/DaangnJobCrawlerServiceTest.java
@@ -1,0 +1,120 @@
+package com.nklcbdty.api.crawler.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.dto.PersonalHistoryDto;
+import com.nklcbdty.common.vo.Job_mst;
+
+/**
+ * 당근 크롤러가 Greenhouse 보드 응답을 제대로 읽는지 확인한다.
+ * (about.daangn.com 의 page-data.json 이 404 가 되면서 보드 API 로 교체됐다)
+ */
+class DaangnJobCrawlerServiceTest {
+
+    @Mock
+    private CrawlerCommonService crawlerCommonService;
+
+    private DaangnJobCrawlerService daangnJobCrawlerService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        daangnJobCrawlerService = new DaangnJobCrawlerService(crawlerCommonService);
+
+        PersonalHistoryDto history = new PersonalHistoryDto();
+        history.setFrom(3);
+        history.setTo(7);
+        when(crawlerCommonService.getPersonalHistory(anyString())).thenReturn(history);
+        // getNotSaveJobItem 은 DB 접근이라 여기서는 파싱 결과를 그대로 돌려주게 둔다.
+        when(crawlerCommonService.getNotSaveJobItem(eq("DAANGN"), anyList()))
+            .thenAnswer(invocation -> invocation.getArgument(1));
+    }
+
+    @Test
+    void 보드_응답을_공고로_변환한다() throws Exception {
+        when(crawlerCommonService.fetchApiResponse(anyString())).thenReturn(boardResponse());
+
+        List<Job_mst> jobs = daangnJobCrawlerService.crawlJobs().get();
+
+        assertEquals(2, jobs.size());
+
+        Job_mst backend = jobs.get(0);
+        assertEquals("4351200003", backend.getAnnoId());
+        assertEquals("Software Engineer, Backend - 광고", backend.getAnnoSubject());
+        assertEquals("https://careers.daangn.com/jobs/role/4351200003/", backend.getJobDetailLink());
+        assertEquals("정규", backend.getEmpTypeCdNm());
+        // Corporate 가 "당근" 으로 와도 화면 표기는 "당근마켓" 으로 통일한다.
+        assertEquals("당근마켓", backend.getSysCompanyCdNm());
+        assertEquals("Software Engineer", backend.getClassCdNm());
+        assertEquals("Backend", backend.getSubJobCdNm());
+        assertEquals(3, backend.getPersonalHistory());
+        assertEquals(7, backend.getPersonalHistoryEnd());
+        // Valid Through 가 비어 있으면 상시채용으로 둔다.
+        assertNull(backend.getEndDate());
+
+        Job_mst designer = jobs.get(1);
+        assertEquals("6589282003", designer.getAnnoId());
+        assertEquals("계약직", designer.getEmpTypeCdNm());
+        assertEquals("Design", designer.getClassCdNm());
+        assertEquals("2026-12-31 23:59:59", designer.getEndDate());
+    }
+
+    @Test
+    void 필수값이_없는_공고는_건너뛴다() throws Exception {
+        when(crawlerCommonService.fetchApiResponse(anyString())).thenReturn(
+            "{\"jobs\":[{\"id\":123,\"title\":\"\"},{\"title\":\"제목만 있는 공고\"}]}");
+
+        List<Job_mst> jobs = daangnJobCrawlerService.crawlJobs().get();
+
+        assertEquals(0, jobs.size());
+    }
+
+    @Test
+    void 응답_형식이_바뀌면_빈_목록을_돌려준다() throws Exception {
+        when(crawlerCommonService.fetchApiResponse(anyString())).thenReturn("{\"message\":\"Not Found\"}");
+
+        List<Job_mst> jobs = daangnJobCrawlerService.crawlJobs().get();
+
+        assertEquals(0, jobs.size());
+    }
+
+    private String boardResponse() {
+        return "{\"jobs\":["
+            + "{"
+            + "  \"id\": 4351200003,"
+            + "  \"title\": \"Software Engineer, Backend - 광고\","
+            + "  \"content\": \"&lt;p&gt;백엔드 개발 경력 3년 이상&lt;/p&gt;\","
+            + "  \"departments\": [{\"id\": 4057801003, \"name\": \"Software Engineer, Backend\"}],"
+            + "  \"metadata\": ["
+            + "    {\"name\": \"Corporate\", \"value\": \"당근\"},"
+            + "    {\"name\": \"Employment Type\", \"value\": \"정규직\"},"
+            + "    {\"name\": \"Valid Through\", \"value\": \"\"}"
+            + "  ]"
+            + "},"
+            + "{"
+            + "  \"id\": 6589282003,"
+            + "  \"title\": \"Brand Designer (계약직) - 브랜딩\","
+            + "  \"content\": \"&lt;p&gt;브랜드 디자인&lt;/p&gt;\","
+            + "  \"departments\": [{\"id\": 4045616003, \"name\": \"Design\"}],"
+            + "  \"metadata\": ["
+            + "    {\"name\": \"Corporate\", \"value\": \"당근마켓\"},"
+            + "    {\"name\": \"Employment Type\", \"value\": \"계약직\"},"
+            + "    {\"name\": \"Valid Through\", \"value\": \"2026-12-31\"}"
+            + "  ]"
+            + "}"
+            + "]}";
+    }
+}

--- a/src/test/java/com/nklcbdty/api/crawler/service/YanoljaCralwerServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/service/YanoljaCralwerServiceTest.java
@@ -1,0 +1,140 @@
+package com.nklcbdty.api.crawler.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.dto.PersonalHistoryDto;
+import com.nklcbdty.common.vo.Job_mst;
+
+/**
+ * 야놀자 크롤러가 Workday CxS 응답을 제대로 읽는지 확인한다.
+ * (careers.yanolja.co 의 _next/data 에서 공고가 빠지면서 Workday 로 교체됐다)
+ */
+class YanoljaCralwerServiceTest {
+
+    private static final String JOBS_URL =
+        "https://yanolja.wd102.myworkdayjobs.com/wday/cxs/yanolja/External_Yanolja/jobs";
+
+    @Mock
+    private CrawlerCommonService commonService;
+
+    private YanoljaCralwerService yanoljaCralwerService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        yanoljaCralwerService = new YanoljaCralwerService(commonService);
+
+        PersonalHistoryDto history = new PersonalHistoryDto();
+        history.setFrom(5);
+        history.setTo(10);
+        when(commonService.getPersonalHistory(anyString())).thenReturn(history);
+        when(commonService.getNotSaveJobItem(eq("YANOLJA"), anyList()))
+            .thenAnswer(invocation -> invocation.getArgument(1));
+    }
+
+    @Test
+    void 목록과_상세를_합쳐_공고로_변환한다() throws Exception {
+        when(commonService.fetchApiResponsePost(eq(JOBS_URL), anyString())).thenReturn(jobsPage());
+        when(commonService.fetchApiResponse(contains("/job/Seoul/Backend-Engineer_JR100"))).thenReturn(detail());
+
+        List<Job_mst> jobs = yanoljaCralwerService.crawlJobs().get();
+
+        assertEquals(1, jobs.size());
+        Job_mst job = jobs.get(0);
+        assertEquals("JR100", job.getAnnoId());
+        assertEquals("Software Engineer, Backend", job.getAnnoSubject());
+        assertEquals(
+            "https://yanolja.wd102.myworkdayjobs.com/ko-KR/External_Yanolja/job/Seoul/Backend-Engineer_JR100",
+            job.getJobDetailLink());
+        assertEquals("야놀자", job.getSysCompanyCdNm());
+        assertEquals("정규", job.getEmpTypeCdNm());
+        assertEquals("2026-07-31", job.getStartDate());
+        assertEquals(5, job.getPersonalHistory());
+        assertEquals(10, job.getPersonalHistoryEnd());
+        // Workday 공고에는 마감일이 없다. 상시채용으로 두고 사라지면 종료 처리된다.
+        assertNull(job.getEndDate());
+        // 제목 키워드 보정
+        assertEquals("Backend", job.getSubJobCdNm());
+    }
+
+    @Test
+    void 상세_조회가_실패해도_공고는_살린다() throws Exception {
+        when(commonService.fetchApiResponsePost(eq(JOBS_URL), anyString())).thenReturn(jobsPage());
+        when(commonService.fetchApiResponse(anyString())).thenThrow(new RuntimeException("boom"));
+
+        List<Job_mst> jobs = yanoljaCralwerService.crawlJobs().get();
+
+        assertEquals(1, jobs.size());
+        assertEquals("JR100", jobs.get(0).getAnnoId());
+        assertNull(jobs.get(0).getEmpTypeCdNm());
+    }
+
+    @Test
+    void 공고가_0건이면_상세를_조회하지_않는다() throws Exception {
+        when(commonService.fetchApiResponsePost(eq(JOBS_URL), anyString()))
+            .thenReturn("{\"total\":0,\"jobPostings\":[]}");
+
+        List<Job_mst> jobs = yanoljaCralwerService.crawlJobs().get();
+
+        assertEquals(0, jobs.size());
+        verify(commonService, never()).fetchApiResponse(anyString());
+        // 빈 페이지에서 바로 멈춰야 한다(페이지 상한까지 계속 때리지 않도록).
+        verify(commonService, times(1)).fetchApiResponsePost(eq(JOBS_URL), anyString());
+    }
+
+    @Test
+    void 응답_형식이_바뀌면_빈_목록을_돌려준다() throws Exception {
+        when(commonService.fetchApiResponsePost(eq(JOBS_URL), anyString()))
+            .thenReturn("{\"errorCode\":\"S21\",\"httpStatus\":404}");
+
+        List<Job_mst> jobs = yanoljaCralwerService.crawlJobs().get();
+
+        assertEquals(0, jobs.size());
+        verify(commonService, times(1)).fetchApiResponsePost(eq(JOBS_URL), anyString());
+    }
+
+    private String jobsPage() {
+        return "{\"total\":1,\"jobPostings\":["
+            + "{"
+            + "  \"title\": \"Software Engineer, Backend\","
+            + "  \"externalPath\": \"/job/Seoul/Backend-Engineer_JR100\","
+            + "  \"locationsText\": \"Seoul\","
+            + "  \"postedOn\": \"Posted Yesterday\","
+            + "  \"bulletFields\": [\"JR100\"]"
+            + "},"
+            // 공고번호가 없는 항목은 건너뛴다.
+            + "{"
+            + "  \"title\": \"공고번호 없는 공고\","
+            + "  \"externalPath\": \"/job/Seoul/No-Id\","
+            + "  \"bulletFields\": []"
+            + "}"
+            + "]}";
+    }
+
+    private String detail() {
+        return "{\"jobPostingInfo\":{"
+            + "  \"jobReqId\": \"JR100\","
+            + "  \"title\": \"Software Engineer, Backend\","
+            + "  \"timeType\": \"Full time\","
+            + "  \"startDate\": \"2026-07-31\","
+            + "  \"jobDescription\": \"&lt;p&gt;백엔드 개발 경력 5년 이상 10년 이하&lt;/p&gt;\""
+            + "}}";
+    }
+}


### PR DESCRIPTION
## 배경

`/api/list` 에서 당근마켓·배달의민족·야놀자가 0건이었다. 원인은 셋이 서로 달랐다.

| 회사 | 원인 | 이 PR |
|---|---|---|
| 당근마켓 | 채용 사이트 이관으로 크롤러 엔드포인트가 404 | 고침 |
| 야놀자 | 채용 시스템이 Workday 로 이관, 기존 소스에 공고가 안 내려옴 | 고침 |
| 배달의민족 | API 는 정상(현재 11건). **운영에 배포된 빌드가 오래됨** | 이 PR 머지 = 재배포로 해결 예상 |

배민이 운영 미배포 상태라는 근거: main 의 `AllowedPaths` 에 있는 `/api/auth/email-exists` 와 `/api/jobs/**` 가 운영에서 401. 즉 배포된 jar 이 #194 이전이라 그 뒤 크롤러 수정들(#197 #198 #199)이 전부 미반영이다.

## 1. 당근마켓 크롤러

`about.daangn.com`(Gatsby) → `careers.daangn.com`(Astro) 이전으로 `/page-data/jobs/page-data.json` 이 **404**. 새 사이트가 그대로 렌더링하는 Greenhouse 공개 보드 API 로 교체했다.

- `boards-api.greenhouse.io/v1/boards/daangn/jobs?content=true` → 실제 응답으로 **38건** 파싱 확인
- `content=true` 로 부서·공고 본문까지 함께 받아, 공고마다 상세 페이지를 다시 긁던 **38회 요청 → 1회**
- `annoId` 는 구 크롤러의 `ghId` 와 같은 Greenhouse job id → 기존 DB row 그대로 매칭
- Corporate 가 "당근"/"당근마켓" 섞여 내려와 표기를 "당근마켓"으로 통일
- `Valid Through` 는 `yyyy-MM-dd` 로 확인된 값만 마감일로 반영 (조회 단계가 파싱 못 하는 형식이 들어오면 살아있는 공고가 목록에서 빠지므로)

## 2. 야놀자 크롤러

채용 시스템이 **Workday 로 이관**됐다. `careers.yanolja.co` 는 회사 소개/복지 페이지만 남고 `_next/data` 의 `openings` 가 항상 0건이다(그리팅 필터 응답도 `occupations`/`jobs` 전부 빈 배열). 지원 버튼은 Workday 로 나간다.

- Workday 공개 CxS API(`/wday/cxs/yanolja/External_Yanolja`)로 교체
- 목록 → 상세 순으로 조회해 고용형태(`timeType`)·게시일·경력을 채운다. 상세 조회가 실패해도 목록 정보만으로 공고는 살린다
- `annoId` 는 공고번호(`bulletFields[0]` = `jobReqId`)
- **현재 야놀자 공개 공고는 실제로 0건**("현재 채용공고가 없습니다"). 공고가 올라오면 바로 수집된다

## 3. 회사별 채용 페이지 바로가기 API

`GET /api/company/list` → `[{companyCd, companyNm, careerPageUrl}]` (인증 불필요)

회사 채용 사이트 이관이 반복되므로 주소를 `CompanyEnums` 한 곳에 모았다. 크롤러 URL 을 고칠 때 같은 자리에서 함께 갱신한다. 8개 회사 주소 전부 접속 확인했고, 야놀자는 공고가 실제로 있는 Workday 쪽을 가리킨다.

프론트(`nklcbdty-ui`) 버튼은 별도로 올린다.

## 기타

`fetchApiResponsePost` 에도 GET 경로와 동일하게 브라우저 User-Agent + 타임아웃 적용.

## 테스트

`DaangnJobCrawlerServiceTest` 3건, `YanoljaCralwerServiceTest` 4건 추가 — 정상 파싱 / 필수값 누락 스킵 / 상세 조회 실패 / 응답 형식 변경을 덮는다.

전체 85개 중 2개 실패인데 `NklcbdtyApplicationTests.contextLoads`(DB 필요), `AdminSubscriptionServiceTest.sendJobEmail` 로 main 에서도 동일하게 실패하는 기존 건이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)