### PR TITLE
🚨 Fix: 크롤 저장 후 외부 KV 목록 캐시 갱신 — 새 공고가 6시간 안 보이던 문제

### DIFF
--- a/src/main/java/com/nklcbdty/api/common/KvCacheRefresher.java
+++ b/src/main/java/com/nklcbdty/api/common/KvCacheRefresher.java
@@ -1,0 +1,151 @@
+package com.nklcbdty.api.common;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.nklcbdty.api.crawler.common.CompanyEnums;
+import com.nklcbdty.api.crawler.service.JobService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 프론트가 목록을 읽어가는 외부 KV 캐시를 크롤 직후 최신 응답으로 덮어쓴다.
+ *
+ * <p>목록 캐시는 3층이고 무효화 주체가 층마다 다르다.
+ * <ol>
+ *   <li>Redis(스프링 {@code jobList}) — {@link com.nklcbdty.api.crawler.common.CrawlerCommonService#saveAll} 의 {@code @CacheEvict}</li>
+ *   <li><b>외부 KV</b> — 지금까지 무효화 경로가 아예 없어 TTL(6시간) 만료만 기다렸다</li>
+ *   <li>브라우저 메모리 — 새로고침</li>
+ * </ol>
+ * 프론트({@code nklcbdty-ui/src/common/kvCache.ts})는 2번을 <b>먼저</b> 읽고 미스일 때만 원본 API 로
+ * 폴백한다. 그래서 크롤이 새 공고를 넣어도 최대 6시간 동안 화면에 안 나왔다. 실제로 배민 공고를
+ * 되살린 뒤에도 API 는 10건인데 화면은 0건인 상태가 이어졌다.</p>
+ *
+ * <p>지우지 않고 <b>덮어쓰는</b> 이유: KV 서버가 DELETE 를 받는지 알 수 없고(프론트는 GET/PUT 만 쓴다),
+ * 지우기만 하면 다음 방문자가 원본 API 비용(예열 후에도 1.5~3초)을 물기 때문이다. 어차피 새 응답을
+ * 만들어야 한다면 그대로 얹는 편이 낫다.</p>
+ *
+ * <p>{@code KV_ORIGIN_IP} / {@code KV_ORIGIN_HOST} 가 없으면 아무것도 하지 않는다. 프론트의
+ * {@code docker/40-kv-origin.sh} 가 같은 환경변수로 {@code /kv} 프록시를 켜고 끄는 것과 같은 규칙이다.</p>
+ */
+@Component
+@Slf4j
+public class KvCacheRefresher {
+
+    /** 프론트 kvCache.ts 의 키 규칙과 반드시 같아야 한다. */
+    private static final String KEY_PREFIX = "nklcb:list:";
+    private static final String ALL = "ALL";
+
+    /** 프론트가 쓰는 TTL(6시간)과 맞춘다. 어긋나면 한쪽만 먼저 만료돼 동작이 헷갈린다. */
+    private static final long TTL_SECONDS = 6 * 60 * 60;
+
+    private final RestTemplate restTemplate;
+    private final JobService jobService;
+    private final String originIp;
+    private final String originHost;
+
+    public KvCacheRefresher(
+        RestTemplate restTemplate,
+        JobService jobService,
+        @Value("${kv.origin.ip:}") String originIp,
+        @Value("${kv.origin.host:}") String originHost) {
+        this.restTemplate = restTemplate;
+        this.jobService = jobService;
+        this.originIp = originIp == null ? "" : originIp.trim();
+        this.originHost = originHost == null ? "" : originHost.trim();
+    }
+
+    private boolean isEnabled() {
+        return !originIp.isEmpty() && !originHost.isEmpty();
+    }
+
+    /**
+     * 한 회사를 크롤한 뒤 호출한다. 그 회사 키와 전체 목록 키만 갱신한다.
+     *
+     * <p>크롤은 해당 회사 행만 건드리므로 다른 회사 키는 여전히 유효하다. 9개를 전부 다시 만들면
+     * 회사당 1.5~3초씩 크롤 응답이 늘어나는데, 배치가 회사별로 7번 호출하는 구조라 그대로 낭비가 된다.</p>
+     */
+    public void refreshAfterCrawl(String companyCd) {
+        if (!isEnabled()) {
+            log.debug("KV 오리진 미설정 — 갱신 건너뜀 (TTL 만료까지 stale)");
+            return;
+        }
+        Set<String> targets = new LinkedHashSet<>();
+        String normalized = normalize(companyCd);
+        if (normalized != null) {
+            targets.add(normalized);
+        }
+        targets.add(ALL);
+        refresh(targets);
+    }
+
+    /** {@code /api/crawler?company=all} 처럼 전 회사가 바뀐 뒤 호출한다. */
+    public void refreshAll() {
+        if (!isEnabled()) {
+            log.debug("KV 오리진 미설정 — 갱신 건너뜀 (TTL 만료까지 stale)");
+            return;
+        }
+        Set<String> targets = new LinkedHashSet<>();
+        targets.add(ALL);
+        for (CompanyEnums company : CompanyEnums.values()) {
+            targets.add(company.getCompanyCd());
+        }
+        refresh(targets);
+    }
+
+    /**
+     * 컨트롤러 파라미터("baemin")를 KV 키("BAEMIN")로 맞춘다.
+     * enum 에 없는 값이면 null 을 주고 전체 키만 갱신하게 한다.
+     */
+    private String normalize(String companyCd) {
+        CompanyEnums company = CompanyEnums.fromCompanyCd(companyCd);
+        return company == null ? null : company.getCompanyCd();
+    }
+
+    private void refresh(Set<String> companyCds) {
+        List<String> failed = new ArrayList<>();
+
+        for (String companyCd : companyCds) {
+            try {
+                // saveAll 의 @CacheEvict 가 끝난 뒤에 불려야 최신 값이 나온다.
+                // (@CacheEvict 는 기본이 beforeInvocation=false 라 메서드 반환 후 비워진다)
+                String json = jobService.listAsJson(companyCd);
+                put(companyCd, json);
+            } catch (Exception e) {
+                // KV 갱신 실패가 크롤을 깨서는 안 된다. 실패해도 TTL 이 걷어간다.
+                failed.add(companyCd);
+                log.warn("KV 갱신 실패 company={} - {}", companyCd, e.getMessage());
+            }
+        }
+
+        if (failed.isEmpty()) {
+            log.info("KV 목록 캐시 갱신 완료 — {}", companyCds);
+        } else {
+            log.warn("KV 목록 캐시 일부 갱신 실패 — 대상={} 실패={}", companyCds, failed);
+        }
+    }
+
+    private void put(String companyCd, String json) {
+        String url = "http://" + originIp + "/api/kv/" + KEY_PREFIX + companyCd + "?ttl=" + TTL_SECONDS;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        // 오리진이 이름 기반 가상호스트라 Host 헤더가 없으면 404 가 난다.
+        // (프론트 nginx 의 proxy_set_header Host 와 같은 이유)
+        headers.set(HttpHeaders.HOST, originHost);
+
+        HttpEntity<byte[]> request = new HttpEntity<>(json.getBytes(StandardCharsets.UTF_8), headers);
+        restTemplate.exchange(url, HttpMethod.PUT, request, String.class);
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/controller/JobController.java
+++ b/src/main/java/com/nklcbdty/api/crawler/controller/JobController.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nklcbdty.api.common.KvCacheRefresher;
 import com.nklcbdty.api.crawler.common.CrawlerCommonService;
 import com.nklcbdty.api.crawler.interfaces.JobCrawler;
 import com.nklcbdty.api.crawler.service.CoupangJobCrawlerService;
@@ -39,6 +41,7 @@ public class JobController {
     private final JobCrawler baeminJobCrawlerService;
     private final DaangnJobCrawlerService daangnJobCrawlerService;
     private final CrawlerCommonService commonService;
+    private final KvCacheRefresher kvCacheRefresher;
 
     @Autowired
     public JobController(
@@ -50,7 +53,8 @@ public class JobController {
         CoupangJobCrawlerService coupangJobCrawlerService,
         @Qualifier("baeminJobCrawlerService") JobCrawler baeminJobCrawlerService,
         DaangnJobCrawlerService daangnJobCrawlerService,
-        JobService jobService, CrawlerCommonService commonService) {
+        JobService jobService, CrawlerCommonService commonService,
+        KvCacheRefresher kvCacheRefresher) {
 
         this.naverJobCrawlerService = naverJobCrawlerService;
         this.kakaoCrawlerService = kakaoCrawlerService;
@@ -62,6 +66,7 @@ public class JobController {
         this.baeminJobCrawlerService = baeminJobCrawlerService;
         this.daangnJobCrawlerService = daangnJobCrawlerService;
         this.commonService = commonService;
+        this.kvCacheRefresher = kvCacheRefresher;
     }
 
     /**
@@ -82,46 +87,22 @@ public class JobController {
         log.info("cralwer company : {}", company);
         try {
             switch (company) {
-                case "naver": {
-                    List<Job_mst> items = naverJobCrawlerService.crawlJobs().get();
-                    commonService.refineJobItemBygemini(items);
-                    return commonService.saveAll(items);
-                }
-                case "kakao": {
-                    List<Job_mst> items = kakaoCrawlerService.crawlJobs().get();
-                    commonService.refineJobItemBygemini(items);
-                    return commonService.saveAll(items);
-                }
-                case "line": {
-                    List<Job_mst> items = lineJobCrawlerService.crawlJobs().get();
-                    commonService.refineJobItemBygemini(items);
-                    return commonService.saveAll(items);
-                }
-                case "coupang": {
-                    List<Job_mst> items = coupangJobCrawlerService.crawlJobs().get();
-                    commonService.refineJobItemBygemini(items);
-                    return commonService.saveAll(items);
-                }
-                case "baemin": {
-                    List<Job_mst> items = baeminJobCrawlerService.crawlJobs().get();
-                    commonService.refineJobItemBygemini(items);
-                    return commonService.saveAll(items);
-                }
-                case "daangn": {
-                    List<Job_mst> items = daangnJobCrawlerService.crawlJobs().get();
-                    commonService.refineJobItemBygemini(items);
-                    return commonService.saveAll(items);
-                }
-                case "toss": {
-                    List<Job_mst> items = tossJobCrawlerService.crawlJobs().get();
-                    commonService.refineJobItemBygemini(items);
-                    return commonService.saveAll(items);
-                }
-                case "yanolja": {
-                    List<Job_mst> items = yanoljaCralwerService.crawlJobs().get();
-                    commonService.refineJobItemBygemini(items);
-                    return commonService.saveAll(items);
-                }
+                case "naver":
+                    return crawlSaveAndRefresh(naverJobCrawlerService::crawlJobs, "NAVER");
+                case "kakao":
+                    return crawlSaveAndRefresh(kakaoCrawlerService::crawlJobs, "KAKAO");
+                case "line":
+                    return crawlSaveAndRefresh(lineJobCrawlerService::crawlJobs, "LINE");
+                case "coupang":
+                    return crawlSaveAndRefresh(coupangJobCrawlerService::crawlJobs, "COUPANG");
+                case "baemin":
+                    return crawlSaveAndRefresh(baeminJobCrawlerService::crawlJobs, "BAEMIN");
+                case "daangn":
+                    return crawlSaveAndRefresh(daangnJobCrawlerService::crawlJobs, "DAANGN");
+                case "toss":
+                    return crawlSaveAndRefresh(tossJobCrawlerService::crawlJobs, "TOSS");
+                case "yanolja":
+                    return crawlSaveAndRefresh(yanoljaCralwerService::crawlJobs, "YANOLJA");
                 case "all": {
                     jobService.deleteAll();
 
@@ -157,7 +138,9 @@ public class JobController {
                         log.info("Combined results count: {}", combinedResults.size());
 
                         // 모든 비동기 작업이 완료된 후에 결과를 반환합니다.
-                        return commonService.saveAll(combinedResults);
+                        List<Job_mst> saved = commonService.saveAll(combinedResults);
+                        kvCacheRefresher.refreshAll();
+                        return saved;
 
                     } catch (InterruptedException | ExecutionException e) {
                         log.error("Error during async crawler execution", e);
@@ -174,5 +157,25 @@ public class JobController {
             log.error("Error during async crawler execution", e);
         }
         return Collections.emptyList();
+    }
+
+    /**
+     * 회사 단건 크롤: 크롤 → LLM 보정 → 저장 → KV 목록 캐시 갱신.
+     *
+     * <p>KV 갱신을 여기 묶어둔 이유는 저장 경로마다 따로 부르면 빠뜨리기 때문이다. 크롤러 타입이
+     * 제각각(일부만 {@link JobCrawler} 구현)이라 메서드 참조로 받는다.</p>
+     *
+     * <p>순서가 중요하다. {@code saveAll} 의 {@code @CacheEvict} 는 기본이
+     * {@code beforeInvocation=false} 라 메서드가 <b>반환된 뒤</b>에 Redis 를 비운다. 그 전에 목록을
+     * 만들면 방금 무효화될 예정인 옛 값을 그대로 KV 에 얹게 되므로, 반드시 저장이 끝난 다음에 부른다.</p>
+     */
+    private List<Job_mst> crawlSaveAndRefresh(
+        Supplier<CompletableFuture<List<Job_mst>>> crawl, String companyCd) throws Exception {
+
+        List<Job_mst> items = crawl.get().get();
+        commonService.refineJobItemBygemini(items);
+        List<Job_mst> saved = commonService.saveAll(items);
+        kvCacheRefresher.refreshAfterCrawl(companyCd);
+        return saved;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,12 @@ spring.datasource.username=${DATASOURCE_USERNAME}
 spring.datasource.password=${DATASOURCE_PASSWORD}
 ip2location.api.key=${IP2LOCATION_API_KEY}
 
+# 프론트가 목록을 읽어가는 외부 KV 캐시. 크롤 직후 최신 응답으로 덮어쓰는 데 쓴다.
+# 프론트(nklcbdty-ui) 의 docker/40-kv-origin.sh 와 같은 환경변수를 그대로 쓴다.
+# 비워두면 KV 갱신을 하지 않는다(로컬 개발 및 미설정 환경) — TTL 만료까지 stale 이 남을 뿐 오동작은 아니다.
+kv.origin.ip=${KV_ORIGIN_IP:}
+kv.origin.host=${KV_ORIGIN_HOST:}
+
 # KAKAO
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}

--- a/src/test/java/com/nklcbdty/api/common/KvCacheRefresherTest.java
+++ b/src/test/java/com/nklcbdty/api/common/KvCacheRefresherTest.java
@@ -1,0 +1,147 @@
+package com.nklcbdty.api.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.nklcbdty.api.crawler.service.JobService;
+
+// 프론트(kvCache.ts)는 /kv 를 먼저 읽고 미스일 때만 원본 API 로 폴백한다. 크롤이 KV 를 갱신하지
+// 않으면 새 공고가 TTL(6시간) 동안 화면에 안 나온다 — 배민 0건 사태의 마지막 원인이었다.
+class KvCacheRefresherTest {
+
+    private RestTemplate restTemplate;
+    private JobService jobService;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        jobService = mock(JobService.class);
+        when(jobService.listAsJson(anyString())).thenReturn("[]");
+    }
+
+    private KvCacheRefresher enabled() {
+        return new KvCacheRefresher(restTemplate, jobService, "10.0.0.5", "cache.example.com");
+    }
+
+    private List<String> capturedUrls() {
+        ArgumentCaptor<String> url = ArgumentCaptor.forClass(String.class);
+        verify(restTemplate, org.mockito.Mockito.atLeastOnce())
+            .exchange(url.capture(), eq(HttpMethod.PUT), any(HttpEntity.class), eq(String.class));
+        return new ArrayList<>(url.getAllValues());
+    }
+
+    @Test
+    @DisplayName("회사 단건 크롤 뒤에는 그 회사 키와 ALL 만 갱신한다")
+    void refreshesCompanyAndAllOnly() {
+        enabled().refreshAfterCrawl("BAEMIN");
+
+        List<String> urls = capturedUrls();
+        assertThat(urls).hasSize(2);
+        assertThat(urls).anyMatch(u -> u.contains("nklcb:list:BAEMIN"));
+        assertThat(urls).anyMatch(u -> u.contains("nklcb:list:ALL"));
+        // 안 바뀐 회사까지 다시 만들면 크롤 응답만 느려진다.
+        assertThat(urls).noneMatch(u -> u.contains("nklcb:list:NAVER"));
+    }
+
+    @Test
+    @DisplayName("컨트롤러 파라미터가 소문자여도 KV 키는 대문자로 맞춘다")
+    void normalizesCompanyCode() {
+        enabled().refreshAfterCrawl("baemin");
+
+        assertThat(capturedUrls()).anyMatch(u -> u.contains("nklcb:list:BAEMIN"));
+    }
+
+    @Test
+    @DisplayName("모르는 회사 코드면 ALL 만 갱신한다")
+    void unknownCompanyRefreshesAllOnly() {
+        enabled().refreshAfterCrawl("nosuchcompany");
+
+        List<String> urls = capturedUrls();
+        assertThat(urls).hasSize(1);
+        assertThat(urls.get(0)).contains("nklcb:list:ALL");
+    }
+
+    @Test
+    @DisplayName("전체 크롤 뒤에는 ALL + 회사 8개를 모두 갱신한다")
+    void refreshAllCoversEveryKey() {
+        enabled().refreshAll();
+
+        List<String> urls = capturedUrls();
+        assertThat(urls).hasSize(9);
+        assertThat(urls).anyMatch(u -> u.contains("nklcb:list:ALL"));
+        assertThat(urls).anyMatch(u -> u.contains("nklcb:list:YANOLJA"));
+    }
+
+    @Test
+    @DisplayName("TTL 과 Host 헤더를 프론트/nginx 와 같은 값으로 보낸다")
+    void sendsTtlAndHostHeader() {
+        enabled().refreshAfterCrawl("BAEMIN");
+
+        ArgumentCaptor<String> url = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<HttpEntity> entity = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate, org.mockito.Mockito.atLeastOnce())
+            .exchange(url.capture(), eq(HttpMethod.PUT), entity.capture(), eq(String.class));
+
+        assertThat(url.getAllValues()).allMatch(u -> u.startsWith("http://10.0.0.5/api/kv/"));
+        assertThat(url.getAllValues()).allMatch(u -> u.endsWith("?ttl=21600"));
+
+        HttpHeaders headers = entity.getValue().getHeaders();
+        assertThat(headers.getFirst(HttpHeaders.HOST)).isEqualTo("cache.example.com");
+    }
+
+    @Test
+    @DisplayName("KV 오리진 미설정이면 아무것도 하지 않는다 — 로컬/미설정 환경")
+    void disabledWhenOriginMissing() {
+        new KvCacheRefresher(restTemplate, jobService, "", "").refreshAfterCrawl("BAEMIN");
+        new KvCacheRefresher(restTemplate, jobService, "10.0.0.5", "").refreshAfterCrawl("BAEMIN");
+        new KvCacheRefresher(restTemplate, jobService, null, null).refreshAll();
+
+        verifyNoInteractions(restTemplate);
+        verify(jobService, never()).listAsJson(anyString());
+    }
+
+    @Test
+    @DisplayName("KV 가 죽어 있어도 크롤을 깨뜨리지 않고, 남은 키는 계속 시도한다")
+    void keepsGoingWhenKvFails() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.PUT), any(HttpEntity.class), eq(String.class)))
+            .thenThrow(new RestClientException("connection refused"));
+
+        // 예외가 밖으로 새어나가면 크롤 엔드포인트가 통째로 실패한다.
+        enabled().refreshAfterCrawl("BAEMIN");
+
+        assertThat(capturedUrls()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("목록 생성이 실패해도 나머지 키 갱신은 이어간다")
+    void keepsGoingWhenListFails() {
+        when(jobService.listAsJson("BAEMIN")).thenThrow(new IllegalStateException("직렬화 실패"));
+        when(jobService.listAsJson("ALL")).thenReturn("[]");
+
+        enabled().refreshAfterCrawl("BAEMIN");
+
+        List<String> urls = capturedUrls();
+        assertThat(urls).hasSize(1);
+        assertThat(urls.get(0)).contains("nklcb:list:ALL");
+    }
+}


### PR DESCRIPTION
## 문제

배민 공고를 되살려 API 는 10건을 내려주는데 화면은 계속 0건이었다. 목록 캐시가 3층인데 무효화 주체가 층마다 다르고, 그중 한 층에는 무효화 경로가 **아예 없었다.**

| 계층 | 무효화 |
|---|---|
| Redis (스프링 `jobList`) | `CrawlerCommonService#saveAll` 의 `@CacheEvict` |
| **외부 KV (TTL 6시간)** | **없음 — TTL 만료뿐** |
| 브라우저 메모리 | 새로고침 |

프론트(`nklcbdty-ui/src/common/kvCache.ts`)는 KV 를 **먼저** 읽고 미스일 때만 원본 API 로 폴백한다. 그래서 크롤이 새 공고를 넣어도 최대 6시간 화면에 안 나온다.

`cache-warmup.yml` 도 이걸 못 고친다. 서비스의 `/api/list` 만 불러 Redis 만 데우고, KV 는 브라우저가 채우는 구조라 손이 닿지 않는다.

## 해결

`KvCacheRefresher` 를 추가해 크롤 저장 직후 KV 를 최신 응답으로 덮어쓴다.

### 지우지 않고 덮어쓰는 이유

1. KV 서버가 DELETE 를 받는지 알 수 없다. 프론트는 GET/PUT 만 쓰고 오리진 API 명세를 확인할 방법이 없었다. PUT 은 동작이 확실하다.
2. 지우기만 하면 다음 방문자가 원본 API 비용(예열 후에도 1.5~3초)을 문다. 어차피 새 응답을 만들어야 한다면 그대로 얹는 편이 낫다.

### 갱신 범위는 2개뿐

크롤한 회사 키와 `ALL`. 크롤은 그 회사 행만 건드리므로 다른 회사 키는 여전히 유효하다. 9개를 전부 다시 만들면 회사당 +15~27초인데, 배치가 회사별로 7번 호출하니 그대로 낭비가 된다. `company=all` 일 때만 9개 전부 갱신한다.

### 순서 주의

`saveAll` 의 `@CacheEvict` 는 기본이 `beforeInvocation=false` 라 메서드가 **반환된 뒤** Redis 를 비운다. 그 전에 목록을 만들면 곧 무효화될 옛 값을 KV 에 얹게 되므로, 반드시 저장이 끝난 다음에 부른다. 주석으로 남겼다.

### JobController 정리

회사별로 거의 같던 8개 case 를 헬퍼 하나로 모았다(순 -37줄). 저장 경로마다 갱신을 따로 부르면 언젠가 빠뜨린다. 크롤러 타입이 제각각(8개 중 3개만 `JobCrawler` 구현)이라 메서드 참조로 받는다.

## 검증

- 신규 테스트 8개 통과 — 키 범위, 소문자 정규화, TTL(21600)/Host 헤더 일치, 미설정 시 no-op, **KV 장애 시 크롤을 깨지 않고 남은 키 계속 시도**
- 전체 133개 중 131개 통과. 실패 2개(`NklcbdtyApplicationTests.contextLoads` — 로컬 `DATASOURCE_URL` 미설정, `AdminSubscriptionServiceTest` — 메일)는 **이 PR 과 무관한 기존 문제**. 스태시 후 base 에서 동일하게 실패하는 것을 확인했다.

## ⚠️ 머지 전 필수

Cloudtype 의 nklcbdty-service 에 환경변수 두 개를 넣어야 한다. 프론트 컨테이너에 이미 설정된 값과 같다.

```
KV_ORIGIN_IP
KV_ORIGIN_HOST
```

**없으면 이 코드는 조용히 no-op 이다.** 로컬/미설정 환경에서 깨지지 않게 일부러 그렇게 만들었지만(프론트 `docker/40-kv-origin.sh` 와 같은 규칙), 운영에서 빠뜨리면 아무 효과가 없다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically refreshes company-specific and full-list cached data after crawler updates.
  * Supports configurable cache service connections, including host settings and six-hour expiration.
  * Normalizes company codes and refreshes relevant cache entries.

* **Bug Fixes**
  * Cache refresh failures no longer interrupt crawl completion.
  * Refreshing is safely skipped when cache service configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->