### PR TITLE
⚡ Perf: 목록 API 응답 캐시 + 아침 예열 — 오전 첫 요청이 느리던 문제

### DIFF
--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -1,0 +1,87 @@
+name: Cache Warmup
+
+# 아침 예열.
+#
+# 클라우드타입 무료 플랜은 새벽 3시쯤 서비스를 내렸다가 다시 올린다. 그래서 오전 첫 사용자가
+#   (a) 앱 기동/예열 비용 (JIT·커넥션풀·Hibernate 첫 쿼리, /api/category/list 측정 시 1.16s → 0.3s)
+#   (b) /api/list 자체 비용 (예열 후에도 1.5~3초)
+# 을 한꺼번에 물었다. 여기서 미리 한 번 호출해 두면 (a)(b) 둘 다 첫 사용자에게서 사라진다.
+#
+# 앱 안의 @Scheduled 로 하지 않는 이유: 앱이 잠들어 있으면 스케줄러도 같이 잠들어 있어서
+# (a)를 못 고친다. 외부에서 HTTP 로 때려야 앱을 깨우는 것까지 같이 된다.
+
+on:
+  schedule:
+    # UTC 22:50 = KST 07:50. 사람들이 쓰기 시작하는 8시 전에 끝나 있어야 한다.
+    # GitHub Actions 의 cron 은 러너 혼잡도에 따라 몇 분에서 십여 분 늦게 뜨므로 8시가 아니라 7:50 에 잡는다.
+    - cron: '50 22 * * *'
+  workflow_dispatch:  # 수동 실행 가능
+
+jobs:
+  warmup:
+    name: 앱 깨우기 + 목록 캐시 채우기
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 앱 깨우기
+        env:
+          API_BASE: ${{ vars.API_BASE_URL || 'https://port-0-nklcbdty-service-m6qh1fte0c037b76.sel4.cloudtype.app' }}
+        run: |
+          # DB 를 타지 않는 가장 싼 엔드포인트로 기동만 확인한다(정상 시 0.1초).
+          # 잠들어 있었다면 첫 요청이 기동을 기다리므로 넉넉한 타임아웃 + 재시도를 준다.
+          for i in $(seq 1 20); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 60 \
+              "$API_BASE/api/company/list" || echo 000)
+            echo "기동 확인 $i/20 → HTTP $code"
+            if [ "$code" = "200" ]; then
+              echo "앱 응답 확인"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::5분 동안 앱이 응답하지 않았습니다(마지막 HTTP $code). 클라우드타입 콘솔을 확인하세요."
+          exit 1
+
+      - name: 목록 캐시 채우기
+        env:
+          API_BASE: ${{ vars.API_BASE_URL || 'https://port-0-nklcbdty-service-m6qh1fte0c037b76.sel4.cloudtype.app' }}
+        run: |
+          # jobList 캐시 키는 ALL + CompanyEnums 전체로 유한하다. 새 회사를 CompanyEnums 에 추가하면
+          # 여기에도 추가해야 그 회사 목록이 예열된다. (빠뜨려도 첫 요청이 느릴 뿐 오동작은 아니다)
+          COMPANIES="ALL NAVER KAKAO LINE COUPANG BAEMIN DAANGN TOSS YANOLJA"
+
+          fail=0
+
+          warm() {
+            path="$1"
+            # 캐시 미스 상태의 첫 호출은 느리므로 넉넉히 준다.
+            # curl -w 출력에는 개행이 없어 read 로 받으면 EOF 로 종료코드 1 이 되고,
+            # 러너의 bash -e 에 걸려 스텝이 통째로 죽는다. 변수로 받아서 잘라 쓴다.
+            out=$(curl -s -o /dev/null --max-time 120 \
+              -w '%{http_code} %{time_total}' "$API_BASE$path" || echo "000 0")
+            code=${out%% *}
+            total=${out##* }
+            if [ "$code" = "200" ]; then
+              echo "  OK   $path (${total}s)"
+            else
+              echo "  FAIL $path → HTTP $code"
+              fail=1
+            fi
+          }
+
+          echo "== 캐시 채우기 =="
+          for c in $COMPANIES; do
+            warm "/api/list?company=$c"
+          done
+          warm "/api/category/list"
+
+          # 두 번째 호출은 캐시 히트여야 한다. 눈에 띄게 빨라지지 않으면 캐시가 안 먹은 것이니
+          # 로그로 확인할 수 있게 같이 남긴다.
+          echo "== 캐시 히트 확인(2회차) =="
+          warm "/api/list?company=ALL"
+          warm "/api/category/list"
+
+          if [ "$fail" != "0" ]; then
+            echo "::error::일부 엔드포인트 예열에 실패했습니다. 위 FAIL 항목을 확인하세요."
+            exit 1
+          fi

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,8 @@ dependencies {
 
 	implementation 'org.json:json:20240303'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// 목록 API 응답 캐시(@Cacheable/@CacheEvict). 저장소는 위 data-redis 를 그대로 쓴다.
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.kafka:spring-kafka'

--- a/src/main/java/com/nklcbdty/api/NklcbdtyApplication.java
+++ b/src/main/java/com/nklcbdty/api/NklcbdtyApplication.java
@@ -5,11 +5,13 @@ import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableCaching
 @EntityScan(basePackages = {"com.nklcbdty.api", "com.nklcbdty.common"})
 @EnableJpaRepositories(basePackages = {"com.nklcbdty.api", "com.nklcbdty.common"})
 public class NklcbdtyApplication {

--- a/src/main/java/com/nklcbdty/api/common/CacheConfig.java
+++ b/src/main/java/com/nklcbdty/api/common/CacheConfig.java
@@ -1,0 +1,104 @@
+package com.nklcbdty.api.common;
+
+import java.time.Duration;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 목록 API 응답 캐시 설정.
+ *
+ * <p>{@code /api/list?company=ALL} 은 예열이 끝난 상태에서도 매 요청 1.5~3초가 걸린다.
+ * 전건 조회 + annoId 중복제거 + 문자열 날짜 파싱 + 마감임박순 정렬 + 128KB 직렬화를
+ * 요청마다 다시 하기 때문이다. 결과가 회사별로 하루 몇 번(크롤 시점)만 바뀌므로 캐싱한다.</p>
+ *
+ * <p>캐시에 넣는 값은 <b>완성된 응답 JSON 문자열</b>이다. 객체(List&lt;Job_mst&gt;)로 캐싱하면
+ * Redis 에서 128KB 를 읽어 객체로 역직렬화한 뒤 응답으로 다시 직렬화하게 되어 이득이 크게 깎인다.
+ * 직렬화가 끝난 문자열을 그대로 담아 조회를 Redis GET 한 번으로 끝낸다.</p>
+ *
+ * <p>Redis 영속성이 꺼져 있어(save 미설정 + appendonly=no) 새벽 재기동마다 캐시가 비지만,
+ * 캐시는 날아가도 되는 데이터라 문제가 아니다. 아침 워밍업이 다시 채운다.
+ * ({@code .github/workflows/cache-warmup.yml})</p>
+ */
+@Configuration
+@Slf4j
+public class CacheConfig implements CachingConfigurer {
+
+    /** {@code /api/list} 응답. 키는 company 파라미터(ALL + CompanyEnums 8개 = 9개). */
+    public static final String JOB_LIST = "jobList";
+
+    /** {@code /api/category/list} 응답. 파라미터가 없어 키가 하나뿐이다. */
+    public static final String CATEGORY_LIST = "categoryList";
+
+    /**
+     * 무효화를 놓친 경우의 안전망. 크롤 후 @CacheEvict 가 정상 동작하면 여기까지 오지 않는다.
+     * 아침에 한 번 채우고 하루 방치하면 그날 올라온 공고가 안 보이므로 짧게 잡는다.
+     */
+    private static final Duration TTL = Duration.ofHours(1);
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // 값이 전부 JSON 문자열이므로 키/값 모두 String 직렬화를 쓴다.
+        // redis-cli 에서 "jobList::ALL" 처럼 그대로 읽을 수 있다.
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(TTL)
+            .disableCachingNullValues()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()));
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(config)
+            .build();
+    }
+
+    /**
+     * Redis 가 죽어 있어도 목록 API 는 살아 있어야 한다.
+     *
+     * <p>스프링의 기본 동작은 캐시 조회 실패 시 예외를 그대로 올려보내는 것이다. 그러면
+     * commandTimeout(2초)에 걸리는 새벽 재기동 구간에 목록 API 가 통째로 500 이 된다.
+     * 캐시를 붙이기 전에는 Redis 상태와 무관하게 잘 동작했던 엔드포인트이므로 그건 순전히 퇴행이다.
+     * 여기서 예외를 삼키면 스프링이 원래 메서드를 그대로 실행해 DB 조회로 폴백한다.</p>
+     */
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new CacheErrorHandler() {
+
+            @Override
+            public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+                log.warn("캐시 조회 실패 — DB 조회로 폴백한다. cache={}, key={}, error={}",
+                    cache.getName(), key, exception.getMessage());
+            }
+
+            @Override
+            public void handleCachePutError(RuntimeException exception, Cache cache, Object key, Object value) {
+                log.warn("캐시 저장 실패 — 응답은 정상 반환한다. cache={}, key={}, error={}",
+                    cache.getName(), key, exception.getMessage());
+            }
+
+            @Override
+            public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+                // 무효화 실패는 stale 을 남기지만 TTL 이 걷어간다.
+                log.warn("캐시 무효화 실패 — TTL({}분) 만료까지 stale 이 남는다. cache={}, key={}, error={}",
+                    TTL.toMinutes(), cache.getName(), key, exception.getMessage());
+            }
+
+            @Override
+            public void handleCacheClearError(RuntimeException exception, Cache cache) {
+                log.warn("캐시 전체 삭제 실패 — TTL({}분) 만료까지 stale 이 남는다. cache={}, error={}",
+                    TTL.toMinutes(), cache.getName(), exception.getMessage());
+            }
+        };
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -4,9 +4,11 @@ import org.json.JSONObject;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 import com.nklcbdty.api.ai.nlp.PersonalHistoryEnsemble;
+import com.nklcbdty.api.common.CacheConfig;
 import com.nklcbdty.api.ai.service.GeminiService;
 import com.nklcbdty.api.crawler.dto.PersonalHistoryDto;
 import com.nklcbdty.common.crawler.repository.CrawlerRepository;
