### PR TITLE
🚨 Fix: 종료 처리된 공고가 크롤에 다시 잡혀도 안 살아나던 문제

### DIFF
--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -172,6 +172,8 @@ public class CrawlerCommonService {
             }
         }
 
+        classifyUnclassifiedExistingJobs(result, existingJobs);
+
         // 기존 row 갱신. 신규(jobsToSave) 는 호출자가 어차피 저장하므로 여기서 다시 다루지 않음.
         // 크롤 결과에 여전히 존재하는(=살아있는) 공고는 최신 값으로 되살린다:
         //  1) personalHistory : LLM 경력 보정 결과 반영
@@ -180,6 +182,8 @@ public class CrawlerCommonService {
         //                       목록(endDate>now 필터)에서 사라지던 문제를 해결한다.
         //  3) subJobCdNm     : 비어있을 때만 크롤 값으로 채운다. Gemini 등으로 이미 분류된
         //                       기존 값은 덮어쓰지 않는다(크롤러 키워드 분류가 null 일 수 있으므로).
+        //  4) jobDetailLink  : 회사가 채용 사이트를 옮기면 기존 row 는 죽은 링크를 계속 들고 있고,
+        //                       링크 점검 배치가 매일 그 row 를 종료 처리한다(당근 이관 때 실제로 발생).
         List<Job_mst> existingToUpdate = new ArrayList<>();
         for (Job_mst jobItem : result) {
             Job_mst existing = existingJobs.stream()
@@ -195,9 +199,18 @@ public class CrawlerCommonService {
             }
 
             final String freshEndDate = jobItem.getEndDate();
-            if (freshEndDate != null && !freshEndDate.isBlank()
-                && !freshEndDate.equals(existing.getEndDate())) {
-                existing.setEndDate(freshEndDate);
+            if (freshEndDate != null && !freshEndDate.isBlank()) {
+                if (!freshEndDate.equals(existing.getEndDate())) {
+                    existing.setEndDate(freshEndDate);
+                    changed = true;
+                }
+            } else if (isEndedOrBroken(existing.getEndDate())) {
+                // 크롤에 잡혔다 = 회사 사이트에 아직 걸려 있다. 그런데 마감일이 없는 상시채용 공고라
+                // 위 분기로는 되살릴 방법이 없어, 한 번 종료로 찍히면 영영 목록에서 빠졌다.
+                // (링크 점검 배치가 이관된 옛 링크를 종료/error 로 찍어둔 당근 공고들이 이 경우)
+                log.info("종료 처리됐지만 크롤에 다시 잡힌 공고 복구 — annoId={} endDate={} → 상시채용",
+                    existing.getAnnoId(), existing.getEndDate());
+                existing.setEndDate(null);
                 changed = true;
             }
 
@@ -205,6 +218,13 @@ public class CrawlerCommonService {
             if (freshSubJob != null && !freshSubJob.isBlank()
                 && (existing.getSubJobCdNm() == null || existing.getSubJobCdNm().isBlank())) {
                 existing.setSubJobCdNm(freshSubJob);
+                changed = true;
+            }
+
+            final String freshLink = jobItem.getJobDetailLink();
+            if (freshLink != null && !freshLink.isBlank()
+                && !freshLink.equals(existing.getJobDetailLink())) {
+                existing.setJobDetailLink(freshLink);
                 changed = true;
             }
 
@@ -218,6 +238,49 @@ public class CrawlerCommonService {
         }
 
         return jobsToSave;
+    }
+
+    /**
+     * 기존 row 중 subJobCdNm 이 비어 있는 건을 LLM 으로 분류한다.
+     *
+     * <p>지금까지 Gemini 분류는 신규 저장분에만 돌았다. 그래서 크롤러 키워드 규칙이 못 맞춘 공고가
+     * subJobCdNm=null 로 한 번 들어가면, 이후 크롤에서는 "이미 있는 공고"로 걸러져 영영 분류되지 않고
+     * 목록(subJobCdNm IS NOT NULL 필터)에서 빠져 있었다. 분류가 필요한 건만 모아 다시 돌린다.</p>
+     */
+    private void classifyUnclassifiedExistingJobs(List<Job_mst> result, List<Job_mst> existingJobs) {
+        List<Job_mst> needClassify = result.stream()
+            .filter(jobItem -> jobItem.getSubJobCdNm() == null || jobItem.getSubJobCdNm().isBlank())
+            .filter(jobItem -> existingJobs.stream().anyMatch(e -> {
+                if (!e.getAnnoId().equals(jobItem.getAnnoId())) return false;
+                return e.getSubJobCdNm() == null || e.getSubJobCdNm().isBlank();
+            }))
+            .collect(Collectors.toList());
+
+        if (needClassify.isEmpty()) return;
+
+        log.info("기존 row 직무 분류 대상 {}건", needClassify.size());
+        refineJobItemBygemini(needClassify);
+    }
+
+    /**
+     * 종료로 찍혀 있거나 손상된 endDate 인지 판단한다.
+     * 링크 점검 배치의 "error"(2000-01-01) 마킹과 과거 날짜를 모두 종료로 본다.
+     */
+    private boolean isEndedOrBroken(String endDateStr) {
+        if (endDateStr == null || "영입종료시".equals(endDateStr)) {
+            return false; // 이미 상시채용
+        }
+        if ("error".equals(endDateStr)) {
+            return true;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        for (DateTimeFormatter formatter : END_DATE_FORMATTERS) {
+            try {
+                return !LocalDateTime.parse(endDateStr, formatter).isAfter(now);
+            } catch (DateTimeParseException ignored) { }
+        }
+        // 파싱 불가는 건드리지 않는다.
+        return false;
     }
 
     public void refineJobData(List<Job_mst> result) {

--- a/src/test/java/com/nklcbdty/api/crawler/common/CrawlerCommonServiceExistingRowTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/common/CrawlerCommonServiceExistingRowTest.java
@@ -1,0 +1,185 @@
+package com.nklcbdty.api.crawler.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.nklcbdty.api.ai.nlp.PersonalHistoryEnsemble;
+import com.nklcbdty.api.ai.service.GeminiService;
+import com.nklcbdty.common.crawler.repository.CrawlerRepository;
+import com.nklcbdty.common.vo.Job_mst;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * 크롤에 다시 잡힌 "기존 row" 를 되살리는 경로 검증.
+ *
+ * <p>회사가 채용 사이트를 옮기면 기존 row 는 죽은 링크를 들고 있다가 링크 점검 배치에 종료 처리되고,
+ * 새 크롤러가 같은 공고를 다시 긁어와도 신규가 아니라는 이유로 아무것도 갱신되지 않아
+ * 목록에서 사라진 채로 남았다(당근 이관 때 38건 중 37건이 이 상태였다).</p>
+ */
+class CrawlerCommonServiceExistingRowTest {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @Mock
+    private CrawlerRepository crawlerRepository;
+    @Mock
+    private GeminiService geminiService;
+    @Mock
+    private PersonalHistoryEnsemble personalHistoryEnsemble;
+
+    @Captor
+    private ArgumentCaptor<List<Job_mst>> savedCaptor;
+
+    private CrawlerCommonService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new CrawlerCommonService(crawlerRepository, geminiService, personalHistoryEnsemble);
+        when(geminiService.classifyExperienceLevels(anyList())).thenReturn(Mono.just(Collections.emptyMap()));
+        when(geminiService.classifyJobTitles(anyList())).thenReturn(Mono.just(Collections.emptyMap()));
+    }
+
+    private Job_mst job(String annoId, String subject) {
+        Job_mst job = new Job_mst();
+        job.setAnnoId(annoId);
+        job.setAnnoSubject(subject);
+        return job;
+    }
+
+    @Test
+    void 종료로_찍힌_상시채용_공고가_크롤에_다시_잡히면_되살린다() {
+        Job_mst existing = job("6498758003", "Software Engineer, Backend - 숏폼");
+        existing.setEndDate(LocalDateTime.now().minusDays(1).format(FORMATTER)); // 링크 점검 배치가 종료 처리
+        existing.setSubJobCdNm("Backend");
+        existing.setJobDetailLink("https://about.daangn.com?gh_jid=6498758003");
+
+        Job_mst crawled = job("6498758003", "Software Engineer, Backend - 숏폼");
+        crawled.setSubJobCdNm("Backend");
+        crawled.setJobDetailLink("https://careers.daangn.com/jobs/role/6498758003/");
+        // 상시채용이라 크롤러가 마감일을 주지 않는다.
+
+        when(crawlerRepository.findAllByAnnoIdIn(anyList())).thenReturn(List.of(existing));
+        when(crawlerRepository.findAllByCompanyCd("DAANGN")).thenReturn(List.of(existing));
+
+        List<Job_mst> toSave = service.getNotSaveJobItem("DAANGN", List.of(crawled));
+
+        assertTrue(toSave.isEmpty(), "이미 있는 공고는 신규 저장 대상이 아니다");
+        verify(crawlerRepository).saveAll(savedCaptor.capture());
+        Job_mst updated = savedCaptor.getValue().get(0);
+        assertNull(updated.getEndDate(), "크롤에 잡혔으면 상시채용으로 되살아나야 한다");
+        // 죽은 링크를 계속 들고 있으면 다음 링크 점검에서 또 종료 처리된다.
+        assertEquals("https://careers.daangn.com/jobs/role/6498758003/", updated.getJobDetailLink());
+    }
+
+    @Test
+    void 크롤러가_준_마감일이_있으면_그_값을_쓴다() {
+        Job_mst existing = job("25497", "Server(배차시스템)");
+        existing.setEndDate(LocalDateTime.now().minusDays(1).format(FORMATTER));
+        existing.setSubJobCdNm("Backend");
+
+        Job_mst crawled = job("25497", "Server(배차시스템)");
+        crawled.setEndDate("2999-12-31 00:00:00");
+        crawled.setSubJobCdNm("Backend");
+
+        when(crawlerRepository.findAllByAnnoIdIn(anyList())).thenReturn(List.of(existing));
+        when(crawlerRepository.findAllByCompanyCd("BAEMIN")).thenReturn(List.of(existing));
+
+        service.getNotSaveJobItem("BAEMIN", List.of(crawled));
+
+        verify(crawlerRepository).saveAll(savedCaptor.capture());
+        assertEquals("2999-12-31 00:00:00", savedCaptor.getValue().get(0).getEndDate());
+    }
+
+    @Test
+    void 아직_안_끝난_마감일은_건드리지_않는다() {
+        Job_mst existing = job("111", "살아있는 공고");
+        String future = LocalDateTime.now().plusDays(10).format(FORMATTER);
+        existing.setEndDate(future);
+        existing.setSubJobCdNm("Backend");
+        existing.setJobDetailLink("https://example.com/111");
+
+        Job_mst crawled = job("111", "살아있는 공고");
+        crawled.setSubJobCdNm("Backend");
+        crawled.setJobDetailLink("https://example.com/111");
+
+        when(crawlerRepository.findAllByAnnoIdIn(anyList())).thenReturn(List.of(existing));
+        when(crawlerRepository.findAllByCompanyCd("TOSS")).thenReturn(List.of(existing));
+
+        service.getNotSaveJobItem("TOSS", List.of(crawled));
+
+        verify(crawlerRepository, never()).saveAll(anyList());
+        assertEquals(future, existing.getEndDate());
+    }
+
+    @Test
+    void 분류가_비어있는_기존_row_는_LLM_분류를_다시_돌린다() {
+        Job_mst existing = job("25548", "로보틱스 S/W 엔지니어링(자율주행 ML/팀장급)");
+        existing.setSubJobCdNm(null); // 크롤러 키워드 규칙이 못 맞춰 null 로 저장돼 있던 row
+        existing.setEndDate("2999-12-31 00:00:00");
+
+        Job_mst crawled = job("25548", "로보틱스 S/W 엔지니어링(자율주행 ML/팀장급)");
+        crawled.setEndDate("2999-12-31 00:00:00");
+
+        when(crawlerRepository.findAllByAnnoIdIn(anyList())).thenReturn(List.of(existing));
+        when(crawlerRepository.findAllByCompanyCd("BAEMIN")).thenReturn(List.of(existing));
+        when(geminiService.classifyJobTitles(anyList()))
+            .thenReturn(Mono.just(Map.of("로보틱스 S/W 엔지니어링(자율주행 ML/팀장급)", "ML")));
+
+        service.getNotSaveJobItem("BAEMIN", List.of(crawled));
+
+        verify(crawlerRepository).saveAll(savedCaptor.capture());
+        assertEquals("ML", savedCaptor.getValue().get(0).getSubJobCdNm());
+    }
+
+    @Test
+    void 이미_분류된_기존_row_는_LLM_을_다시_부르지_않는다() {
+        Job_mst existing = job("222", "이미 분류된 공고");
+        existing.setSubJobCdNm("Backend");
+        existing.setEndDate("2999-12-31 00:00:00");
+
+        Job_mst crawled = job("222", "이미 분류된 공고");
+        crawled.setEndDate("2999-12-31 00:00:00");
+
+        when(crawlerRepository.findAllByAnnoIdIn(anyList())).thenReturn(List.of(existing));
+        when(crawlerRepository.findAllByCompanyCd("KAKAO")).thenReturn(List.of(existing));
+
+        service.getNotSaveJobItem("KAKAO", List.of(crawled));
+
+        verify(geminiService, never()).classifyJobTitles(anyList());
+    }
+
+    @Test
+    void 신규_공고는_기존_row_갱신_대상이_아니다() {
+        Job_mst crawled = job("999", "새로 올라온 공고");
+
+        when(crawlerRepository.findAllByAnnoIdIn(anyList())).thenReturn(Collections.emptyList());
+        when(crawlerRepository.findAllByCompanyCd(anyString())).thenReturn(Collections.emptyList());
+
+        List<Job_mst> toSave = service.getNotSaveJobItem("DAANGN", List.of(crawled));
+
+        assertEquals(1, toSave.size());
+        assertEquals("DAANGN", toSave.get(0).getCompanyCd());
+        verify(crawlerRepository, never()).saveAll(anyList());
+    }
+}


### PR DESCRIPTION
#203 배포 후 크롤러를 돌려 확인하다 발견한 후속 건.

당근 크롤러는 정상 동작해서 **38건을 전부 수집**하는데 `/api/list?company=DAANGN` 에는 **1건만** 나왔다. 나머지 37건은 이미 DB 에 있어 "신규 아님"으로 걸러지고, 기존 row 갱신 로직이 그 상태를 되살리지 못해 숨어 있었다.

## 1. 상시채용 공고를 되살릴 방법이 없었다

링크 점검 배치(`LinkValidatorProcessor`)가 이관 전 옛 링크(`about.daangn.com?gh_jid=...`)를 훑고 종료(어제) 또는 `error`(2000-01-01)로 찍어뒀다.

그런데 갱신 로직은 크롤러가 준 `endDate` 가 있을 때만 덮어쓴다:

```java
if (freshEndDate != null && !freshEndDate.isBlank() && !freshEndDate.equals(existing.getEndDate()))
```

당근·야놀자처럼 마감일이 없는 상시채용 공고는 크롤러가 `endDate=null` 을 주므로 이 분기에 절대 안 들어간다. 즉 **한 번 종료로 찍히면 영영 못 되살아난다.**

크롤에 잡혔다 = 회사 사이트에 아직 걸려 있다는 뜻이고, 이건 `reconcileEndedJobs`(크롤에 없으면 종료 처리)와 같은 판단 기준이다. 그래서 크롤러가 마감일을 안 주고 기존 값이 과거/`error` 면 상시채용(null)으로 되돌린다.

## 2. 죽은 링크가 그대로 남았다

갱신 대상에 `jobDetailLink` 가 없었다. 되살려도 옛 링크를 들고 있으니 다음 링크 점검에서 또 종료 처리될 상태였다. 링크도 최신 값으로 갱신한다.

## 3. 기존 row 는 영영 미분류로 남았다

Gemini 분류가 신규 저장분에만 돌았다. 크롤러 키워드 규칙이 못 맞춘 공고가 `subJobCdNm=null` 로 한 번 들어가면, 이후 크롤에서는 "이미 있는 공고"로 걸러져 다시 분류될 기회가 없고 목록(`subJobCdNm IS NOT NULL` 필터)에서 계속 빠진다.

배민 11건 중 `로보틱스 S/W 엔지니어링(자율주행 ML/팀장급)` 이 정확히 이 경우다(키워드가 `ML엔지니어` 를 찾는데 제목은 `ML/팀장급`). 분류가 필요한 건만 모아 다시 돌린다.

## 테스트

`CrawlerCommonServiceExistingRowTest` 6건 — 부활 / 크롤러 마감일 우선 / 미래 마감일 미변경 / 미분류 재분류 / 분류된 건 LLM 재호출 안 함 / 신규는 갱신 대상 아님.

전체 91개 중 2개 실패는 main 에서도 동일하게 실패하는 기존 건(`contextLoads`, `AdminSubscriptionServiceTest.sendJobEmail`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)