### PR TITLE
⚡ Perf: 캘린더 응답도 Redis 캐싱 + 비로그인 공개 경로 테스트

### DIFF
--- a/src/main/java/com/nklcbdty/api/calendar/controller/CalendarController.java
+++ b/src/main/java/com/nklcbdty/api/calendar/controller/CalendarController.java
@@ -3,7 +3,9 @@ package com.nklcbdty.api.calendar.controller;
 import java.time.YearMonth;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,8 +36,14 @@ public class CalendarController {
         this.calendarService = calendarService;
     }
 
-    @GetMapping("/deadlines")
-    public ResponseEntity<?> deadlines(
+    /**
+     * 응답은 캐시된 JSON 문자열을 그대로 흘려보낸다.
+     *
+     * <p>charset 을 명시하는 이유는 목록 API({@code /api/list})와 같다 — String 반환 시
+     * StringHttpMessageConverter 의 프레임워크 기본 charset 이 ISO-8859-1 이라 한글이 깨질 수 있다.</p>
+     */
+    @GetMapping(value = "/deadlines", produces = "application/json;charset=UTF-8")
+    public String deadlines(
         @RequestParam(required = false) Integer year,
         @RequestParam(required = false) Integer month,
         @RequestParam(defaultValue = "ALL") String company) {
@@ -45,14 +53,21 @@ public class CalendarController {
         final int targetMonth = month != null ? month : thisMonth.getMonthValue();
 
         if (targetMonth < 1 || targetMonth > 12) {
-            return ResponseEntity.badRequest().body("month 는 1~12 여야 합니다. (요청값: " + targetMonth + ")");
+            throw new IllegalArgumentException("month 는 1~12 여야 합니다. (요청값: " + targetMonth + ")");
         }
         if (targetYear < MIN_YEAR || targetYear > MAX_YEAR) {
-            return ResponseEntity.badRequest()
-                                 .body("year 는 " + MIN_YEAR + "~" + MAX_YEAR + " 여야 합니다. (요청값: " + targetYear + ")");
+            throw new IllegalArgumentException(
+                "year 는 " + MIN_YEAR + "~" + MAX_YEAR + " 여야 합니다. (요청값: " + targetYear + ")");
         }
 
-        return ResponseEntity.ok(
-            calendarService.getMonthlyDeadlines(YearMonth.of(targetYear, targetMonth), company));
+        return calendarService.getMonthlyDeadlinesAsJson(YearMonth.of(targetYear, targetMonth), company);
+    }
+
+    /** 잘못된 year/month 는 400. 이 컨트롤러 안에서만 처리해 다른 API 의 예외 처리에 영향을 주지 않는다. */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleInvalidParameter(IllegalArgumentException e) {
+        return ResponseEntity.badRequest()
+                             .contentType(MediaType.valueOf("text/plain;charset=UTF-8"))
+                             .body(e.getMessage());
     }
 }

--- a/src/main/java/com/nklcbdty/api/calendar/dto/CalendarJobDto.java
+++ b/src/main/java/com/nklcbdty/api/calendar/dto/CalendarJobDto.java
@@ -30,10 +30,10 @@ public class CalendarJobDto {
     private final String endDate;
     /** 마감 시각 (HH:mm). 캘린더 칸에 "18:00 마감" 처럼 쓴다. */
     private final String endTime;
-    /** 조회 시점 기준 이미 마감된 공고인지. 지난 날짜를 흐리게 처리하는 데 쓴다. */
-    private final boolean closed;
 
-    public CalendarJobDto(Job_mst job, LocalDateTime now) {
+    // 마감 여부(closed)는 일부러 담지 않는다. "지금" 기준 값이라 응답이 시점에 따라 달라지면
+    // Redis 캐싱이 stale 을 만든다. endDate 를 그대로 주고 판정은 프론트가 한다.
+    public CalendarJobDto(Job_mst job) {
         this.id = job.getId();
         this.annoId = job.getAnnoId();
         this.companyCd = job.getCompanyCd();
@@ -49,6 +49,5 @@ public class CalendarJobDto {
         // 캘린더에 올라온 공고는 마감일시가 이미 파싱된 것들이라 null 이 아니지만, 방어적으로 처리한다.
         final LocalDateTime endDateTime = JobEndDates.parse(job.getEndDate());
         this.endTime = endDateTime != null ? endDateTime.format(TIME_FORMATTER) : null;
-        this.closed = endDateTime != null && endDateTime.isBefore(now);
     }
 }

--- a/src/main/java/com/nklcbdty/api/calendar/service/CalendarService.java
+++ b/src/main/java/com/nklcbdty/api/calendar/service/CalendarService.java
@@ -1,7 +1,6 @@
 package com.nklcbdty.api.calendar.service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,11 +8,15 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nklcbdty.api.calendar.dto.CalendarDayDto;
 import com.nklcbdty.api.calendar.dto.CalendarJobDto;
 import com.nklcbdty.api.calendar.dto.CalendarMonthDto;
+import com.nklcbdty.api.common.CacheConfig;
 import com.nklcbdty.api.crawler.common.JobEndDates;
 import com.nklcbdty.api.crawler.service.JobService;
 import com.nklcbdty.common.vo.Job_mst;
@@ -23,10 +26,30 @@ import com.nklcbdty.common.vo.Job_mst;
 public class CalendarService {
 
     private final JobService jobService;
+    private final ObjectMapper objectMapper;
 
     @Autowired
-    public CalendarService(JobService jobService) {
+    public CalendarService(JobService jobService, ObjectMapper objectMapper) {
         this.jobService = jobService;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * {@code /api/calendar/deadlines} 응답 JSON. 캐시 히트 시 Redis GET 한 번으로 끝난다.
+     *
+     * <p>목록({@code /api/list})과 같은 이유로 캐싱한다 — 전건 조회 + 중복제거 + 문자열 날짜 파싱을
+     * 달을 넘길 때마다 다시 하기 때문이다. 캐싱해도 안전한 이유는 {@link CacheConfig#JOB_CALENDAR}
+     * 주석 참고. 무효화는 목록 캐시와 같은 지점(크롤 저장 · 공고 삭제)에서 함께 일어난다.</p>
+     */
+    @Cacheable(cacheNames = CacheConfig.JOB_CALENDAR, key = "#company + ':' + #yearMonth")
+    public String getMonthlyDeadlinesAsJson(YearMonth yearMonth, String company) {
+        try {
+            return objectMapper.writeValueAsString(getMonthlyDeadlines(yearMonth, company));
+        } catch (JsonProcessingException e) {
+            // 직렬화 실패는 설정/모델 문제이므로 조용히 넘기지 않는다.
+            throw new IllegalStateException(
+                "캘린더 JSON 직렬화 실패 company=" + company + ", yearMonth=" + yearMonth, e);
+        }
     }
 
     /**
@@ -38,15 +61,13 @@ public class CalendarService {
         final List<Job_mst> jobs =
             jobService.findClosingBetween(company, yearMonth.atDay(1), yearMonth.atEndOfMonth());
 
-        final LocalDateTime now = LocalDateTime.now();
-
         // TreeMap: 날짜 오름차순. 하루 안에서는 findClosingBetween 이 준 마감 임박순을 유지한다.
         final Map<LocalDate, List<CalendarJobDto>> jobsByDate = new TreeMap<>();
         for (Job_mst job : jobs) {
             // findClosingBetween 이 마감일시 파싱 가능한 공고만 주므로 parse 결과는 null 이 아니다.
             final LocalDate endDay = JobEndDates.parse(job.getEndDate()).toLocalDate();
             jobsByDate.computeIfAbsent(endDay, key -> new ArrayList<>())
-                      .add(new CalendarJobDto(job, now));
+                      .add(new CalendarJobDto(job));
         }
 
         final List<CalendarDayDto> days = new ArrayList<>();

--- a/src/main/java/com/nklcbdty/api/common/CacheConfig.java
+++ b/src/main/java/com/nklcbdty/api/common/CacheConfig.java
@@ -41,6 +41,15 @@ public class CacheConfig implements CachingConfigurer {
     public static final String CATEGORY_LIST = "categoryList";
 
     /**
+     * {@code /api/calendar/deadlines} 응답. 키는 {@code company:yyyy-MM} 이다.
+     *
+     * <p>목록과 같은 전건 조회·중복제거·날짜 파싱을 매번 다시 하므로 같은 이유로 캐싱한다.
+     * 달을 넘길 때마다 원본을 때리던 것이 캐시 히트로 끝난다. 응답에 "지금 기준 마감 여부" 같은
+     * 시점 의존 값을 담지 않기 때문에(마감 판정은 프론트가 endDate 로 한다) 캐싱해도 안전하다.</p>
+     */
+    public static final String JOB_CALENDAR = "jobCalendar";
+
+    /**
      * 무효화를 놓친 경우의 안전망. 크롤 후 @CacheEvict 가 정상 동작하면 여기까지 오지 않는다.
      * 아침에 한 번 채우고 하루 방치하면 그날 올라온 공고가 안 보이므로 짧게 잡는다.
      */

--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -503,7 +503,7 @@ public class CrawlerCommonService {
      * <p>크롤 중간에 일어나는 다른 쓰기(getNotSaveJobItem 의 기존 row 갱신, reconcileEndedJobs 의
      * 종료 마킹)는 전부 이 호출보다 앞이라, 여기서 한 번 비우면 그 변경분까지 같이 반영된다.</p>
      */
-    @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
+    @CacheEvict(cacheNames = { CacheConfig.JOB_LIST, CacheConfig.JOB_CALENDAR }, allEntries = true)
     public List<Job_mst> saveAll(List<Job_mst> result) {
         return crawlerRepository.saveAll(result);
     }

--- a/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/JobService.java
@@ -172,13 +172,13 @@ public class JobService {
     }
 
     @Transactional
-    @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
+    @CacheEvict(cacheNames = { CacheConfig.JOB_LIST, CacheConfig.JOB_CALENDAR }, allEntries = true)
     public void deleteByCompany(String company_cd) {
         jobRepository.deleteByCompanyCd(company_cd);
     }
 
     // company=ALL 캐시도 같이 틀어지므로 특정 키만 지우지 않고 전체를 비운다.
-    @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
+    @CacheEvict(cacheNames = { CacheConfig.JOB_LIST, CacheConfig.JOB_CALENDAR }, allEntries = true)
     public void deleteAll() {
         jobRepository.deleteAllInBatch();
     }

--- a/src/main/java/com/nklcbdty/api/jobdelete/service/JobDeleteRequestService.java
+++ b/src/main/java/com/nklcbdty/api/jobdelete/service/JobDeleteRequestService.java
@@ -79,7 +79,7 @@ public class JobDeleteRequestService {
     /** 승인: 상태 변경 + 실제 공고(job_mst) 삭제 */
     @Transactional
     // 공고를 실제로 지우므로 목록 캐시를 비운다. 안 지우면 삭제된 공고가 최대 TTL 동안 계속 보인다.
-    @CacheEvict(cacheNames = CacheConfig.JOB_LIST, allEntries = true)
+    @CacheEvict(cacheNames = { CacheConfig.JOB_LIST, CacheConfig.JOB_CALENDAR }, allEntries = true)
     public JobDeleteRequest approve(Long id, String processedBy) {
         JobDeleteRequest request = repository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("삭제요청을 찾을 수 없습니다. id=" + id));

--- a/src/test/java/com/nklcbdty/api/calendar/controller/CalendarControllerTest.java
+++ b/src/test/java/com/nklcbdty/api/calendar/controller/CalendarControllerTest.java
@@ -6,19 +6,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 import java.time.YearMonth;
-import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.nklcbdty.api.calendar.dto.CalendarMonthDto;
 import com.nklcbdty.api.calendar.service.CalendarService;
 
 class CalendarControllerTest {
@@ -35,8 +34,8 @@ class CalendarControllerTest {
     @Test
     @DisplayName("GET /api/calendar/deadlines: year/month 로 그 달 캘린더를 조회한다")
     void deadlines_returnsRequestedMonth() throws Exception {
-        when(calendarService.getMonthlyDeadlines(YearMonth.of(2026, 8), "NAVER"))
-            .thenReturn(new CalendarMonthDto(YearMonth.of(2026, 8), 0, Collections.emptyList()));
+        when(calendarService.getMonthlyDeadlinesAsJson(YearMonth.of(2026, 8), "NAVER"))
+            .thenReturn("{\"year\":2026,\"month\":8,\"totalCount\":0,\"days\":[]}");
 
         mockMvc.perform(get("/api/calendar/deadlines?year=2026&month=8&company=NAVER"))
             .andExpect(status().isOk())
@@ -49,13 +48,24 @@ class CalendarControllerTest {
     @DisplayName("year/month 를 안 주면 이번 달, company 를 안 주면 전체 회사를 조회한다")
     void deadlines_defaultsToThisMonthAndAllCompanies() throws Exception {
         YearMonth thisMonth = YearMonth.now();
-        when(calendarService.getMonthlyDeadlines(any(), any()))
-            .thenReturn(new CalendarMonthDto(thisMonth, 0, Collections.emptyList()));
+        when(calendarService.getMonthlyDeadlinesAsJson(any(), any())).thenReturn("{}");
 
         mockMvc.perform(get("/api/calendar/deadlines"))
             .andExpect(status().isOk());
 
-        verify(calendarService).getMonthlyDeadlines(eq(thisMonth), eq("ALL"));
+        verify(calendarService).getMonthlyDeadlinesAsJson(eq(thisMonth), eq("ALL"));
+    }
+
+    @Test
+    @DisplayName("한글이 깨지지 않도록 UTF-8 로 응답한다")
+    void deadlines_respondsAsUtf8Json() throws Exception {
+        when(calendarService.getMonthlyDeadlinesAsJson(any(), any()))
+            .thenReturn("{\"companyNm\":\"네이버\"}");
+
+        mockMvc.perform(get("/api/calendar/deadlines"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json;charset=UTF-8"))
+            .andExpect(jsonPath("$.companyNm").value("네이버"));
     }
 
     @Test

--- a/src/test/java/com/nklcbdty/api/calendar/service/CalendarServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/calendar/service/CalendarServiceTest.java
@@ -26,8 +26,10 @@ class CalendarServiceTest {
     @Mock
     private JobRepository jobRepository;
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     private CalendarService calendarService() {
-        return new CalendarService(new JobService(jobRepository, new ObjectMapper()));
+        return new CalendarService(new JobService(jobRepository, objectMapper), objectMapper);
     }
 
     private Job_mst job(String annoId, String subject, String endDate) {
@@ -117,8 +119,8 @@ class CalendarServiceTest {
     }
 
     @Test
-    @DisplayName("이미 지난 마감도 그 달 캘린더에는 남고, closed=true 로 표시된다")
-    void keepsPastDeadlinesMarkedClosed() {
+    @DisplayName("이미 지난 마감도 그 달 캘린더에는 남는다 (마감 여부 판정은 프론트가 endDate 로 한다)")
+    void keepsPastDeadlines() {
         givenJobs(
             job("1", "이미 마감된 공고", "2000-01-10 18:00:00"),
             job("2", "아직 열린 공고", "2099-08-10 18:00:00")
@@ -127,10 +129,33 @@ class CalendarServiceTest {
 
         CalendarMonthDto past = service.getMonthlyDeadlines(YearMonth.of(2000, 1), "NAVER");
         assertThat(past.getTotalCount()).isEqualTo(1);
-        assertThat(past.getDays().get(0).getJobs().get(0).isClosed()).isTrue();
+        assertThat(past.getDays().get(0).getJobs().get(0).getEndDate()).isEqualTo("2000-01-10 18:00:00");
 
         CalendarMonthDto future = service.getMonthlyDeadlines(YearMonth.of(2099, 8), "NAVER");
-        assertThat(future.getDays().get(0).getJobs().get(0).isClosed()).isFalse();
+        assertThat(future.getTotalCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("응답 JSON 은 '지금' 에 의존하는 값을 담지 않는다 — 그래야 캐싱해도 안전하다")
+    void jsonHasNoTimeDependentField() {
+        givenJobs(job("1", "마감 지난 공고", "2000-01-10 18:00:00"));
+
+        String json = calendarService().getMonthlyDeadlinesAsJson(YearMonth.of(2000, 1), "NAVER");
+
+        assertThat(json).doesNotContain("closed");
+        assertThat(json).contains("\"endDate\":\"2000-01-10 18:00:00\"", "\"endTime\":\"18:00\"");
+    }
+
+    @Test
+    @DisplayName("JSON 응답은 객체 응답을 그대로 직렬화한 것이다")
+    void jsonMatchesObject() throws Exception {
+        givenJobs(job("1", "공고", "2099-08-10 18:00:00"));
+        CalendarService service = calendarService();
+
+        String json = service.getMonthlyDeadlinesAsJson(YearMonth.of(2099, 8), "NAVER");
+
+        assertThat(json).isEqualTo(
+            objectMapper.writeValueAsString(service.getMonthlyDeadlines(YearMonth.of(2099, 8), "NAVER")));
     }
 
     @Test

--- a/src/test/java/com/nklcbdty/api/common/security/AllowedPathsTest.java
+++ b/src/test/java/com/nklcbdty/api/common/security/AllowedPathsTest.java
@@ -1,0 +1,43 @@
+package com.nklcbdty.api.common.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 로그인 없이 볼 수 있어야 하는 화면의 API 가 공개 경로로 남아 있는지 고정한다.
+ *
+ * <p>{@code AuthFilter} 가 실제로 쓰는 것과 같은 방식(와일드카드를 정규식으로 바꿔 매칭)으로 검사한다.
+ * 여기서 빠지면 비로그인 사용자에게 401 이 떨어진다.</p>
+ */
+class AllowedPathsTest {
+
+    private boolean isPublic(String requestUri) {
+        return Arrays.stream(AllowedPaths.getAllowedPaths())
+                     .anyMatch(path -> requestUri.matches(path.replace("**", ".*")));
+    }
+
+    @Test
+    @DisplayName("채용 캘린더는 로그인 없이 볼 수 있다")
+    void calendarIsPublic() {
+        assertThat(isPublic("/api/calendar/deadlines")).isTrue();
+    }
+
+    @Test
+    @DisplayName("공고 목록 · 카테고리 · 회사 목록도 로그인 없이 볼 수 있다")
+    void publicListScreensStayPublic() {
+        assertThat(isPublic("/api/list")).isTrue();
+        assertThat(isPublic("/api/category/list")).isTrue();
+        assertThat(isPublic("/api/company/list")).isTrue();
+    }
+
+    @Test
+    @DisplayName("마이페이지처럼 로그인이 필요한 경로는 공개 목록에 없다")
+    void privatePathsStayPrivate() {
+        assertThat(isPublic("/mypage")).isFalse();
+        assertThat(isPublic("/api/admin/subscriptions")).isFalse();
+    }
+}


### PR DESCRIPTION
## 왜

캘린더가 캐시를 안 타서 달을 넘길 때마다 원본을 때리고 있었다. 목록(`/api/list`)과 똑같이 전건 조회 + annoId 중복제거 + 문자열 날짜 파싱 + 직렬화를 매 요청 다시 한다.

## 무엇

- `jobCalendar` 캐시 추가. 키는 `company:yyyy-MM`, 값은 목록과 같은 방식(직렬화까지 끝낸 JSON 문자열)이라 캐시 히트가 Redis GET 한 번으로 끝난다.
- 무효화는 목록 캐시와 같은 지점에서 함께 — 크롤 저장(`CrawlerCommonService#saveAll`), 회사별/전체 삭제(`JobService`), 삭제요청 승인(`JobDeleteRequestService#approve`).
- **응답에서 `closed` 제거.** "지금 기준 마감 여부"는 시점 의존 값이라 캐싱하면 stale 이 된다. `endDate` 를 그대로 주고 마감 판정은 프론트가 한다 (프론트 PR에서 처리).
- 400 응답은 컨트롤러 내부 `@ExceptionHandler` 로 옮겼다. 성공 응답이 캐시된 JSON 문자열이라 반환 타입을 `String` 으로 바꾸면서 정리한 것으로, 동작(잘못된 year/month → 400)은 그대로다.

## 비로그인 접근

`/api/calendar/**` 는 처음부터 `AllowedPaths` 공개 경로라 로그인 없이 열린다. 운영에서 401 이 나는 건 백엔드가 아직 배포되지 않아서다(Cloudtype 배포 잡 비활성). 이런 게 조용히 깨지지 않도록 `AllowedPathsTest` 를 추가해 `AuthFilter` 와 같은 매칭 방식으로 공개 여부를 고정했다.

## 테스트

21건 통과 — `CalendarServiceTest` 9(응답에 시점 의존 값이 없음 · JSON 이 객체 응답과 동일 포함), `CalendarControllerTest` 5(UTF-8 응답 포함), `AllowedPathsTest` 3, 기존 `JobServiceListOrderTest` 3 · `CacheFallbackTest` 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)