@@ -495,6 +497,13 @@ public class CrawlerCommonService {
         return now.isAfter(endDateTime);
     }
 
+    /**
+     * 크롤 결과 저장. 모든 크롤 경로({@code /api/crawler} 의 각 case)가 마지막에 여기를 거친다.
+     *
+     * <p>크롤 중간에 일어나는 다른 쓰기(getNotSaveJobItem 의 기존 row 갱신, reconcileEndedJobs 의
+     * 종료 마킹)는 전부 이 호출보다 앞이라, 여기서 한 번 비우면 그 변경분까지 같이 반영된다.</p>
+     */
+    @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
     public List<Job_mst> saveAll(List<Job_mst> result) {
         return crawlerRepository.saveAll(result);
     }

--- a/src/main/java/com/nklcbdty/api/crawler/controller/CategoryController.java
+++ b/src/main/java/com/nklcbdty/api/crawler/controller/CategoryController.java
@@ -1,14 +1,11 @@
 package com.nklcbdty.api.crawler.controller;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nklcbdty.api.crawler.service.CategoryService;
-import com.nklcbdty.api.crawler.vo.CategoryMst;
 
 @RestController
 @RequestMapping("/api/category")
@@ -20,8 +17,9 @@ public class CategoryController {
         this.categoryService = categoryService;
     }
 
