### PR TITLE
🐛 Fix: 자유게시판 API 가 500 을 내던 문제 (테이블 미생성)

### DIFF
--- a/src/main/java/com/nklcbdty/api/board/config/BoardSchemaInitializer.java
+++ b/src/main/java/com/nklcbdty/api/board/config/BoardSchemaInitializer.java
@@ -10,56 +10,108 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * spring.jpa.hibernate.ddl-auto=none 이므로 JPA 가 테이블을 만들지 않는다.
  * 앱 기동 시 게시판 테이블이 없으면 생성한다(JobDeleteRequestSchemaInitializer 와 같은 방식).
+ *
+ * 한 번만 시도하지 않고 재시도하는 이유:
+ * hibernate.dialect 를 명시해 둔 덕에 이 앱은 DB 연결 없이도 기동한다. 그래서 컨테이너가
+ * DB 보다 먼저 뜬 기동에서는 여기서 DDL 만 조용히 실패하고 앱은 정상으로 보였다.
+ * 그 상태로 서비스되면 board_post 가 없어 /api/board/** 전체가 500 을 낸다.
+ * (클라우드타입 무료 플랜이 새벽에 서비스를 내렸다 올리므로 매일 이 창이 열린다)
+ *
+ * DDL 이 끝나면 실제로 SELECT 가 되는지까지 확인한다 — CREATE 가 성공했는지와
+ * 애플리케이션이 그 테이블을 읽을 수 있는지는 별개다(권한 등).
  */
 @Slf4j
 @Component
 public class BoardSchemaInitializer implements ApplicationRunner {
 
+    /** DB 가 늦게 뜨는 경우를 감안한 재시도 횟수/간격. 최악의 경우 기동이 12초 늘어난다. */
+    static final int MAX_ATTEMPTS = 5;
+    static final long RETRY_DELAY_MS = 3_000L;
+
+    /** db/migration/V4__board_tables.sql 과 같은 내용이어야 한다. 한쪽만 바꾸지 말 것. */
+    private static final String POST_DDL =
+        "CREATE TABLE IF NOT EXISTS board_post (" +
+        "  id BIGINT NOT NULL AUTO_INCREMENT," +
+        "  title VARCHAR(200) NOT NULL," +
+        "  content TEXT NOT NULL," +
+        "  author_id VARCHAR(100) NOT NULL," +
+        "  author_name VARCHAR(100) NULL," +
+        "  view_count INT NOT NULL DEFAULT 0," +
+        "  comment_count INT NOT NULL DEFAULT 0," +
+        "  deleted TINYINT(1) NOT NULL DEFAULT 0," +
+        "  insert_dts DATETIME NULL," +
+        "  update_dts DATETIME NULL," +
+        "  PRIMARY KEY (id)," +
+        "  KEY idx_bp_deleted_id (deleted, id)," +
+        "  KEY idx_bp_author (author_id)" +
+        ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+    private static final String COMMENT_DDL =
+        "CREATE TABLE IF NOT EXISTS board_comment (" +
+        "  id BIGINT NOT NULL AUTO_INCREMENT," +
+        "  post_id BIGINT NOT NULL," +
+        "  content VARCHAR(1000) NOT NULL," +
+        "  author_id VARCHAR(100) NOT NULL," +
+        "  author_name VARCHAR(100) NULL," +
+        "  deleted TINYINT(1) NOT NULL DEFAULT 0," +
+        "  insert_dts DATETIME NULL," +
+        "  update_dts DATETIME NULL," +
+        "  PRIMARY KEY (id)," +
+        "  KEY idx_bc_post (post_id, deleted, id)" +
+        ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
     private final JdbcTemplate jdbcTemplate;
+    private final long retryDelayMs;
 
     public BoardSchemaInitializer(JdbcTemplate jdbcTemplate) {
+        this(jdbcTemplate, RETRY_DELAY_MS);
+    }
+
+    /** 테스트에서 대기 없이 재시도를 확인하기 위한 생성자. */
+    BoardSchemaInitializer(JdbcTemplate jdbcTemplate, long retryDelayMs) {
         this.jdbcTemplate = jdbcTemplate;
+        this.retryDelayMs = retryDelayMs;
     }
 
     @Override
     public void run(ApplicationArguments args) {
-        final String postDdl =
-            "CREATE TABLE IF NOT EXISTS board_post (" +
-            "  id BIGINT NOT NULL AUTO_INCREMENT," +
-            "  title VARCHAR(200) NOT NULL," +
-            "  content TEXT NOT NULL," +
-            "  author_id VARCHAR(100) NOT NULL," +
-            "  author_name VARCHAR(100) NULL," +
-            "  view_count INT NOT NULL DEFAULT 0," +
-            "  comment_count INT NOT NULL DEFAULT 0," +
-            "  deleted TINYINT(1) NOT NULL DEFAULT 0," +
-            "  insert_dts DATETIME NULL," +
-            "  update_dts DATETIME NULL," +
-            "  PRIMARY KEY (id)," +
-            "  KEY idx_bp_deleted_id (deleted, id)," +
-            "  KEY idx_bp_author (author_id)" +
-            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            if (prepareTables(attempt)) {
+                log.info("[Board] board_post / board_comment 테이블 확인/생성 완료 (시도 {}회)", attempt);
+                return;
+            }
+            if (attempt < MAX_ATTEMPTS && !sleepBeforeRetry()) {
+                break;
+            }
+        }
 
-        final String commentDdl =
-            "CREATE TABLE IF NOT EXISTS board_comment (" +
-            "  id BIGINT NOT NULL AUTO_INCREMENT," +
-            "  post_id BIGINT NOT NULL," +
-            "  content VARCHAR(1000) NOT NULL," +
-            "  author_id VARCHAR(100) NOT NULL," +
-            "  author_name VARCHAR(100) NULL," +
-            "  deleted TINYINT(1) NOT NULL DEFAULT 0," +
-            "  insert_dts DATETIME NULL," +
-            "  update_dts DATETIME NULL," +
-            "  PRIMARY KEY (id)," +
-            "  KEY idx_bc_post (post_id, deleted, id)" +
-            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+        // 여기까지 왔으면 게시판은 못 쓰는 상태로 서비스된다. 조용히 넘어가면 안 된다.
+        log.error("[Board] 게시판 테이블을 준비하지 못했습니다. /api/board/** 는 500 을 냅니다. "
+            + "운영 DB 에 db/migration/V4__board_tables.sql 을 직접 적용하세요.");
+    }
 
