### PR TITLE
✨ Feat: 채용 캘린더 API — 마감일 기준 월별 공고 조회

### DIFF
--- a/src/main/java/com/nklcbdty/api/calendar/controller/CalendarController.java
+++ b/src/main/java/com/nklcbdty/api/calendar/controller/CalendarController.java
@@ -1,0 +1,58 @@
+package com.nklcbdty.api.calendar.controller;
+
+import java.time.YearMonth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nklcbdty.api.calendar.service.CalendarService;
+
+/**
+ * 채용 캘린더. 그 달에 마감되는 공고를 날짜별로 보여준다.
+ *
+ * <p>예: {@code GET /api/calendar/deadlines?year=2026&month=8&company=NAVER}</p>
+ *
+ * <p>year/month 를 생략하면 이번 달, company 를 생략하면 전체 회사다.
+ * 상시채용("영입종료시")처럼 마감일이 없는 공고는 캘린더에 찍을 날짜가 없어 제외된다.</p>
+ */
+@RestController
+@RequestMapping("/api/calendar")
+public class CalendarController {
+
+    // 잘못된 값으로 엉뚱한 달을 조회하는 것을 막는 상식적인 범위.
+    private static final int MIN_YEAR = 2000;
+    private static final int MAX_YEAR = 2100;
+
+    private final CalendarService calendarService;
+
+    @Autowired
+    public CalendarController(CalendarService calendarService) {
+        this.calendarService = calendarService;
+    }
+
+    @GetMapping("/deadlines")
+    public ResponseEntity<?> deadlines(
+        @RequestParam(required = false) Integer year,
+        @RequestParam(required = false) Integer month,
+        @RequestParam(defaultValue = "ALL") String company) {
+
+        final YearMonth thisMonth = YearMonth.now();
+        final int targetYear = year != null ? year : thisMonth.getYear();
+        final int targetMonth = month != null ? month : thisMonth.getMonthValue();
+
+        if (targetMonth < 1 || targetMonth > 12) {
+            return ResponseEntity.badRequest().body("month 는 1~12 여야 합니다. (요청값: " + targetMonth + ")");
+        }
+        if (targetYear < MIN_YEAR || targetYear > MAX_YEAR) {
+            return ResponseEntity.badRequest()
+                                 .body("year 는 " + MIN_YEAR + "~" + MAX_YEAR + " 여야 합니다. (요청값: " + targetYear + ")");
+        }
+
+        return ResponseEntity.ok(
+            calendarService.getMonthlyDeadlines(YearMonth.of(targetYear, targetMonth), company));
+    }
+}