-    @GetMapping("/list")
-    public List<CategoryMst> list() {
-        return categoryService.getAllCategoriesOrderedByRank();
+    // 캐시된 응답 JSON 을 그대로 흘려보낸다. charset 명시 이유는 JobController#list 주석 참고.
+    @GetMapping(value = "/list", produces = "application/json;charset=UTF-8")
+    public String list() {
+        return categoryService.getAllCategoriesOrderedByRankAsJson();
     }
 }

--- a/src/main/java/com/nklcbdty/api/crawler/controller/JobController.java
+++ b/src/main/java/com/nklcbdty/api/crawler/controller/JobController.java
@@ -64,11 +64,19 @@ public class JobController {
         this.commonService = commonService;
     }
 
-    @GetMapping("/list")
-    public List<Job_mst> list(@RequestParam(defaultValue = "ALL") String company) {
-        return jobService.list(company);
+    /**
+     * 공고 목록. 응답은 캐시된 JSON 문자열을 그대로 흘려보낸다(본문은 캐시 도입 전과 동일).
+     *
+     * <p>charset 을 명시하는 이유: String 을 반환하면 StringHttpMessageConverter 가 쓰이는데,
+     * 이 컨버터의 프레임워크 기본 charset 은 ISO-8859-1 이라 한글이 깨질 수 있다.
+     * 스프링 부트가 UTF-8 로 바꿔주긴 하지만 설정에 의존하지 않도록 여기서 못박는다.</p>
+     */
+    @GetMapping(value = "/list", produces = "application/json;charset=UTF-8")
+    public String list(@RequestParam(defaultValue = "ALL") String company) {
+        return jobService.listAsJson(company);
     }
 
+    // 크롤 결과 저장으로 목록이 바뀌면 CrawlerCommonService#saveAll 이 캐시를 비운다.
     @GetMapping("/crawler")
     public List<Job_mst> cralwer(@RequestParam String company) {
         log.info("cralwer company : {}", company);

--- a/src/main/java/com/nklcbdty/api/crawler/service/CategoryService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/CategoryService.java
@@ -5,8 +5,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nklcbdty.api.common.CacheConfig;
 import com.nklcbdty.api.crawler.vo.CategoryDtl;
 import com.nklcbdty.api.crawler.vo.CategoryMst;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -17,10 +21,27 @@ import static com.nklcbdty.api.crawler.vo.QCategoryMst.*;
 public class CategoryService {
 
     private final JPAQueryFactory queryFactory;
+    private final ObjectMapper objectMapper;
 
     @Autowired
-    public CategoryService(JPAQueryFactory queryFactory) {
+    public CategoryService(JPAQueryFactory queryFactory, ObjectMapper objectMapper) {
         this.queryFactory = queryFactory;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * {@code /api/category/list} 응답 JSON.
+     *
+     * <p>파라미터가 없어 캐시 키가 하나뿐이라 상수 키를 쓴다. 카테고리는 크롤과 무관하게
+     * 거의 바뀌지 않으므로 별도 무효화 없이 TTL 만료에만 의존한다.</p>
+     */
+    @Cacheable(cacheNames = CacheConfig.CATEGORY_LIST, key = "'all'")
+    public String getAllCategoriesOrderedByRankAsJson() {
+        try {
+            return objectMapper.writeValueAsString(getAllCategoriesOrderedByRank());
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("카테고리 목록 JSON 직렬화 실패", e);
+        }
     }
 
     public List<CategoryMst> getAllCategoriesOrderedByRank() {

--- a/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
@@ -9,9 +9,14 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nklcbdty.api.common.CacheConfig;
 import com.nklcbdty.common.crawler.repository.JobRepository;
 import com.nklcbdty.common.vo.Job_mst;
 
@@ -21,10 +26,29 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class JobService {
     private final JobRepository jobRepository;
+    private final ObjectMapper objectMapper;
 
     @Autowired
-    public JobService(JobRepository jobRepository) {
+    public JobService(JobRepository jobRepository, ObjectMapper objectMapper) {
         this.jobRepository = jobRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * {@code /api/list} 응답 JSON. 캐시 히트 시 Redis GET 한 번으로 끝난다.
+     *
+     * <p>{@link #list(String)} 결과를 객체로 캐싱하지 않고 직렬화까지 끝낸 문자열을 담는 이유는
+     * {@link CacheConfig} 주석에 적어두었다. 직렬화는 컨트롤러가 쓰는 것과 같은
+     * 스프링 관리 ObjectMapper 로 하므로 응답 본문은 캐시 도입 전과 동일하다.</p>
+     */
+    @Cacheable(cacheNames = CacheConfig.JOB_LIST, key = "#company")
+    public String listAsJson(String company) {
+        try {
+            return objectMapper.writeValueAsString(list(company));
+        } catch (JsonProcessingException e) {
+            // 직렬화 실패는 설정/모델 문제이므로 조용히 넘기지 않는다.
+            throw new IllegalStateException("공고 목록 JSON 직렬화 실패 company=" + company, e);
+        }
     }
 
     public List<Job_mst> list(String company) {
@@ -114,10 +138,13 @@ public class JobService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
     public void deleteByCompany(String company_cd) {
         jobRepository.deleteByCompanyCd(company_cd);
     }
 
+    // company=ALL 캐시도 같이 틀어지므로 특정 키만 지우지 않고 전체를 비운다.
+    @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
     public void deleteAll() {
         jobRepository.deleteAllInBatch();
     }

--- a/src/main/java/com/nklcbdty/api/jobdelete/service/JobDeleteRequestService.java
+++ b/src/main/java/com/nklcbdty/api/jobdelete/service/JobDeleteRequestService.java
@@ -4,9 +4,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.nklcbdty.api.common.CacheConfig;
 import com.nklcbdty.api.jobdelete.repository.JobDeleteRequestRepository;
 import com.nklcbdty.api.jobdelete.vo.JobDeleteRequest;
 import com.nklcbdty.common.crawler.repository.JobRepository;
@@ -76,6 +78,8 @@ public class JobDeleteRequestService {
 
     /** 승인: 상태 변경 + 실제 공고(job_mst) 삭제 */
     @Transactional
+    // 공고를 실제로 지우므로 목록 캐시를 비운다. 안 지우면 삭제된 공고가 최대 TTL 동안 계속 보인다.
+    @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
     public JobDeleteRequest approve(Long id, String processedBy) {
         JobDeleteRequest request = repository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("삭제요청을 찾을 수 없습니다. id=" + id));

--- a/src/test/java/com/nklcbdty/api/common/CacheFallbackTest.java
+++ b/src/test/java/com/nklcbdty/api/common/CacheFallbackTest.java
@@ -1,0 +1,82 @@
+package com.nklcbdty.api.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+/**
+ * Redis 가 죽어 있어도 캐시를 붙인 메서드가 예외 없이 동작해야 한다.
+ *
+ * <p>목록 API 는 캐시 도입 전까지 Redis 와 무관하게 잘 동작했다. 스프링의 기본 동작은
+ * 캐시 조회 실패 시 예외를 그대로 올려보내는 것이어서, 그대로 두면 새벽 재기동 구간에
+ * {@code /api/list} 가 통째로 500 이 되는 퇴행이 생긴다.
+ * {@link CacheConfig#errorHandler()} 가 그걸 막는지 고정한다.</p>
+ */
+class CacheFallbackTest {
+
+    @Test
+    void redis_가_죽어있으면_캐시를_건너뛰고_원래_메서드로_폴백한다() {
+        try (AnnotationConfigApplicationContext ctx =
+                 new AnnotationConfigApplicationContext(TestConfig.class, CacheConfig.class)) {
+
+            CountingService service = ctx.getBean(CountingService.class);
+
+            // 예외가 나지 않고 값이 정상 반환되는 것이 핵심이다.
+            assertThatNoException().isThrownBy(() -> service.value("A"));
+            assertThat(service.value("A")).isEqualTo("v-A");
+
+            // Redis 가 없으니 캐시 히트가 있을 수 없고, 매 호출이 실제 메서드로 내려간다.
+            // (캐시가 살아 있으면 호출 수가 줄어든다 = 캐시가 먹고 있다는 뜻)
+            // 필드가 아니라 메서드로 읽는다. service 는 CGLIB 프록시라 필드를 직접 보면 프록시 쪽 빈 값이 나온다.
+            assertThat(service.callCount()).isGreaterThan(1);
+        }
+    }
+
+    @Configuration
+    @EnableCaching
+    static class TestConfig {
+
+        @Bean
+        RedisConnectionFactory redisConnectionFactory() {
+            // 아무도 듣고 있지 않은 포트. 접속이 즉시 거부돼 캐시 연산이 예외를 던진다.
+            return new LettuceConnectionFactory(
+                new RedisStandaloneConfiguration("127.0.0.1", 63999),
+                LettuceClientConfiguration.builder()
+                    .commandTimeout(Duration.ofMillis(200))
+                    .build());
+        }
+
+        @Bean
+        CountingService countingService() {
+            return new CountingService();
+        }
+    }
+
+    static class CountingService {
+
+        private final AtomicInteger calls = new AtomicInteger();
+
+        @Cacheable(cacheNames = CacheConfig.JOB_LIST, key = "#key")
+        public String value(String key) {
+            calls.incrementAndGet();
+            return "v-" + key;
+        }
+
+        public int callCount() {
+            return calls.get();
+        }
+    }
+}

--- a/src/test/java/com/nklcbdty/api/crawler/service/JobServiceListOrderTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/service/JobServiceListOrderTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nklcbdty.common.crawler.repository.JobRepository;
 import com.nklcbdty.common.vo.Job_mst;
 
@@ -19,6 +20,8 @@ class JobServiceListOrderTest {
 
     @Mock
     private JobRepository jobRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private Job_mst job(String subject, String endDate) {
         Job_mst j = new Job_mst();
@@ -38,7 +41,7 @@ class JobServiceListOrderTest {
         when(jobRepository.findAllByCompanyCdAndSubJobCdNmIsNotNullOrderByEndDateAsc("KAKAO"))
             .thenReturn(Arrays.asList(later, always1, earlier, always2));
 
-        JobService service = new JobService(jobRepository);
+        JobService service = new JobService(jobRepository, objectMapper);
         List<Job_mst> result = service.list("KAKAO");
 
         // 종료기간 있는 공고가 먼저(마감 임박순), 그 다음 상시채용
@@ -65,10 +68,31 @@ class JobServiceListOrderTest {
         when(jobRepository.findAllByCompanyCdAndSubJobCdNmIsNotNullOrderByEndDateAsc("NAVER"))
             .thenReturn(Arrays.asList(dup1, dup2, other));
 
-        JobService service = new JobService(jobRepository);
+        JobService service = new JobService(jobRepository, objectMapper);
         List<Job_mst> result = service.list("NAVER");
 
         assertThat(result).hasSize(2);
         assertThat(result).extracting(Job_mst::getAnnoId).containsExactlyInAnyOrder("12345", "99999");
+    }
+
+    /**
+     * 캐시에 담는 값이 "컨트롤러가 원래 내려주던 응답 본문"과 같아야 한다.
+     * listAsJson 은 list() 결과를 같은 ObjectMapper 로 직렬화한 것일 뿐임을 고정한다.
+     */
+    @Test
+    void listAsJson_은_list_결과를_직렬화한_것과_동일하다() throws Exception {
+        Job_mst a = jobFull("NAVER", "12345", "Product Data Analyst (경력)", "2099-01-01 23:59:00");
+        Job_mst b = jobFull("NAVER", "99999", "다른 공고", "2099-02-01 23:59:00");
+
+        when(jobRepository.findAllByCompanyCdAndSubJobCdNmIsNotNullOrderByEndDateAsc("NAVER"))
+            .thenReturn(Arrays.asList(a, b));
+
+        JobService service = new JobService(jobRepository, objectMapper);
+
+        String json = service.listAsJson("NAVER");
+
+        assertThat(json).isEqualTo(objectMapper.writeValueAsString(service.list("NAVER")));
+        // 한글이 유니코드 이스케이프 없이 그대로 실려야 한다(응답 charset 과 함께 확인).
+        assertThat(json).contains("다른 공고");
     }
 }


### PR DESCRIPTION
## 왜

오전 첫 요청이 느린 원인을 재보니 두 가지가 섞여 있었습니다.

| 엔드포인트 | 첫 호출 | 이후 (warm) | 크기 |
|---|---|---|---|
| `/api/company/list` | 0.10s | — | 815B |
| `/api/category/list` | **1.16s** | 0.22 / 0.30 / 0.34s | 1.2KB |
| `/api/list?company=ALL` | 2.66s | **3.04 / 1.54 / 2.05s** | 128KB |

- **(a) 기동/예열 비용** — `category/list` 가 1.16s → 0.3s. 첫 호출에만 붙는 JIT·커넥션풀·Hibernate 첫 쿼리 몫.
- **(b) `/api/list` 자체 비용** — 예열 후에도 매번 1.5~3초. TTFB 3초에 전송은 0.1초라 전부 서버 처리 시간. 전건 조회 + `annoId` 중복제거 + 문자열 날짜 파싱 + 정렬 + 128KB 직렬화를 요청마다 다시 하고 있었습니다.

## 무엇을

**(b) → 캐시.** 캐시에는 객체가 아니라 완성된 응답 JSON 문자열을 담습니다. `List<Job_mst>` 로 캐싱하면 Redis 에서 128KB 를 읽어 역직렬화한 뒤 응답으로 재직렬화하게 돼 이득이 크게 깎입니다. 직렬화는 컨트롤러가 쓰던 것과 같은 스프링 관리 `ObjectMapper` 로 하므로 **응답 본문은 캐시 도입 전과 동일**합니다(테스트로 고정).

- `/api/list` — 키는 `company` (`ALL` + `CompanyEnums` 8개 = 9개로 유한)
- `/api/category/list` — 키 1개
- `/api/company/list` 는 제외. `CompanyEnums.values()` 순회뿐이라 DB 를 안 타고 0.1초입니다. Redis 왕복이 오히려 느립니다.

**(a) → 캐시로 안 고쳐집니다.** 요청은 앱을 통과해야 하고, 앱 부팅이 끝나야 Redis 를 읽습니다. 그래서 워머를 앱 안의 `@Scheduled` 가 아니라 **GitHub Actions cron** 으로 뒀습니다. 외부에서 HTTP 로 때려야 앱 깨우기 + 예열 + 캐시 채우기가 한 번에 됩니다. 앱 안에 두면 앱이 잠들었을 때 스케줄러도 같이 잠들어 아무것도 안 합니다. KST 07:50 실행(Actions cron 지연을 감안해 8시가 아닌 7:50).

## 짚어둘 것

**`CacheErrorHandler` 를 반드시 같이 넣었습니다.** 목록 API 는 캐시를 붙이기 전까지 Redis 와 무관하게 잘 동작했습니다. 그런데 스프링 기본 동작은 캐시 조회 실패 시 예외를 그대로 올려보냅니다. 그대로 두면 `commandTimeout`(2초)에 걸리는 새벽 재기동 구간에 `/api/list` 가 통째로 500 이 되는 퇴행이 생깁니다. 죽은 포트를 물려 폴백을 확인하는 테스트를 같이 넣었습니다.

**무효화는 컨트롤러가 아니라 실제 쓰기 지점**(`CrawlerCommonService#saveAll`)에 뒀습니다. 컨트롤러 빈에 캐시 프록시를 씌우면 핸들러 매핑과 얽힐 여지가 있고, 크롤 중간 쓰기(`getNotSaveJobItem` 의 기존 row 갱신, `reconcileEndedJobs` 의 종료 마킹)는 전부 `saveAll` 보다 앞이라 커버리지는 같습니다. TTL 1시간은 무효화를 놓친 경우의 안전망입니다.

**Redis 영속성은 꺼져 있습니다** (`save` 미설정, `appendonly=no`, 마지막 기동 시 `rdb_last_load_keys_loaded=0`). 새벽 재기동마다 내용이 전부 날아가지만 캐시는 날아가도 되는 데이터라 문제가 아닙니다. 아침 워밍업이 다시 채웁니다. (별개로 refresh 토큰도 같이 날아가 매일 로그인이 풀리는데, 그건 이번 PR 범위 밖입니다)

## 검증

- 전체 테스트 93개, 실패 2개 — 둘 다 이 브랜치 이전에도 동일하게 실패하는 기존 실패입니다(`contextLoads` 는 로컬에 `DATASOURCE_URL` 없음, `AdminSubscriptionServiceTest` 는 무관).
- `CacheFallbackTest` 신규 — Redis 가 죽어도 `@Cacheable` 메서드가 예외 없이 폴백.
- `listAsJson` 이 기존 `list()` 직렬화 결과와 동일함을 테스트로 고정.
- 워밍업 스크립트를 실제 API 에 돌려 12개 호출 전부 200 확인.

**확인 못 한 것:** 로컬에 `application-dev.properties` 가 없어 앱을 띄워보지는 못했습니다. 스프링 컨텍스트에서 캐시가 실제로 붙는지는 배포 후 확인이 필요합니다:

```bash
curl -s -o /dev/null -w '%{time_total}s\n' "https://port-0-nklcbdty-service-m6qh1fte0c037b76.sel4.cloudtype.app/api/list?company=ALL"
```

두 번 연속 호출해 두 번째가 확 빨라지면 정상입니다 (1.5~3초 → 0.2초대 기대). Redis 에서 `jobList::ALL` 키로도 보입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caching for job listings and categories, improving response times.
  * Added automatic cache refresh after job data changes or deletions.
  * Preserved UTF-8 characters, including Korean text, in JSON responses.
  * Added scheduled and manual cache warmup to prepare frequently used data.

* **Bug Fixes**
  * API requests now continue normally when the cache service is unavailable.

* **Tests**
  * Added coverage for cache fallback behavior and JSON encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->