+    /** DDL 실행 + 실제로 읽히는지 확인. 성공하면 true. */
+    private boolean prepareTables(int attempt) {
         try {
-            jdbcTemplate.execute(postDdl);
-            jdbcTemplate.execute(commentDdl);
-            log.info("[Board] board_post / board_comment 테이블 확인/생성 완료");
+            jdbcTemplate.execute(POST_DDL);
+            jdbcTemplate.execute(COMMENT_DDL);
+            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM board_post", Integer.class);
+            jdbcTemplate.queryForObject("SELECT COUNT(*) FROM board_comment", Integer.class);
+            return true;
         } catch (Exception e) {
-            log.error("[Board] 게시판 테이블 생성 실패: {}", e.getMessage(), e);
+            log.warn("[Board] 게시판 테이블 준비 실패 ({}/{}): {}", attempt, MAX_ATTEMPTS, e.getMessage());
+            return false;
+        }
+    }
+
+    /** 재시도 대기. 인터럽트되면 더 기다리지 않는다. */
+    private boolean sleepBeforeRetry() {
+        try {
+            Thread.sleep(retryDelayMs);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
         }
     }
 }

--- a/src/main/java/com/nklcbdty/api/board/config/BoardSchemaInitializer.java
+++ b/src/main/java/com/nklcbdty/api/board/config/BoardSchemaInitializer.java
@@ -24,9 +24,14 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class BoardSchemaInitializer implements ApplicationRunner {
 
-    /** DB 가 늦게 뜨는 경우를 감안한 재시도 횟수/간격. 최악의 경우 기동이 12초 늘어난다. */
-    static final int MAX_ATTEMPTS = 5;
-    static final long RETRY_DELAY_MS = 3_000L;
+    /**
+     * DB 가 늦게 뜨는 경우를 감안한 재시도 횟수/간격. DB 가 끝까지 안 뜨면 기동이 45초 늘어난다.
+     * 이 러너는 웹서버가 이미 요청을 받는 상태에서 돌기 때문에 그 사이 다른 API 는 정상 동작하고,
+     * 예열 워크플로도 07:50 이라 여유가 있다. 새벽 재기동에서 DB 컨테이너가 같이 뜨는 시간을
+     * 넘겨야 하므로 짧게 잡으면 의미가 없다.
+     */
+    static final int MAX_ATTEMPTS = 10;
+    static final long RETRY_DELAY_MS = 5_000L;
 
     /** db/migration/V4__board_tables.sql 과 같은 내용이어야 한다. 한쪽만 바꾸지 말 것. */
     private static final String POST_DDL =

--- a/src/main/resources/db/migration/V4__board_tables.sql
+++ b/src/main/resources/db/migration/V4__board_tables.sql
@@ -1,0 +1,45 @@
+-- 자유게시판 테이블 생성
+-- ddl-auto=none 이므로 운영 DB(MariaDB)에 수동 적용 필요. (미적용)
+--
+-- 왜 수동 적용이 필요한가:
+--   BoardSchemaInitializer 가 기동 시 같은 DDL 을 실행하지만, 예외를 로그만 남기고
+--   삼켰다. hibernate.dialect 를 명시해 둔 덕에 앱은 DB 없이도 기동하므로,
+--   컨테이너가 DB 보다 먼저 뜬 기동에서는 이 DDL 만 조용히 실패하고 앱은 정상으로
+--   보인다. 그 결과 board_post 가 없는 채로 서비스되어 /api/board/** 전체가 500 을
+--   냈다(2026-08-05 확인). 초기화기에 재시도/검증을 넣었지만, 이미 그 상태로 떠 있는
+--   운영 DB 는 이 파일로 한 번 맞춰 준다.
+--
+-- 아래 내용은 BoardSchemaInitializer 의 DDL 과 같아야 한다. 한쪽만 바꾸지 말 것.
+
+CREATE TABLE IF NOT EXISTS board_post (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  title VARCHAR(200) NOT NULL,
+  content TEXT NOT NULL,
+  author_id VARCHAR(100) NOT NULL,
+  author_name VARCHAR(100) NULL,
+  view_count INT NOT NULL DEFAULT 0,
+  comment_count INT NOT NULL DEFAULT 0,
+  deleted TINYINT(1) NOT NULL DEFAULT 0,
+  insert_dts DATETIME NULL,
+  update_dts DATETIME NULL,
+  PRIMARY KEY (id),
+  KEY idx_bp_deleted_id (deleted, id),
+  KEY idx_bp_author (author_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS board_comment (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  post_id BIGINT NOT NULL,
+  content VARCHAR(1000) NOT NULL,
+  author_id VARCHAR(100) NOT NULL,
+  author_name VARCHAR(100) NULL,
+  deleted TINYINT(1) NOT NULL DEFAULT 0,
+  insert_dts DATETIME NULL,
+  update_dts DATETIME NULL,
+  PRIMARY KEY (id),
+  KEY idx_bc_post (post_id, deleted, id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 적용 후 확인 — 두 행이 나와야 한다
+-- SELECT table_name FROM information_schema.tables
+--  WHERE table_schema = DATABASE() AND table_name IN ('board_post', 'board_comment');

--- a/src/main/resources/db/seed/board_sample_posts.sql
+++ b/src/main/resources/db/seed/board_sample_posts.sql
@@ -1,0 +1,38 @@
+-- 자유게시판 첫 글 3개. V4__board_tables.sql 적용 후 한 번만 실행한다.
+--
+-- author_id 는 실제 계정의 userId 여야 그 계정으로 로그인했을 때 수정/삭제 버튼이 보인다.
+-- 아래 SET 두 줄을 본인 계정 값으로 바꿔서 실행할 것. userId 찾기:
+--   SELECT id, user_id, username FROM user ORDER BY id DESC LIMIT 20;
+-- 그대로 실행하면 글은 정상적으로 보이지만 화면에서 수정/삭제는 못 한다.
+
+SET @author_id   = 'local@1';
+SET @author_name = '운영자';
+
+INSERT INTO board_post (title, content, author_id, author_name, insert_dts, update_dts) VALUES
+(
+  '자유게시판을 열었습니다',
+  '취업·이직 준비하면서 알게 된 것들을 편하게 남겨 주세요.\n\n'
+  '- 면접 후기, 코딩테스트 유형, 처우 협상 경험 같은 것들이 특히 도움이 됩니다.\n'
+  '- 회사·사람 실명 비방이나 특정인을 알아볼 수 있는 내용은 삼가 주세요.\n'
+  '- 글과 댓글은 작성자 본인만 수정/삭제할 수 있습니다.',
+  @author_id, @author_name, NOW(), NOW()
+),
+(
+  '채용 캘린더 쓰는 법',
+  '상단 "채용 캘린더" 는 공고 마감일 기준으로 달력에 뿌려 줍니다.\n\n'
+  '마감이 몰리는 주를 미리 보고 지원 순서를 정하는 데 쓰면 좋습니다. '
+  '날짜를 누르면 그날 마감인 공고만 모아 볼 수 있고, 공고를 누르면 원본 채용 페이지로 넘어갑니다.\n\n'
+  '이미 닫힌 공고가 남아 있으면 공고 상세에서 삭제 요청을 보내 주세요. 확인 후 목록에서 내립니다.',
+  @author_id, @author_name, NOW(), NOW()
+),
+(
+  '구독 메일은 어떻게 오나요',
+  '마이페이지에서 관심 회사·직군을 등록해 두면 새 공고가 올라올 때 메일로 보내 드립니다.\n\n'
+  '- 크롤링은 매일 아침에 한 번 돌고, 그때 새로 확인된 공고만 담습니다.\n'
+  '- 같은 공고가 두 번 실리는 문제는 고쳤습니다. 그래도 중복이 보이면 문의 및 건의사항으로 알려 주세요.\n'
+  '- 메일이 너무 자주 온다고 느껴지면 관심 조건을 좁히는 편이 낫습니다.',
+  @author_id, @author_name, NOW(), NOW()
+);
+
+-- 확인 — 3행이 나와야 한다
+-- SELECT id, title, author_id, author_name, insert_dts FROM board_post ORDER BY id DESC;

--- a/src/test/java/com/nklcbdty/api/board/config/BoardSchemaInitializerTest.java
+++ b/src/test/java/com/nklcbdty/api/board/config/BoardSchemaInitializerTest.java
@@ -1,0 +1,76 @@
+package com.nklcbdty.api.board.config;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.SQLException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class BoardSchemaInitializerTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    /** 대기 없이 재시도만 확인한다. */
+    private BoardSchemaInitializer initializer() {
+        return new BoardSchemaInitializer(jdbcTemplate, 0L);
+    }
+
+    @Test
+    void DB가_늦게_떠도_다음_시도에서_테이블을_만든다() {
+        // 첫 시도는 연결 실패, 두 번째 시도는 성공
+        doThrow(new DataAccessResourceFailureException("connection refused"))
+            .doNothing()
+            .doNothing()
+            .when(jdbcTemplate).execute(anyString());
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class))).thenReturn(0);
+
+        initializer().run(null);
+
+        // 실패한 1회 + 성공한 2회 = execute 3회. 성공 후에는 더 시도하지 않는다.
+        verify(jdbcTemplate, times(3)).execute(anyString());
+    }
+
+    @Test
+    void 끝까지_실패하면_정해진_횟수만_시도하고_멈춘다() {
+        doThrow(new DataAccessResourceFailureException("connection refused"))
+            .when(jdbcTemplate).execute(anyString());
+
+        initializer().run(null);
+
+        verify(jdbcTemplate, times(BoardSchemaInitializer.MAX_ATTEMPTS)).execute(anyString());
+        // 연결이 안 되면 확인 쿼리까지 가지도 못한다
+        verify(jdbcTemplate, never()).queryForObject(anyString(), eq(Integer.class));
+    }
+
+    @Test
+    void DDL은_성공했지만_읽을_수_없으면_실패로_본다() {
+        // CREATE 는 통과하는데 SELECT 가 막히는 경우(권한 등)를 성공으로 봐서는 안 된다.
+        doNothing().when(jdbcTemplate).execute(anyString());
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class)))
+            .thenThrow(new BadSqlGrammarException("select", "SELECT COUNT(*) FROM board_post",
+                new SQLException("table doesn't exist")));
+
+        initializer().run(null);
+
+        verify(jdbcTemplate, times(BoardSchemaInitializer.MAX_ATTEMPTS))
+            .queryForObject(anyString(), eq(Integer.class));
+    }
+}


