### PR TITLE
✨ Feat: 자유게시판 API — 글/댓글 작성·수정·삭제

### DIFF
--- a/src/main/java/com/nklcbdty/api/board/config/BoardSchemaInitializer.java
+++ b/src/main/java/com/nklcbdty/api/board/config/BoardSchemaInitializer.java
@@ -1,0 +1,65 @@
+package com.nklcbdty.api.board.config;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * spring.jpa.hibernate.ddl-auto=none 이므로 JPA 가 테이블을 만들지 않는다.
+ * 앱 기동 시 게시판 테이블이 없으면 생성한다(JobDeleteRequestSchemaInitializer 와 같은 방식).
+ */
+@Slf4j
+@Component
+public class BoardSchemaInitializer implements ApplicationRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public BoardSchemaInitializer(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        final String postDdl =
+            "CREATE TABLE IF NOT EXISTS board_post (" +
+            "  id BIGINT NOT NULL AUTO_INCREMENT," +
+            "  title VARCHAR(200) NOT NULL," +
+            "  content TEXT NOT NULL," +
+            "  author_id VARCHAR(100) NOT NULL," +
+            "  author_name VARCHAR(100) NULL," +
+            "  view_count INT NOT NULL DEFAULT 0," +
+            "  comment_count INT NOT NULL DEFAULT 0," +
+            "  deleted TINYINT(1) NOT NULL DEFAULT 0," +
+            "  insert_dts DATETIME NULL," +
+            "  update_dts DATETIME NULL," +
+            "  PRIMARY KEY (id)," +
+            "  KEY idx_bp_deleted_id (deleted, id)," +
+            "  KEY idx_bp_author (author_id)" +
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+        final String commentDdl =
+            "CREATE TABLE IF NOT EXISTS board_comment (" +
+            "  id BIGINT NOT NULL AUTO_INCREMENT," +
+            "  post_id BIGINT NOT NULL," +
+            "  content VARCHAR(1000) NOT NULL," +
+            "  author_id VARCHAR(100) NOT NULL," +
+            "  author_name VARCHAR(100) NULL," +
+            "  deleted TINYINT(1) NOT NULL DEFAULT 0," +
+            "  insert_dts DATETIME NULL," +
+            "  update_dts DATETIME NULL," +
+            "  PRIMARY KEY (id)," +
+            "  KEY idx_bc_post (post_id, deleted, id)" +
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+        try {
+            jdbcTemplate.execute(postDdl);
+            jdbcTemplate.execute(commentDdl);
+            log.info("[Board] board_post / board_comment 테이블 확인/생성 완료");
+        } catch (Exception e) {
+            log.error("[Board] 게시판 테이블 생성 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/controller/BoardController.java
+++ b/src/main/java/com/nklcbdty/api/board/controller/BoardController.java
@@ -1,0 +1,170 @@
+package com.nklcbdty.api.board.controller;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nklcbdty.api.board.dto.BoardCommentRequest;
+import com.nklcbdty.api.board.dto.BoardPostRequest;
+import com.nklcbdty.api.board.exception.BoardForbiddenException;
+import com.nklcbdty.api.board.exception.BoardNotFoundException;
+import com.nklcbdty.api.board.service.BoardService;
+import com.nklcbdty.api.board.vo.BoardComment;
+import com.nklcbdty.api.board.vo.BoardPost;
+import com.nklcbdty.api.common.filter.AuthFilter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 자유게시판 API.
+ * - GET    /api/board/posts                    : 목록(page, size, keyword)
+ * - GET    /api/board/posts/{id}               : 상세 + 댓글
+ * - POST   /api/board/posts                    : 글 작성(로그인 필요)
+ * - PUT    /api/board/posts/{id}               : 글 수정(작성자만)
+ * - DELETE /api/board/posts/{id}               : 글 삭제(작성자만)
+ * - POST   /api/board/posts/{id}/comments      : 댓글 작성(로그인 필요)
+ * - DELETE /api/board/comments/{commentId}     : 댓글 삭제(작성자만)
+ *
+ * 목록/상세는 로그인 없이 볼 수 있어야 해서 경로 전체를 AllowedPaths 에 등록했다.
+ * 그래서 AuthFilter 가 userId 속성을 넣어주지 않으므로, 로그인 사용자는 이 컨트롤러에서
+ * 토큰을 직접 해석해 확인한다(작성 계열은 userId 가 없으면 401).
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/board")
+public class BoardController {
+
+    private final BoardService boardService;
+    private final AuthFilter authFilter;
+
+    public BoardController(BoardService boardService, AuthFilter authFilter) {
+        this.boardService = boardService;
+        this.authFilter = authFilter;
+    }
+
+    @GetMapping("/posts")
+    public ResponseEntity<?> list(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size,
+        @RequestParam(required = false) String keyword
+    ) {
+        return ResponseEntity.ok(boardService.list(page, size, keyword));
+    }
+
+    @GetMapping("/posts/{id}")
+    public ResponseEntity<?> detail(@PathVariable Long id, HttpServletRequest request) {
+        try {
+            return ResponseEntity.ok(boardService.detail(id, currentUserId(request)));
+        } catch (BoardNotFoundException e) {
+            return error(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @PostMapping("/posts")
+    public ResponseEntity<?> create(@RequestBody BoardPostRequest dto, HttpServletRequest request) {
+        String userId = currentUserId(request);
+        if (userId == null) {
+            return error(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        try {
+            BoardPost saved = boardService.create(dto.getTitle(), dto.getContent(), userId);
+            return ResponseEntity.ok(Map.of("id", saved.getId()));
+        } catch (IllegalArgumentException e) {
+            return error(HttpStatus.BAD_REQUEST, e.getMessage());
+        }
+    }
+
+    @PutMapping("/posts/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody BoardPostRequest dto,
+                                    HttpServletRequest request) {
+        String userId = currentUserId(request);
+        if (userId == null) {
+            return error(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        try {
+            BoardPost saved = boardService.update(id, dto.getTitle(), dto.getContent(), userId);
+            return ResponseEntity.ok(Map.of("id", saved.getId()));
+        } catch (IllegalArgumentException e) {
+            return error(HttpStatus.BAD_REQUEST, e.getMessage());
+        } catch (BoardNotFoundException e) {
+            return error(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (BoardForbiddenException e) {
+            return error(HttpStatus.FORBIDDEN, e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/posts/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id, HttpServletRequest request) {
+        String userId = currentUserId(request);
+        if (userId == null) {
+            return error(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        try {
+            boardService.delete(id, userId);
+            return ResponseEntity.ok(Map.of("status", "deleted"));
+        } catch (BoardNotFoundException e) {
+            return error(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (BoardForbiddenException e) {
+            return error(HttpStatus.FORBIDDEN, e.getMessage());
+        }
+    }
+
+    @PostMapping("/posts/{id}/comments")
+    public ResponseEntity<?> addComment(@PathVariable Long id, @RequestBody BoardCommentRequest dto,
+                                        HttpServletRequest request) {
+        String userId = currentUserId(request);
+        if (userId == null) {
+            return error(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        try {
+            BoardComment saved = boardService.addComment(id, dto.getContent(), userId);
+            return ResponseEntity.ok(Map.of("id", saved.getId()));
+        } catch (IllegalArgumentException e) {
+            return error(HttpStatus.BAD_REQUEST, e.getMessage());
+        } catch (BoardNotFoundException e) {
+            return error(HttpStatus.NOT_FOUND, e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long commentId, HttpServletRequest request) {
+        String userId = currentUserId(request);
+        if (userId == null) {
+            return error(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+
+        try {
+            boardService.deleteComment(commentId, userId);
+            return ResponseEntity.ok(Map.of("status", "deleted"));
+        } catch (BoardNotFoundException e) {
+            return error(HttpStatus.NOT_FOUND, e.getMessage());
+        } catch (BoardForbiddenException e) {
+            return error(HttpStatus.FORBIDDEN, e.getMessage());
+        }
+    }
+
+    /** Authorization 헤더의 토큰에서 userId. 토큰이 없거나 유효하지 않으면 null(=비로그인). */
+    private String currentUserId(HttpServletRequest request) {
+        return authFilter.getUserIdByRequest(request);
+    }
+
+    private ResponseEntity<Map<String, String>> error(HttpStatus status, String message) {
+        return ResponseEntity.status(status)
+            .body(Map.of("message", message == null ? "요청을 처리할 수 없습니다." : message));
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/dto/BoardCommentDto.java
+++ b/src/main/java/com/nklcbdty/api/board/dto/BoardCommentDto.java
@@ -1,0 +1,26 @@
+package com.nklcbdty.api.board.dto;
+
+import java.time.LocalDateTime;
+
+import com.nklcbdty.api.board.vo.BoardComment;
+
+/**
+ * 댓글 응답. authorId 는 내보내지 않고 "내 댓글인지"(mine) 만 알려준다.
+ */
+public record BoardCommentDto(
+    Long id,
+    String content,
+    String authorName,
+    LocalDateTime insertDts,
+    boolean mine
+) {
+    public static BoardCommentDto of(BoardComment comment, String viewerId) {
+        return new BoardCommentDto(
+            comment.getId(),
+            comment.getContent(),
+            comment.getAuthorName(),
+            comment.getInsertDts(),
+            viewerId != null && viewerId.equals(comment.getAuthorId())
+        );
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/dto/BoardCommentRequest.java
+++ b/src/main/java/com/nklcbdty/api/board/dto/BoardCommentRequest.java
@@ -1,0 +1,9 @@
+package com.nklcbdty.api.board.dto;
+
+import lombok.Data;
+
+/** 댓글 작성 요청 */
+@Data
+public class BoardCommentRequest {
+    private String content;
+}

--- a/src/main/java/com/nklcbdty/api/board/dto/BoardPostDetailDto.java
+++ b/src/main/java/com/nklcbdty/api/board/dto/BoardPostDetailDto.java
@@ -1,0 +1,38 @@
+package com.nklcbdty.api.board.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.nklcbdty.api.board.vo.BoardPost;
+
+/**
+ * 상세 응답. mine 이 true 면 프론트에서 수정/삭제 버튼을 보여준다.
+ * (서버도 수정/삭제 시 작성자를 다시 확인한다 — 이 값은 화면 표시용)
+ */
+public record BoardPostDetailDto(
+    Long id,
+    String title,
+    String content,
+    String authorName,
+    int viewCount,
+    int commentCount,
+    LocalDateTime insertDts,
+    LocalDateTime updateDts,
+    boolean mine,
+    List<BoardCommentDto> comments
+) {
+    public static BoardPostDetailDto of(BoardPost post, List<BoardCommentDto> comments, String viewerId) {
+        return new BoardPostDetailDto(
+            post.getId(),
+            post.getTitle(),
+            post.getContent(),
+            post.getAuthorName(),
+            post.getViewCount(),
+            post.getCommentCount(),
+            post.getInsertDts(),
+            post.getUpdateDts(),
+            viewerId != null && viewerId.equals(post.getAuthorId()),
+            comments
+        );
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/dto/BoardPostPageDto.java
+++ b/src/main/java/com/nklcbdty/api/board/dto/BoardPostPageDto.java
@@ -1,0 +1,26 @@
+package com.nklcbdty.api.board.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.nklcbdty.api.board.vo.BoardPost;
+
+/** 목록 + 페이징 정보. Page 를 그대로 내보내면 응답 구조가 스프링 구현에 종속되므로 필요한 값만 담는다. */
+public record BoardPostPageDto(
+    List<BoardPostSummaryDto> items,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages
+) {
+    public static BoardPostPageDto of(Page<BoardPost> page) {
+        return new BoardPostPageDto(
+            page.getContent().stream().map(BoardPostSummaryDto::of).toList(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/dto/BoardPostRequest.java
+++ b/src/main/java/com/nklcbdty/api/board/dto/BoardPostRequest.java
@@ -1,0 +1,10 @@
+package com.nklcbdty.api.board.dto;
+
+import lombok.Data;
+
+/** 글 작성/수정 요청 */
+@Data
+public class BoardPostRequest {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/nklcbdty/api/board/dto/BoardPostSummaryDto.java
+++ b/src/main/java/com/nklcbdty/api/board/dto/BoardPostSummaryDto.java
@@ -1,0 +1,26 @@
+package com.nklcbdty.api.board.dto;
+
+import java.time.LocalDateTime;
+
+import com.nklcbdty.api.board.vo.BoardPost;
+
+/** 목록용. 본문은 담지 않는다. */
+public record BoardPostSummaryDto(
+    Long id,
+    String title,
+    String authorName,
+    int viewCount,
+    int commentCount,
+    LocalDateTime insertDts
+) {
+    public static BoardPostSummaryDto of(BoardPost post) {
+        return new BoardPostSummaryDto(
+            post.getId(),
+            post.getTitle(),
+            post.getAuthorName(),
+            post.getViewCount(),
+            post.getCommentCount(),
+            post.getInsertDts()
+        );
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/exception/BoardForbiddenException.java
+++ b/src/main/java/com/nklcbdty/api/board/exception/BoardForbiddenException.java
@@ -1,0 +1,8 @@
+package com.nklcbdty.api.board.exception;
+
+/** 작성자가 아닌 사용자가 수정/삭제를 시도한 경우. 컨트롤러에서 403 으로 변환한다. */
+public class BoardForbiddenException extends RuntimeException {
+    public BoardForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/exception/BoardNotFoundException.java
+++ b/src/main/java/com/nklcbdty/api/board/exception/BoardNotFoundException.java
@@ -1,0 +1,8 @@
+package com.nklcbdty.api.board.exception;
+
+/** 글/댓글이 없거나 이미 삭제된 경우. 컨트롤러에서 404 로 변환한다. */
+public class BoardNotFoundException extends RuntimeException {
+    public BoardNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/repository/BoardCommentRepository.java
+++ b/src/main/java/com/nklcbdty/api/board/repository/BoardCommentRepository.java
@@ -1,0 +1,18 @@
+package com.nklcbdty.api.board.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nklcbdty.api.board.vo.BoardComment;
+
+public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
+
+    /** 특정 글의 댓글(등록순) */
+    List<BoardComment> findByPostIdAndDeletedFalseOrderByIdAsc(Long postId);
+
+    Optional<BoardComment> findByIdAndDeletedFalse(Long id);
+
+    int countByPostIdAndDeletedFalse(Long postId);
+}

--- a/src/main/java/com/nklcbdty/api/board/repository/BoardPostRepository.java
+++ b/src/main/java/com/nklcbdty/api/board/repository/BoardPostRepository.java
@@ -1,0 +1,40 @@
+package com.nklcbdty.api.board.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.nklcbdty.api.board.vo.BoardPost;
+
+public interface BoardPostRepository extends JpaRepository<BoardPost, Long> {
+
+    /** 목록(최신순). 삭제된 글은 제외한다. */
+    Page<BoardPost> findByDeletedFalseOrderByIdDesc(Pageable pageable);
+
+    /** 제목/본문 검색 */
+    @Query("select p from BoardPost p where p.deleted = false "
+        + "and (lower(p.title) like lower(concat('%', :keyword, '%')) "
+        + "  or lower(p.content) like lower(concat('%', :keyword, '%'))) "
+        + "order by p.id desc")
+    Page<BoardPost> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    Optional<BoardPost> findByIdAndDeletedFalse(Long id);
+
+    /**
+     * 조회수 증가. 엔티티를 읽어 save 하면 @UpdateTimestamp 때문에 수정일시가 바뀌므로
+     * 조회수만 UPDATE 한다. 삭제된 글은 올리지 않는다.
+     */
+    @Modifying
+    @Query("update BoardPost p set p.viewCount = p.viewCount + 1 where p.id = :id and p.deleted = false")
+    void increaseViewCount(@Param("id") Long id);
+
+    /** 댓글 수 재계산 결과 반영 (댓글 등록/삭제 후) */
+    @Modifying
+    @Query("update BoardPost p set p.commentCount = :count where p.id = :id")
+    void updateCommentCount(@Param("id") Long id, @Param("count") int count);
+}

--- a/src/main/java/com/nklcbdty/api/board/service/BoardService.java
+++ b/src/main/java/com/nklcbdty/api/board/service/BoardService.java
@@ -1,0 +1,189 @@
+package com.nklcbdty.api.board.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nklcbdty.api.board.dto.BoardCommentDto;
+import com.nklcbdty.api.board.dto.BoardPostDetailDto;
+import com.nklcbdty.api.board.dto.BoardPostPageDto;
+import com.nklcbdty.api.board.exception.BoardForbiddenException;
+import com.nklcbdty.api.board.exception.BoardNotFoundException;
+import com.nklcbdty.api.board.repository.BoardCommentRepository;
+import com.nklcbdty.api.board.repository.BoardPostRepository;
+import com.nklcbdty.api.board.vo.BoardComment;
+import com.nklcbdty.api.board.vo.BoardPost;
+import com.nklcbdty.common.user.repository.UserRepository;
+import com.nklcbdty.common.vo.UserVo;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 자유게시판. 목록/상세는 로그인 없이 볼 수 있고 글/댓글 작성은 로그인이 필요하다.
+ * 수정/삭제는 작성자 본인만 가능하며, 삭제는 deleted 플래그로 처리한다.
+ */
+@Slf4j
+@Service
+public class BoardService {
+
+    private static final int MAX_PAGE_SIZE = 50;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    private final BoardPostRepository postRepository;
+    private final BoardCommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    public BoardService(BoardPostRepository postRepository, BoardCommentRepository commentRepository,
+                        UserRepository userRepository) {
+        this.postRepository = postRepository;
+        this.commentRepository = commentRepository;
+        this.userRepository = userRepository;
+    }
+
+    /** 목록. keyword 가 있으면 제목/본문 검색. */
+    @Transactional(readOnly = true)
+    public BoardPostPageDto list(int page, int size, String keyword) {
+        Pageable pageable = PageRequest.of(Math.max(page, 0), normalizeSize(size));
+        Page<BoardPost> found = (keyword == null || keyword.isBlank())
+            ? postRepository.findByDeletedFalseOrderByIdDesc(pageable)
+            : postRepository.searchByKeyword(keyword.trim(), pageable);
+        return BoardPostPageDto.of(found);
+    }
+
+    /**
+     * 상세. 조회수를 1 올린 뒤 읽으므로 화면에 방금 올라간 값이 그대로 보인다.
+     * viewerId 는 로그인 사용자(없으면 null) — 수정/삭제 버튼 표시 여부에 쓰인다.
+     */
+    @Transactional
+    public BoardPostDetailDto detail(Long id, String viewerId) {
+        postRepository.increaseViewCount(id);
+        BoardPost post = postRepository.findByIdAndDeletedFalse(id)
+            .orElseThrow(() -> new BoardNotFoundException("글을 찾을 수 없습니다. id=" + id));
+
+        List<BoardCommentDto> comments = commentRepository
+            .findByPostIdAndDeletedFalseOrderByIdAsc(id)
+            .stream()
+            .map(comment -> BoardCommentDto.of(comment, viewerId))
+            .toList();
+
+        return BoardPostDetailDto.of(post, comments, viewerId);
+    }
+
+    @Transactional
+    public BoardPost create(String title, String content, String authorId) {
+        BoardPost post = new BoardPost();
+        post.setTitle(validateTitle(title));
+        post.setContent(validateContent(content, BoardPost.MAX_CONTENT_LENGTH));
+        post.setAuthorId(authorId);
+        post.setAuthorName(resolveAuthorName(authorId));
+        return postRepository.save(post);
+    }
+
+    @Transactional
+    public BoardPost update(Long id, String title, String content, String requesterId) {
+        BoardPost post = findWritablePost(id, requesterId);
+        post.setTitle(validateTitle(title));
+        post.setContent(validateContent(content, BoardPost.MAX_CONTENT_LENGTH));
+        return postRepository.save(post);
+    }
+
+    /** 글 삭제(플래그). 딸린 댓글도 같이 감춘다. */
+    @Transactional
+    public void delete(Long id, String requesterId) {
+        BoardPost post = findWritablePost(id, requesterId);
+        post.setDeleted(true);
+        postRepository.save(post);
+
+        List<BoardComment> comments = commentRepository.findByPostIdAndDeletedFalseOrderByIdAsc(id);
+        comments.forEach(comment -> comment.setDeleted(true));
+        commentRepository.saveAll(comments);
+        log.info("[Board] 글 삭제 id={} 댓글 {}건 함께 삭제", id, comments.size());
+    }
+
+    @Transactional
+    public BoardComment addComment(Long postId, String content, String authorId) {
+        // 삭제된 글에는 댓글을 달 수 없다
+        postRepository.findByIdAndDeletedFalse(postId)
+            .orElseThrow(() -> new BoardNotFoundException("글을 찾을 수 없습니다. id=" + postId));
+
+        BoardComment comment = new BoardComment();
+        comment.setPostId(postId);
+        comment.setContent(validateContent(content, BoardComment.MAX_CONTENT_LENGTH));
+        comment.setAuthorId(authorId);
+        comment.setAuthorName(resolveAuthorName(authorId));
+        BoardComment saved = commentRepository.save(comment);
+
+        refreshCommentCount(postId);
+        return saved;
+    }
+
+    @Transactional
+    public void deleteComment(Long commentId, String requesterId) {
+        BoardComment comment = commentRepository.findByIdAndDeletedFalse(commentId)
+            .orElseThrow(() -> new BoardNotFoundException("댓글을 찾을 수 없습니다. id=" + commentId));
+        if (!comment.getAuthorId().equals(requesterId)) {
+            throw new BoardForbiddenException("본인이 쓴 댓글만 삭제할 수 있습니다.");
+        }
+
+        comment.setDeleted(true);
+        commentRepository.save(comment);
+        refreshCommentCount(comment.getPostId());
+    }
+
+    /** 목록에 보여줄 댓글 수를 실제 개수로 맞춘다. */
+    private void refreshCommentCount(Long postId) {
+        postRepository.updateCommentCount(postId, commentRepository.countByPostIdAndDeletedFalse(postId));
+    }
+
+    /** 수정/삭제 대상 글을 찾고 작성자 본인인지 확인한다. */
+    private BoardPost findWritablePost(Long id, String requesterId) {
+        BoardPost post = postRepository.findByIdAndDeletedFalse(id)
+            .orElseThrow(() -> new BoardNotFoundException("글을 찾을 수 없습니다. id=" + id));
+        if (!post.getAuthorId().equals(requesterId)) {
+            throw new BoardForbiddenException("본인이 쓴 글만 수정/삭제할 수 있습니다.");
+        }
+        return post;
+    }
+
+    /** user 테이블의 닉네임. 없으면 userId 를 대신 보여준다. */
+    private String resolveAuthorName(String userId) {
+        UserVo user = userRepository.findByUserId(userId);
+        if (user != null && user.getUsername() != null && !user.getUsername().isBlank()) {
+            return user.getUsername();
+        }
+        return userId;
+    }
+
+    private String validateTitle(String title) {
+        String trimmed = title == null ? "" : title.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("제목을 입력해주세요.");
+        }
+        if (trimmed.length() > BoardPost.MAX_TITLE_LENGTH) {
+            throw new IllegalArgumentException("제목은 " + BoardPost.MAX_TITLE_LENGTH + "자 이하로 입력해주세요.");
+        }
+        return trimmed;
+    }
+
+    private String validateContent(String content, int maxLength) {
+        String trimmed = content == null ? "" : content.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("내용을 입력해주세요.");
+        }
+        if (trimmed.length() > maxLength) {
+            throw new IllegalArgumentException("내용은 " + maxLength + "자 이하로 입력해주세요.");
+        }
+        return trimmed;
+    }
+
+    private int normalizeSize(int size) {
+        if (size <= 0) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+}

--- a/src/main/java/com/nklcbdty/api/board/vo/BoardComment.java
+++ b/src/main/java/com/nklcbdty/api/board/vo/BoardComment.java
@@ -1,0 +1,53 @@
+package com.nklcbdty.api.board.vo;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+/**
+ * 자유게시판 댓글. 글(BoardPost)과는 FK 없이 postId 로만 연결한다(기존 테이블들과 같은 방식).
+ * 삭제는 deleted 플래그로 처리한다.
+ */
+@Entity
+@Table(name = "board_comment")
+@Data
+public class BoardComment {
+
+    public static final int MAX_CONTENT_LENGTH = 1000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long postId;
+
+    @Column(nullable = false, length = MAX_CONTENT_LENGTH)
+    private String content;
+
+    /** 작성자 userId */
+    @Column(nullable = false, length = 100)
+    private String authorId;
+
+    /** 작성 시점의 닉네임 스냅샷 */
+    @Column(nullable = true, length = 100)
+    private String authorName;
+
+    @Column(nullable = false)
+    private boolean deleted;
+
+    @CreationTimestamp
+    private LocalDateTime insertDts;
+
+    @UpdateTimestamp
+    private LocalDateTime updateDts;
+}

--- a/src/main/java/com/nklcbdty/api/board/vo/BoardPost.java
+++ b/src/main/java/com/nklcbdty/api/board/vo/BoardPost.java
@@ -1,0 +1,62 @@
+package com.nklcbdty.api.board.vo;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+/**
+ * 자유게시판 글. 삭제는 실제 DELETE 대신 deleted 플래그로 처리한다(댓글이 딸려 있어 흔적을 남긴다).
+ * 작성자 닉네임(authorName)은 작성 시점 값을 복사해 둔다 — 나중에 닉네임이 바뀌어도 글 목록 조회에
+ * user 테이블을 조인하지 않도록.
+ */
+@Entity
+@Table(name = "board_post")
+@Data
+public class BoardPost {
+
+    public static final int MAX_TITLE_LENGTH = 200;
+    public static final int MAX_CONTENT_LENGTH = 10000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = MAX_TITLE_LENGTH)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    /** 작성자 userId. "kakao@{id}" 또는 "local@{id}" */
+    @Column(nullable = false, length = 100)
+    private String authorId;
+
+    /** 작성 시점의 닉네임 스냅샷 */
+    @Column(nullable = true, length = 100)
+    private String authorName;
+
+    @Column(nullable = false)
+    private int viewCount;
+
+    /** 목록에서 "제목 [3]" 처럼 보여주기 위한 댓글 수. 댓글 등록/삭제 시 함께 갱신한다. */
+    @Column(nullable = false)
+    private int commentCount;
+
+    @Column(nullable = false)
+    private boolean deleted;
+
+    @CreationTimestamp
+    private LocalDateTime insertDts;
+
+    @UpdateTimestamp
+    private LocalDateTime updateDts;
+}

--- a/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
+++ b/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
@@ -26,6 +26,9 @@ public enum AllowedPaths {
     CRALWER("/api/crawler"),
     JOB_DELETE_REQUEST("/api/job-delete-requests"),
     JOB_DELETE_REQUEST_ALL("/api/job-delete-requests/**"),
+    // 자유게시판. 목록/상세는 로그인 없이 보므로 공개하고, 작성/수정/삭제는
+    // BoardController 가 토큰을 직접 확인해 비로그인 요청을 401 로 막는다.
+    BOARD_ALL("/api/board/**"),
     COUNT_BY_DATE("/api/statistics/count-by-date"),
     TEST("/api/test"),
     SEARCH("/api/job/**"),

--- a/src/test/java/com/nklcbdty/api/board/service/BoardServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/board/service/BoardServiceTest.java
@@ -1,0 +1,210 @@
+package com.nklcbdty.api.board.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nklcbdty.api.board.dto.BoardPostDetailDto;
+import com.nklcbdty.api.board.exception.BoardForbiddenException;
+import com.nklcbdty.api.board.exception.BoardNotFoundException;
+import com.nklcbdty.api.board.repository.BoardCommentRepository;
+import com.nklcbdty.api.board.repository.BoardPostRepository;
+import com.nklcbdty.api.board.vo.BoardComment;
+import com.nklcbdty.api.board.vo.BoardPost;
+import com.nklcbdty.common.user.repository.UserRepository;
+import com.nklcbdty.common.vo.UserVo;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTest {
+
+    private static final String AUTHOR = "local@7";
+    private static final String OTHER = "kakao@99";
+
+    @Mock
+    private BoardPostRepository postRepository;
+
+    @Mock
+    private BoardCommentRepository commentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private BoardService service;
+
+    private BoardPost post(Long id, String authorId) {
+        BoardPost post = new BoardPost();
+        post.setId(id);
+        post.setTitle("제목");
+        post.setContent("내용");
+        post.setAuthorId(authorId);
+        post.setAuthorName("작성자");
+        return post;
+    }
+
+    // ------------------------------------------------------------------- 작성
+
+    @Test
+    void create_작성시점_닉네임을_스냅샷으로_저장한다() {
+        when(userRepository.findByUserId(AUTHOR))
+            .thenReturn(UserVo.builder().userId(AUTHOR).username("길동이").build());
+        when(postRepository.save(any(BoardPost.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        BoardPost saved = service.create("  첫 글  ", "  내용입니다  ", AUTHOR);
+
+        assertThat(saved.getTitle()).isEqualTo("첫 글");
+        assertThat(saved.getContent()).isEqualTo("내용입니다");
+        assertThat(saved.getAuthorId()).isEqualTo(AUTHOR);
+        assertThat(saved.getAuthorName()).isEqualTo("길동이");
+    }
+
+    @Test
+    void create_닉네임이_없으면_userId를_보여준다() {
+        when(userRepository.findByUserId(AUTHOR)).thenReturn(null);
+        when(postRepository.save(any(BoardPost.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        BoardPost saved = service.create("제목", "내용", AUTHOR);
+
+        assertThat(saved.getAuthorName()).isEqualTo(AUTHOR);
+    }
+
+    @Test
+    void create_제목이_비어있으면_저장하지_않는다() {
+        assertThatThrownBy(() -> service.create("   ", "내용", AUTHOR))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(postRepository, never()).save(any(BoardPost.class));
+    }
+
+    // --------------------------------------------------------------- 수정/삭제
+
+    @Test
+    void update_작성자가_아니면_거부한다() {
+        when(postRepository.findByIdAndDeletedFalse(1L)).thenReturn(Optional.of(post(1L, AUTHOR)));
+
+        assertThatThrownBy(() -> service.update(1L, "바뀐 제목", "바뀐 내용", OTHER))
+            .isInstanceOf(BoardForbiddenException.class);
+
+        verify(postRepository, never()).save(any(BoardPost.class));
+    }
+
+    @Test
+    void delete_글과_딸린_댓글을_함께_삭제표시한다() {
+        BoardComment comment = new BoardComment();
+        comment.setId(11L);
+        comment.setPostId(1L);
+        comment.setAuthorId(OTHER);
+
+        when(postRepository.findByIdAndDeletedFalse(1L)).thenReturn(Optional.of(post(1L, AUTHOR)));
+        when(commentRepository.findByPostIdAndDeletedFalseOrderByIdAsc(1L)).thenReturn(List.of(comment));
+        when(postRepository.save(any(BoardPost.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.delete(1L, AUTHOR);
+
+        ArgumentCaptor<BoardPost> captor = ArgumentCaptor.forClass(BoardPost.class);
+        verify(postRepository).save(captor.capture());
+        assertThat(captor.getValue().isDeleted()).isTrue();
+        assertThat(comment.isDeleted()).isTrue();
+        verify(commentRepository, times(1)).saveAll(anyList());
+    }
+
+    @Test
+    void delete_없는_글이면_404로_다룬다() {
+        when(postRepository.findByIdAndDeletedFalse(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.delete(404L, AUTHOR))
+            .isInstanceOf(BoardNotFoundException.class);
+    }
+
+    // ------------------------------------------------------------------- 댓글
+
+    @Test
+    void addComment_등록하면_글의_댓글수를_실제개수로_맞춘다() {
+        when(postRepository.findByIdAndDeletedFalse(1L)).thenReturn(Optional.of(post(1L, AUTHOR)));
+        when(userRepository.findByUserId(OTHER))
+            .thenReturn(UserVo.builder().userId(OTHER).username("지나가던행인").build());
+        when(commentRepository.save(any(BoardComment.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(commentRepository.countByPostIdAndDeletedFalse(1L)).thenReturn(3);
+
+        BoardComment saved = service.addComment(1L, "좋은 글이네요", OTHER);
+
+        assertThat(saved.getPostId()).isEqualTo(1L);
+        assertThat(saved.getAuthorName()).isEqualTo("지나가던행인");
+        verify(postRepository, times(1)).updateCommentCount(1L, 3);
+    }
+
+    @Test
+    void addComment_삭제된_글에는_달_수_없다() {
+        when(postRepository.findByIdAndDeletedFalse(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addComment(1L, "댓글", OTHER))
+            .isInstanceOf(BoardNotFoundException.class);
+
+        verify(commentRepository, never()).save(any(BoardComment.class));
+    }
+
+    @Test
+    void deleteComment_남의_댓글은_지울_수_없다() {
+        BoardComment comment = new BoardComment();
+        comment.setId(11L);
+        comment.setPostId(1L);
+        comment.setAuthorId(AUTHOR);
+
+        when(commentRepository.findByIdAndDeletedFalse(11L)).thenReturn(Optional.of(comment));
+
+        assertThatThrownBy(() -> service.deleteComment(11L, OTHER))
+            .isInstanceOf(BoardForbiddenException.class);
+
+        assertThat(comment.isDeleted()).isFalse();
+        verify(postRepository, never()).updateCommentCount(anyLong(), anyInt());
+    }
+
+    // ------------------------------------------------------------------- 상세
+
+    @Test
+    void detail_조회수를_올리고_내글여부를_알려준다() {
+        BoardComment comment = new BoardComment();
+        comment.setId(11L);
+        comment.setPostId(1L);
+        comment.setContent("댓글 내용");
+        comment.setAuthorId(OTHER);
+
+        when(postRepository.findByIdAndDeletedFalse(1L)).thenReturn(Optional.of(post(1L, AUTHOR)));
+        when(commentRepository.findByPostIdAndDeletedFalseOrderByIdAsc(1L)).thenReturn(List.of(comment));
+
+        BoardPostDetailDto detail = service.detail(1L, AUTHOR);
+
+        verify(postRepository, times(1)).increaseViewCount(1L);
+        assertThat(detail.mine()).isTrue();
+        assertThat(detail.comments()).hasSize(1);
+        // 댓글은 다른 사람이 썼으므로 삭제 버튼이 보이면 안 된다
+        assertThat(detail.comments().get(0).mine()).isFalse();
+    }
+
+    @Test
+    void detail_비로그인이면_내글여부는_모두_false다() {
+        when(postRepository.findByIdAndDeletedFalse(1L)).thenReturn(Optional.of(post(1L, AUTHOR)));
+        when(commentRepository.findByPostIdAndDeletedFalseOrderByIdAsc(1L)).thenReturn(List.of());
+
+        BoardPostDetailDto detail = service.detail(1L, null);
+
+        assertThat(detail.mine()).isFalse();
+    }
+}

--- a/src/test/java/com/nklcbdty/api/common/security/AllowedPathsTest.java
+++ b/src/test/java/com/nklcbdty/api/common/security/AllowedPathsTest.java
@@ -35,6 +35,13 @@ class AllowedPathsTest {
     }
 
     @Test
+    @DisplayName("자유게시판 목록·상세는 로그인 없이 볼 수 있다")
+    void boardIsPublic() {
+        assertThat(isPublic("/api/board/posts")).isTrue();
+        assertThat(isPublic("/api/board/posts/12")).isTrue();
+    }
+
+    @Test
     @DisplayName("마이페이지처럼 로그인이 필요한 경로는 공개 목록에 없다")
     void privatePathsStayPrivate() {
         assertThat(isPublic("/mypage")).isFalse();


### PR DESCRIPTION
## 왜

게시판이 아예 없었다. 지난번에 만든 건 `/email`(문의 및 건의사항)이라 게시판과는 별개였다.

## 무엇

`com.nklcbdty.api.board` 패키지 신규. 구조는 기존 `jobdelete` 패키지를 그대로 따랐다.

| 메서드 | 경로 | 권한 |
|---|---|---|
| GET | `/api/board/posts?page&size&keyword` | 공개 |
| GET | `/api/board/posts/{id}` | 공개 (댓글 포함) |
| POST | `/api/board/posts` | 로그인 |
| PUT | `/api/board/posts/{id}` | 작성자 |
| DELETE | `/api/board/posts/{id}` | 작성자 (댓글 함께 삭제) |
| POST | `/api/board/posts/{id}/comments` | 로그인 |
| DELETE | `/api/board/comments/{commentId}` | 작성자 |

## 봐주셨으면 하는 곳

- **인증** — 목록/상세가 비로그인에 열려야 해서 `/api/board/**` 를 `AllowedPaths` 에 공개 등록했다. 그러면 `AuthFilter` 가 `userId` 속성을 넣어주지 않으므로, `BoardController` 가 `AuthFilter.getUserIdByRequest()` 로 토큰을 직접 해석해 비로그인 작성은 401, 남의 글 수정/삭제는 403 으로 막는다.
- **테이블** — `ddl-auto=none` 이라 `BoardSchemaInitializer` 가 기동 시 `board_post` / `board_comment` 를 `CREATE TABLE IF NOT EXISTS` 한다. 배포 시 수동 DDL·마이그레이션 불필요.
- **삭제는 플래그** — 댓글이 딸려 있어 실제 DELETE 대신 `deleted` 처리. 글을 지우면 댓글도 함께 감춘다.
- **닉네임 스냅샷** — 작성 시점 닉네임을 복사해 둬서 목록 조회 때 user 테이블을 조인하지 않는다.
- **조회수** — 엔티티를 save 하면 `@UpdateTimestamp` 때문에 수정일시가 바뀌므로 조회수만 별도 UPDATE 한다.

## 검증

- `./gradlew compileJava` 통과
- `BoardServiceTest` 11개 통과 (작성자 검증, 삭제 시 댓글 연동, 댓글 수 갱신, 비로그인 `mine=false` 등)
- `AllowedPathsTest` 에 게시판 공개 경로 테스트 1개 추가

## 함께 봐야 하는 PR

프론트: kingle1024/nklcbdty-ui#claude/board-ui (아래 코멘트에 링크)

## 남겨둔 것

- **관리자 모더레이션 없음.** 작성자 본인만 지울 수 있어서 스팸 글을 지울 방법이 지금은 없다. `/api/admin/board/**` + 관리자 화면이 다음 작업으로 적당하다.
- 도배 방지(rate limit), 첨부파일 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public free-board with paginated listing, keyword search, and detailed post views.
  * Added authenticated post and comment creation, editing, and deletion.
  * Added view and comment counts, author information, ownership indicators, and soft deletion.
  * Added validation and clear responses for missing content or unauthorized actions.
* **Tests**
  * Added coverage for board operations, validation, permissions, deletion, counting, and public access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->