--- a/src/main/java/com/nklcbdty/api/calendar/dto/CalendarDayDto.java
+++ b/src/main/java/com/nklcbdty/api/calendar/dto/CalendarDayDto.java
@@ -1,0 +1,25 @@
+package com.nklcbdty.api.calendar.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Getter;
+
+/** 마감 공고가 하나 이상 있는 하루. 공고가 없는 날은 응답에 담지 않는다(빈 칸은 프론트가 그린다). */
+@Getter
+public class CalendarDayDto {
+
+    /** yyyy-MM-dd */
+    private final String date;
+    /** 1(월) ~ 7(일). 요일 색 처리에 쓴다. */
+    private final int dayOfWeek;
+    private final int count;
+    private final List<CalendarJobDto> jobs;
+
+    public CalendarDayDto(LocalDate date, List<CalendarJobDto> jobs) {
+        this.date = date.toString();
+        this.dayOfWeek = date.getDayOfWeek().getValue();
+        this.count = jobs.size();
+        this.jobs = jobs;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/calendar/dto/CalendarJobDto.java
+++ b/src/main/java/com/nklcbdty/api/calendar/dto/CalendarJobDto.java
@@ -1,0 +1,54 @@
+package com.nklcbdty.api.calendar.dto;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.nklcbdty.api.crawler.common.CompanyEnums;
+import com.nklcbdty.api.crawler.common.JobEndDates;
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.Getter;
+
+/** 캘린더 한 칸에 들어가는 공고 한 건. */
+@Getter
+public class CalendarJobDto {
+
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final Long id;
+    /** 공고 클릭 로그(/api/log/job_history)에 쓰는 공고 번호 */
+    private final String annoId;
+    private final String companyCd;
+    /** 회사 한글명. enum 에 없는 코드면 코드값 그대로. */
+    private final String companyNm;
+    private final String annoSubject;
+    private final String subJobCdNm;
+    private final String empTypeCdNm;
+    private final String workplace;
+    private final String jobDetailLink;
+    /** 원본 마감일시 문자열 (yyyy-MM-dd HH:mm[:ss]) */
+    private final String endDate;
+    /** 마감 시각 (HH:mm). 캘린더 칸에 "18:00 마감" 처럼 쓴다. */
+    private final String endTime;
+    /** 조회 시점 기준 이미 마감된 공고인지. 지난 날짜를 흐리게 처리하는 데 쓴다. */
+    private final boolean closed;
+
+    public CalendarJobDto(Job_mst job, LocalDateTime now) {
+        this.id = job.getId();
+        this.annoId = job.getAnnoId();
+        this.companyCd = job.getCompanyCd();
+        final CompanyEnums company = CompanyEnums.fromCompanyCd(job.getCompanyCd());
+        this.companyNm = company != null ? company.getCompanyNm() : job.getCompanyCd();
+        this.annoSubject = job.getAnnoSubject();
+        this.subJobCdNm = job.getSubJobCdNm();
+        this.empTypeCdNm = job.getEmpTypeCdNm();
+        this.workplace = job.getWorkplace();
+        this.jobDetailLink = job.getJobDetailLink();
+        this.endDate = job.getEndDate();
+
+        // 캘린더에 올라온 공고는 마감일시가 이미 파싱된 것들이라 null 이 아니지만, 방어적으로 처리한다.
+        final LocalDateTime endDateTime = JobEndDates.parse(job.getEndDate());
+        this.endTime = endDateTime != null ? endDateTime.format(TIME_FORMATTER) : null;
+        this.closed = endDateTime != null && endDateTime.isBefore(now);
+    }
+}

--- a/src/main/java/com/nklcbdty/api/calendar/dto/CalendarMonthDto.java
+++ b/src/main/java/com/nklcbdty/api/calendar/dto/CalendarMonthDto.java
@@ -1,0 +1,37 @@
+package com.nklcbdty.api.calendar.dto;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import lombok.Getter;
+
+/**
+ * 한 달치 마감 캘린더 응답.
+ *
+ * <p>{@code days} 는 마감 공고가 있는 날만 날짜 오름차순으로 담긴다. 달의 칸 배치는
+ * {@code firstDayOfWeek}/{@code lengthOfMonth} 로 프론트가 계산한다.</p>
+ */
+@Getter
+public class CalendarMonthDto {
+
+    private final int year;
+    private final int month;
+    /** 1일의 요일 (1=월 ~ 7=일) */
+    private final int firstDayOfWeek;
+    /** 그 달의 일수 */
+    private final int lengthOfMonth;
+    /** 이 달에 마감되는 공고 총 건수 */
+    private final int totalCount;
+    private final List<CalendarDayDto> days;
+
+    public CalendarMonthDto(YearMonth yearMonth, int totalCount, List<CalendarDayDto> days) {
+        this.year = yearMonth.getYear();
+        this.month = yearMonth.getMonthValue();
+        final LocalDate firstDay = yearMonth.atDay(1);
+        this.firstDayOfWeek = firstDay.getDayOfWeek().getValue();
+        this.lengthOfMonth = yearMonth.lengthOfMonth();
+        this.totalCount = totalCount;
+        this.days = days;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/calendar/service/CalendarService.java
+++ b/src/main/java/com/nklcbdty/api/calendar/service/CalendarService.java
@@ -1,0 +1,59 @@
+package com.nklcbdty.api.calendar.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.nklcbdty.api.calendar.dto.CalendarDayDto;
+import com.nklcbdty.api.calendar.dto.CalendarJobDto;
+import com.nklcbdty.api.calendar.dto.CalendarMonthDto;
+import com.nklcbdty.api.crawler.common.JobEndDates;
+import com.nklcbdty.api.crawler.service.JobService;
+import com.nklcbdty.common.vo.Job_mst;
+
+/** 채용 캘린더. 공고를 마감일 기준으로 날짜별로 모아 준다. */
+@Service
+public class CalendarService {
+
+    private final JobService jobService;
+
+    @Autowired
+    public CalendarService(JobService jobService) {
+        this.jobService = jobService;
+    }
+
+    /**
+     * 해당 월에 마감되는 공고를 날짜별로 모아 반환한다.
+     *
+     * @param company 회사 코드(예: NAVER). "ALL" 이면 전체 회사.
+     */
+    public CalendarMonthDto getMonthlyDeadlines(YearMonth yearMonth, String company) {
+        final List<Job_mst> jobs =
+            jobService.findClosingBetween(company, yearMonth.atDay(1), yearMonth.atEndOfMonth());
+
+        final LocalDateTime now = LocalDateTime.now();
+
+        // TreeMap: 날짜 오름차순. 하루 안에서는 findClosingBetween 이 준 마감 임박순을 유지한다.
+        final Map<LocalDate, List<CalendarJobDto>> jobsByDate = new TreeMap<>();
+        for (Job_mst job : jobs) {
+            // findClosingBetween 이 마감일시 파싱 가능한 공고만 주므로 parse 결과는 null 이 아니다.
+            final LocalDate endDay = JobEndDates.parse(job.getEndDate()).toLocalDate();
+            jobsByDate.computeIfAbsent(endDay, key -> new ArrayList<>())
+                      .add(new CalendarJobDto(job, now));
+        }
+
+        final List<CalendarDayDto> days = new ArrayList<>();
+        for (Map.Entry<LocalDate, List<CalendarJobDto>> entry : jobsByDate.entrySet()) {
+            days.add(new CalendarDayDto(entry.getKey(), entry.getValue()));
+        }
+
+        return new CalendarMonthDto(yearMonth, jobs.size(), days);
+    }
+}

--- a/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
+++ b/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
@@ -20,6 +20,8 @@ public enum AllowedPaths {
     CATEGORY_ALL("/api/category/**"),
     // 회사 목록 + 채용 페이지 주소. 로그인 없이 보는 목록 화면에서 쓰므로 공개.
     COMPANY_ALL("/api/company/**"),
+    // 채용 캘린더(마감일 기준). 목록 화면과 같이 로그인 없이 보는 화면이라 공개.
+    CALENDAR_ALL("/api/calendar/**"),
     EMAIL("/api/email/**"),
     CRALWER("/api/crawler"),
     JOB_DELETE_REQUEST("/api/job-delete-requests"),

--- a/src/main/java/com/nklcbdty/api/crawler/common/CompanyEnums.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CompanyEnums.java
@@ -35,4 +35,22 @@ public enum CompanyEnums {
     public String getCompanyCd() {
         return name();
     }
+
+    /**
+     * {@code job_mst.company_cd} 로 회사를 찾는다.
+     *
+     * <p>없으면 null. 크롤러가 먼저 추가되고 이 enum 에 아직 없는 코드가 DB 에 있을 수 있어,
+     * 예외 대신 null 을 주고 호출부가 코드값으로 폴백하게 한다.</p>
+     */
+    public static CompanyEnums fromCompanyCd(String companyCd) {
+        if (companyCd == null) {
+            return null;
+        }
+        for (CompanyEnums company : values()) {
+            if (company.getCompanyCd().equalsIgnoreCase(companyCd)) {
+                return company;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/nklcbdty/api/crawler/common/JobEndDates.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/JobEndDates.java
@@ -1,0 +1,62 @@
+package com.nklcbdty.api.crawler.common;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@code job_mst.end_date} 문자열 해석 공통 로직.
+ *
+ * <p>마감일은 회사마다 포맷이 달라 문자열로 적재된다. 목록(/api/list)과 캘린더(/api/calendar/deadlines)가
+ * 같은 규칙으로 읽도록 한 곳에 모았다.</p>
+ */
+@Slf4j
+public final class JobEndDates {
+
+    /** 마감일 없이 채용될 때까지 뽑는 상시채용 공고. */
+    private static final String UNTIL_FILLED = "영입종료시";
+
+    /** 크롤러가 마감일 파싱에 실패하면 "error" 문자열이 그대로 적재된다 → 손상 데이터로 간주. */
+    private static final String CORRUPTED = "error";
+
+    // 더 긴 포맷 (HH:mm:ss) 을 먼저 시도해서 정상 데이터에 불필요한 error 로그 안 남기게 한다.
+    private static final List<DateTimeFormatter> FORMATTERS = Arrays.asList(
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+    );
+
+    private JobEndDates() {
+    }
+
+    /** 종료기간이 없는 상시채용 공고인지 여부 (종료일 null 또는 "영입종료시") */
+    public static boolean isAlwaysRecruiting(String endDateStr) {
+        return endDateStr == null || UNTIL_FILLED.equals(endDateStr);
+    }
+
+    /** 크롤러 파싱 실패로 손상된 값인지 여부 */
+    public static boolean isCorrupted(String endDateStr) {
+        return CORRUPTED.equals(endDateStr);
+    }
+
+    /** 마감일시. 파싱 실패 시 null. */
+    public static LocalDateTime parse(String endDateStr) {
+        if (endDateStr == null) {
+            return null;
+        }
+        for (DateTimeFormatter formatter : FORMATTERS) {
+            try {
+                return LocalDateTime.parse(endDateStr, formatter);
+            } catch (Exception ignored) {
+                // 다음 formatter 시도
+            }
+        }
+        if (!isCorrupted(endDateStr)) {
+            // "error" 는 이미 알려진 손상 데이터라 로그를 남기지 않는다.
+            log.warn("endDate 파싱 실패: '{}'", endDateStr);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
@@ -1,9 +1,9 @@
 package com.nklcbdty.api.crawler.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nklcbdty.api.common.CacheConfig;
+import com.nklcbdty.api.crawler.common.JobEndDates;
 import com.nklcbdty.common.crawler.repository.JobRepository;
 import com.nklcbdty.common.vo.Job_mst;
 
@@ -52,12 +53,7 @@ public class JobService {
     }
 
     public List<Job_mst> list(String company) {
-        List<Job_mst> items;
-        if ("ALL".equals(company)) {
-            items = jobRepository.findAllBySubJobCdNmIsNotNull();
-        } else {
-            items = jobRepository.findAllByCompanyCdAndSubJobCdNmIsNotNullOrderByEndDateAsc(company);
-        }
+        List<Job_mst> items = findByCompany(company);
 
         LocalDateTime now = LocalDateTime.now();
 
@@ -68,14 +64,12 @@ public class JobService {
             String endDateStr = item.getEndDate();
             boolean shouldAdd = false;
 
-            if (endDateStr == null) {
+            if (JobEndDates.isAlwaysRecruiting(endDateStr)) {
                 shouldAdd = true;
-            } else if ("영입종료시".equals(endDateStr)) {
-                shouldAdd = true;
-            } else if ("error".equals(endDateStr)) {
+            } else if (JobEndDates.isCorrupted(endDateStr)) {
                 // 크롤러가 파싱 실패 시 "error" 문자열을 그대로 적재 → 손상 데이터로 간주, 조용히 제외 (shouldAdd 는 false 유지)
             } else {
-                LocalDateTime endDate = parseDateTime(endDateStr);
+                LocalDateTime endDate = JobEndDates.parse(endDateStr);
                 if (endDate != null && endDate.isAfter(now)) {
                     shouldAdd = true;
                 }
@@ -90,16 +84,16 @@ public class JobService {
         // 종료기간이 있는 공고를 위로, 상시채용(종료일 없음/"영입종료시")은 아래로.
         // 종료기간이 있는 공고끼리는 마감 임박순(오름차순)으로 정렬한다.
         result.sort((a, b) -> {
-            boolean aAlways = isAlwaysRecruiting(a.getEndDate());
-            boolean bAlways = isAlwaysRecruiting(b.getEndDate());
+            boolean aAlways = JobEndDates.isAlwaysRecruiting(a.getEndDate());
+            boolean bAlways = JobEndDates.isAlwaysRecruiting(b.getEndDate());
             if (aAlways != bAlways) {
                 return aAlways ? 1 : -1; // 상시채용은 뒤로
             }
             if (aAlways) {
                 return 0; // 둘 다 상시채용이면 기존 순서 유지
             }
-            LocalDateTime ad = parseDateTime(a.getEndDate());
-            LocalDateTime bd = parseDateTime(b.getEndDate());
+            LocalDateTime ad = JobEndDates.parse(a.getEndDate());
+            LocalDateTime bd = JobEndDates.parse(b.getEndDate());
             if (ad == null && bd == null) {
                 return 0;
             }
@@ -115,9 +109,49 @@ public class JobService {
         return result;
     }
 
-    /** 종료기간이 없는 상시채용 공고인지 여부 (종료일 null 또는 "영입종료시") */
-    private boolean isAlwaysRecruiting(String endDateStr) {
-        return endDateStr == null || "영입종료시".equals(endDateStr);
+    /**
+     * 마감일이 {@code [from, to]} (양끝 포함) 안에 있는 공고를 마감 임박순으로 반환한다. 캘린더에서 쓴다.
+     *
+     * <p>{@link #list(String)} 와 두 가지가 다르다.
+     * <ul>
+     *   <li>캘린더에 찍을 날짜가 없는 공고(상시채용 · 손상 데이터 · 파싱 불가)는 제외한다.</li>
+     *   <li>"이미 지난 마감"을 걸러내지 않는다. 지난 달로 이동해도 그 달에 마감된 공고를 볼 수 있어야 한다.</li>
+     * </ul>
+     */
+    public List<Job_mst> findClosingBetween(String company, LocalDate from, LocalDate to) {
+        final Set<String> seenKeys = new HashSet<>();
+        final List<Job_mst> result = new ArrayList<>();
+
+        for (Job_mst item : findByCompany(company)) {
+            final String endDateStr = item.getEndDate();
+            if (JobEndDates.isAlwaysRecruiting(endDateStr) || JobEndDates.isCorrupted(endDateStr)) {
+                continue;
+            }
+            final LocalDateTime endDate = JobEndDates.parse(endDateStr);
+            if (endDate == null) {
+                continue;
+            }
+            final LocalDate endDay = endDate.toLocalDate();
+            if (endDay.isBefore(from) || endDay.isAfter(to)) {
+                continue;
+            }
+            if (seenKeys.add(dedupKey(item))) {
+                result.add(item);
+            }
+        }
+
+        // 마감 임박순. 같은 날 안에서도 시간순으로 보이게 한다.
+        result.sort(Comparator.comparing((Job_mst item) -> JobEndDates.parse(item.getEndDate())));
+
+        return result;
+    }
+
+    /** 회사별 공고 조회. company 가 "ALL" 이면 전체. 직무 미분류(subJobCdNm=null) 공고는 노출 대상이 아니다. */
+    private List<Job_mst> findByCompany(String company) {
+        if ("ALL".equals(company)) {
+            return jobRepository.findAllBySubJobCdNmIsNotNull();
+        }
+        return jobRepository.findAllByCompanyCdAndSubJobCdNmIsNotNullOrderByEndDateAsc(company);
     }
 
     /**
@@ -147,23 +181,5 @@ public class JobService {
     @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
     public void deleteAll() {
         jobRepository.deleteAllInBatch();
-    }
-
-    // 더 긴 포맷 (HH:mm:ss) 을 먼저 시도해서 정상 데이터에 불필요한 error 로그 안 남기게 한다.
-    private final List<DateTimeFormatter> FORMATTERS = Arrays.asList(
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
-    );
-
-    private LocalDateTime parseDateTime(String dateTimeStr) {
-        for (DateTimeFormatter formatter : FORMATTERS) {
-            try {
-                return LocalDateTime.parse(dateTimeStr, formatter);
-            } catch (Exception ignored) {
-                // 다음 formatter 시도
-            }
-        }
-        log.warn("endDate 파싱 실패: '{}'", dateTimeStr);
-        return null;
     }
 }

--- a/src/test/java/com/nklcbdty/api/calendar/controller/CalendarControllerTest.java
+++ b/src/test/java/com/nklcbdty/api/calendar/controller/CalendarControllerTest.java
@@ -1,0 +1,74 @@
+package com.nklcbdty.api.calendar.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.time.YearMonth;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nklcbdty.api.calendar.dto.CalendarMonthDto;
+import com.nklcbdty.api.calendar.service.CalendarService;
+
+class CalendarControllerTest {
+
+    private CalendarService calendarService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        calendarService = mock(CalendarService.class);
+        mockMvc = standaloneSetup(new CalendarController(calendarService)).build();
+    }
+
+    @Test
+    @DisplayName("GET /api/calendar/deadlines: year/month 로 그 달 캘린더를 조회한다")
+    void deadlines_returnsRequestedMonth() throws Exception {
+        when(calendarService.getMonthlyDeadlines(YearMonth.of(2026, 8), "NAVER"))
+            .thenReturn(new CalendarMonthDto(YearMonth.of(2026, 8), 0, Collections.emptyList()));
+
+        mockMvc.perform(get("/api/calendar/deadlines?year=2026&month=8&company=NAVER"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.year").value(2026))
+            .andExpect(jsonPath("$.month").value(8))
+            .andExpect(jsonPath("$.totalCount").value(0));
+    }
+
+    @Test
+    @DisplayName("year/month 를 안 주면 이번 달, company 를 안 주면 전체 회사를 조회한다")
+    void deadlines_defaultsToThisMonthAndAllCompanies() throws Exception {
+        YearMonth thisMonth = YearMonth.now();
+        when(calendarService.getMonthlyDeadlines(any(), any()))
+            .thenReturn(new CalendarMonthDto(thisMonth, 0, Collections.emptyList()));
+
+        mockMvc.perform(get("/api/calendar/deadlines"))
+            .andExpect(status().isOk());
+
+        verify(calendarService).getMonthlyDeadlines(eq(thisMonth), eq("ALL"));
+    }
+
+    @Test
+    @DisplayName("month 가 1~12 밖이면 400 을 준다")
+    void deadlines_rejectsInvalidMonth() throws Exception {
+        mockMvc.perform(get("/api/calendar/deadlines?year=2026&month=13"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("year 가 지원 범위 밖이면 400 을 준다")
+    void deadlines_rejectsInvalidYear() throws Exception {
+        mockMvc.perform(get("/api/calendar/deadlines?year=1900&month=1"))
+            .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/nklcbdty/api/calendar/service/CalendarServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/calendar/service/CalendarServiceTest.java
@@ -1,0 +1,163 @@
+package com.nklcbdty.api.calendar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.YearMonth;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nklcbdty.api.calendar.dto.CalendarDayDto;
+import com.nklcbdty.api.calendar.dto.CalendarJobDto;
+import com.nklcbdty.api.calendar.dto.CalendarMonthDto;
+import com.nklcbdty.api.crawler.service.JobService;
+import com.nklcbdty.common.crawler.repository.JobRepository;
+import com.nklcbdty.common.vo.Job_mst;
+
+@ExtendWith(MockitoExtension.class)
+class CalendarServiceTest {
+
+    @Mock
+    private JobRepository jobRepository;
+
+    private CalendarService calendarService() {
+        return new CalendarService(new JobService(jobRepository, new ObjectMapper()));
+    }
+
+    private Job_mst job(String annoId, String subject, String endDate) {
+        Job_mst j = new Job_mst();
+        j.setCompanyCd("NAVER");
+        j.setAnnoId(annoId);
+        j.setAnnoSubject(subject);
+        j.setSubJobCdNm("백엔드");
+        j.setEndDate(endDate);
+        return j;
+    }
+
+    private void givenJobs(Job_mst... jobs) {
+        when(jobRepository.findAllByCompanyCdAndSubJobCdNmIsNotNullOrderByEndDateAsc("NAVER"))
+            .thenReturn(Arrays.asList(jobs));
+    }
+
+    @Test
+    @DisplayName("같은 날 마감되는 공고는 한 날짜로 묶이고, 날짜는 오름차순으로 나온다")
+    void groupsJobsByDeadlineDate() {
+        givenJobs(
+            job("3", "8월 20일 마감", "2099-08-20 18:00:00"),
+            job("1", "8월 10일 마감 A", "2099-08-10 23:59:00"),
+            job("2", "8월 10일 마감 B", "2099-08-10 12:00:00")
+        );
+
+        CalendarMonthDto result = calendarService().getMonthlyDeadlines(YearMonth.of(2099, 8), "NAVER");
+
+        assertThat(result.getYear()).isEqualTo(2099);
+        assertThat(result.getMonth()).isEqualTo(8);
+        assertThat(result.getTotalCount()).isEqualTo(3);
+        assertThat(result.getDays()).extracting(CalendarDayDto::getDate)
+            .containsExactly("2099-08-10", "2099-08-20");
+        // 하루 안에서는 마감 시간이 빠른 공고가 먼저
+        assertThat(result.getDays().get(0).getJobs()).extracting(CalendarJobDto::getAnnoSubject)
+            .containsExactly("8월 10일 마감 B", "8월 10일 마감 A");
+        assertThat(result.getDays().get(0).getCount()).isEqualTo(2);
+        assertThat(result.getDays().get(0).getJobs().get(0).getEndTime()).isEqualTo("12:00");
+    }
+
+    @Test
+    @DisplayName("다른 달에 마감되는 공고는 그 달 캘린더에 나오지 않는다")
+    void excludesOtherMonths() {
+        givenJobs(
+            job("1", "이번 달 마감", "2099-08-31 23:59:00"),
+            job("2", "다음 달 마감", "2099-09-01 00:00:00"),
+            job("3", "지난 달 마감", "2099-07-31 23:59:00")
+        );
+
+        CalendarMonthDto result = calendarService().getMonthlyDeadlines(YearMonth.of(2099, 8), "NAVER");
+
+        assertThat(result.getTotalCount()).isEqualTo(1);
+        assertThat(result.getDays()).hasSize(1);
+        assertThat(result.getDays().get(0).getJobs()).extracting(CalendarJobDto::getAnnoSubject)
+            .containsExactly("이번 달 마감");
+    }
+
+    @Test
+    @DisplayName("마감일이 없는 상시채용과 손상된 마감일 공고는 캘린더에서 제외된다")
+    void excludesJobsWithoutUsableDeadline() {
+        givenJobs(
+            job("1", "마감일 있는 공고", "2099-08-15 18:00:00"),
+            job("2", "상시채용(null)", null),
+            job("3", "상시채용(영입종료시)", "영입종료시"),
+            job("4", "손상 데이터", "error")
+        );
+
+        CalendarMonthDto result = calendarService().getMonthlyDeadlines(YearMonth.of(2099, 8), "NAVER");
+
+        assertThat(result.getTotalCount()).isEqualTo(1);
+        assertThat(result.getDays().get(0).getJobs()).extracting(CalendarJobDto::getAnnoSubject)
+            .containsExactly("마감일 있는 공고");
+    }
+
+    @Test
+    @DisplayName("크롤 중복으로 같은 annoId 가 여러 건이어도 캘린더에는 한 건만 나온다")
+    void deduplicatesSameAnnoId() {
+        givenJobs(
+            job("12345", "Product Data Analyst", "2099-08-15 18:00:00"),
+            job("12345", "Product Data Analyst", "2099-08-15 18:00:00")
+        );
+
+        CalendarMonthDto result = calendarService().getMonthlyDeadlines(YearMonth.of(2099, 8), "NAVER");
+
+        assertThat(result.getTotalCount()).isEqualTo(1);
+        assertThat(result.getDays().get(0).getCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("이미 지난 마감도 그 달 캘린더에는 남고, closed=true 로 표시된다")
+    void keepsPastDeadlinesMarkedClosed() {
+        givenJobs(
+            job("1", "이미 마감된 공고", "2000-01-10 18:00:00"),
+            job("2", "아직 열린 공고", "2099-08-10 18:00:00")
+        );
+        CalendarService service = calendarService();
+
+        CalendarMonthDto past = service.getMonthlyDeadlines(YearMonth.of(2000, 1), "NAVER");
+        assertThat(past.getTotalCount()).isEqualTo(1);
+        assertThat(past.getDays().get(0).getJobs().get(0).isClosed()).isTrue();
+
+        CalendarMonthDto future = service.getMonthlyDeadlines(YearMonth.of(2099, 8), "NAVER");
+        assertThat(future.getDays().get(0).getJobs().get(0).isClosed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("company=ALL 이면 전체 회사 공고를 보고, 회사명은 한글로 채워진다")
+    void allCompaniesAndKoreanCompanyName() {
+        Job_mst naver = job("1", "네이버 공고", "2099-08-05 18:00:00");
+        Job_mst kakao = job("2", "카카오 공고", "2099-08-06 18:00:00");
+        kakao.setCompanyCd("KAKAO");
+        when(jobRepository.findAllBySubJobCdNmIsNotNull()).thenReturn(Arrays.asList(naver, kakao));
+
+        CalendarMonthDto result = calendarService().getMonthlyDeadlines(YearMonth.of(2099, 8), "ALL");
+
+        assertThat(result.getTotalCount()).isEqualTo(2);
+        assertThat(result.getDays()).flatExtracting(CalendarDayDto::getJobs)
+            .extracting(CalendarJobDto::getCompanyNm)
+            .containsExactly("네이버", "카카오");
+    }
+
+    @Test
+    @DisplayName("달 정보(1일 요일 · 일수)를 함께 줘서 프론트가 달력 칸을 배치할 수 있다")
+    void includesMonthMetadata() {
+        when(jobRepository.findAllBySubJobCdNmIsNotNull()).thenReturn(Arrays.asList());
+
+        CalendarMonthDto result = calendarService().getMonthlyDeadlines(YearMonth.of(2026, 8), "ALL");
+
+        assertThat(result.getFirstDayOfWeek()).isEqualTo(6); // 2026-08-01 은 토요일
+        assertThat(result.getLengthOfMonth()).isEqualTo(31);
+        assertThat(result.getDays()).isEmpty();
+    }
+}


### PR DESCRIPTION
## 무엇

`GET /api/calendar/deadlines?year=&month=&company=` — 그 달에 마감되는 공고를 날짜별로 묶어 준다. 프론트([nklcbdty-ui](https://github.com/kingle1024/nklcbdty-ui)) 캘린더 화면이 쓰는 API.

```json
{
  "year": 2026, "month": 8,
  "firstDayOfWeek": 6, "lengthOfMonth": 31, "totalCount": 12,
  "days": [
    { "date": "2026-08-10", "dayOfWeek": 1, "count": 2,
      "jobs": [ { "id": 41, "annoId": "12345", "companyCd": "NAVER", "companyNm": "네이버",
                  "annoSubject": "백엔드 엔지니어", "subJobCdNm": "백엔드",
                  "endDate": "2026-08-10 12:00:00", "endTime": "12:00",
                  "workplace": "...", "jobDetailLink": "...", "closed": false } ] }
  ]
}
```

- year/month 생략 시 이번 달, company 생략 시 전체. 범위 밖 값은 400.
- 로그인 없이 보는 화면이라 `AllowedPaths` 에 공개 경로로 등록.

## 목록(/api/list) 과 다른 점

- 마감일이 없는 상시채용(`영입종료시`/null)과 크롤 실패로 `"error"` 가 박힌 공고는 캘린더에 찍을 날짜가 없어 제외.
- **이미 지난 마감을 걸러내지 않는다.** 지난 달로 이동해도 그 달 마감 공고가 보여야 하므로, 대신 `closed: true` 로 표시한다.
- 마감 여부가 시시각각 바뀌므로 목록 API 와 달리 응답을 캐싱하지 않는다.
- 중복(annoId) 제거 규칙은 목록과 동일.

## 리팩터링

`end_date` 문자열 해석(포맷 2종 · 상시채용/손상 데이터 판별)이 목록과 캘린더 양쪽에 필요해 `JobEndDates` 로 뽑았다. `JobService` 의 기존 private 헬퍼를 대체한 것이라 목록 동작은 그대로다(`JobServiceListOrderTest` 통과로 고정).

## 테스트

- `CalendarServiceTest` 7건 — 날짜별 그룹핑/정렬, 다른 달 제외, 상시채용·손상 데이터 제외, 중복 제거, 지난 마감 `closed` 표시, 회사 필터, 달 메타데이터
- `CalendarControllerTest` 4건 — 파라미터 기본값(이번 달·ALL), 잘못된 month/year 400
- 기존 `JobServiceListOrderTest` · `CacheFallbackTest` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public calendar API for viewing monthly job deadlines.
  * Supports filtering by year, month, and company, with sensible defaults.
  * Displays daily deadlines, job counts, closing times, company names, and closed-status indicators.
  * Excludes ongoing, invalid, and corrupted deadline entries while removing duplicates.
* **Bug Fixes**
  * Improved handling of varied and invalid deadline formats.
* **Tests**
  * Added coverage for calendar retrieval, validation, filtering, grouping, ordering, and status mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->