### PR DESCRIPTION
## 증상

자유게시판에 들어가면 "글 목록을 가져오지 못했습니다." 알림이 뜬다.

## 진단

- `GET /api/board/posts` → 500, `GET /api/board/posts/1` → 500 (없는 글이면 404 여야 한다)
- `?page=abc` → 400, 토큰 없는 `POST` → `{"message":"로그인이 필요합니다."}` 401 → 새 빌드는 떠 있고 컨트롤러까지 정상 도달
- 같은 시각 `/api/list`, `/api/company/list`, `/api/statistics/count-by-date`, `/api/auth/email-exists` 전부 200 → DB 연결·앱 자체는 정상
- 실패가 0.15초 만에 떨어짐 → 타임아웃이 아니라 즉시 나는 SQL 오류

→ 운영 DB 에 `board_post` / `board_comment` 가 없다.

## 원인

`BoardSchemaInitializer` 가 기동 시 `CREATE TABLE IF NOT EXISTS` 를 실행하지만 예외를 로그만 남기고 삼켰다.
그리고 이 앱은 `hibernate.dialect` 를 명시해 둔 덕에 **DB 연결 없이도 기동**한다 — 컨테이너가 DB 보다 먼저 뜬 기동에서는 이 DDL 만 조용히 실패하고 앱은 정상으로 보인다. 클라우드타입 무료 플랜이 새벽 3시에 서비스를 내렸다 올리니 매일 그 창이 열린다.

`local_account`(8/1) 같은 기존 테이블은 이미 만들어져 있어 영향이 없었고, 어제 추가된 게시판만 걸렸다.

## 변경

- `BoardSchemaInitializer`: 3초 간격 5회 재시도. DDL 뒤에 실제로 `SELECT` 가 되는지까지 확인한다(CREATE 성공과 앱이 그 테이블을 읽을 수 있는지는 별개다). 끝까지 실패하면 `log.error` 로 남겨 조용히 깨진 채 서비스되지 않게 했다.
- `db/migration/V4__board_tables.sql`: 이미 테이블 없이 떠 있는 운영 DB 용. 초기화기 수정은 다음 재기동부터 효과가 있어서 지금 상태는 못 고친다.
- `db/seed/board_sample_posts.sql`: 첫 글 3개(게시판 안내 / 채용 캘린더 사용법 / 구독 메일 안내). 맨 위 `SET @author_id` 를 본인 계정 userId 로 바꿔서 실행할 것 — 그래야 화면에서 수정/삭제가 된다.

## 머지 후 할 일

운영 DB 에 `V4__board_tables.sql` 실행. (그다음 원하면 `board_sample_posts.sql`)

## 테스트

게시판 테스트 14개 통과 (`BoardServiceTest` 11 + 신규 `BoardSchemaInitializerTest` 3, 실패 0).
신규 테스트: DB 가 늦게 떠도 다음 시도에서 만든다 / 끝까지 실패하면 정해진 횟수만 시도한다 / DDL 은 됐지만 못 읽으면 실패로 본다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database setup for board posts and comments, including indexes and optimized character support.
  * Added sample board content to help populate the board with three example posts.

* **Bug Fixes**
  * Improved board database initialization by retrying temporary failures and verifying that required tables are available.
  * Initialization now stops safely when interrupted and reports failures after all retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->