### PR TITLE
🚨 Fix: 회사가 공고명을 바꾸면 링크 점검이 매일 종료 처리하던 문제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     implementation 'org.springframework.data:spring-data-elasticsearch'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// @Query 로 직접 쓴 JPQL 은 앱 기동 때 검증된다 — 틀리면 배포가 곧 장애다.
+	// 운영 DB 없이 그 검증을 미리 하기 위한 인메모리 DB(@DataJpaTest 용).
+	testRuntimeOnly 'com.h2database:h2'
 
 	implementation 'org.json:json:20240303'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/nklcbdty/api/common/SchedulingConfig.java
+++ b/src/main/java/com/nklcbdty/api/common/SchedulingConfig.java
@@ -1,0 +1,29 @@
+package com.nklcbdty.api.common;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * {@code @Scheduled} 작업용 스레드 풀.
+ *
+ * <p>스프링 기본 스케줄러는 스레드가 하나라 등록된 작업이 서로를 막는다. 본문 수집
+ * ({@code JobContentIndexer})은 외부 사이트를 순서대로 받느라 한 주기가 수십 초씩 걸리는데,
+ * 그동안 임베딩 색인({@code JobEmbeddingIndexer}, 60초 주기)이 통째로 밀린다.
+ * 풀을 주면 각자 자기 주기대로 돈다.</p>
+ */
+@Configuration
+public class SchedulingConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(3);
+        scheduler.setThreadNamePrefix("Scheduled-");
+        // 종료 시 돌던 작업이 끊기지 않게 한다(본문 수집 중 커넥션이 끊기면 실패로 기록된다).
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(20);
+        return scheduler;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/common/CrawlerCommonService.java
@@ -194,6 +194,9 @@ public class CrawlerCommonService {
         //                       기존 값은 덮어쓰지 않는다(크롤러 키워드 분류가 null 일 수 있으므로).
         //  4) jobDetailLink  : 회사가 채용 사이트를 옮기면 기존 row 는 죽은 링크를 계속 들고 있고,
         //                       링크 점검 배치가 매일 그 row 를 종료 처리한다(당근 이관 때 실제로 발생).
+        //  5) annoSubject    : 링크 점검 배치는 "상세페이지 HTML 에 DB 의 공고명이 들어있는가"로 생존을
+        //                       판정한다. 회사가 공고 제목을 바꾸면(당근이 "A | B" → "A - B" 로 일괄 변경)
+        //                       DB 만 옛 제목으로 남아 살아있는 공고가 매일 종료 처리된다.
         List<Job_mst> existingToUpdate = new ArrayList<>();
         for (Job_mst jobItem : result) {
             Job_mst existing = existingJobs.stream()
@@ -235,6 +238,18 @@ public class CrawlerCommonService {
             if (freshLink != null && !freshLink.isBlank()
                 && !freshLink.equals(existing.getJobDetailLink())) {
                 existing.setJobDetailLink(freshLink);
+                changed = true;
+            }
+
+            final String freshSubject = jobItem.getAnnoSubject() == null ? null : jobItem.getAnnoSubject().strip();
+            if (freshSubject != null && !freshSubject.isEmpty()
+                && !freshSubject.equals(existing.getAnnoSubject())) {
+                log.info("공고명 변경 반영 — annoId={} '{}' → '{}'",
+                    existing.getAnnoId(), existing.getAnnoSubject(), freshSubject);
+                existing.setAnnoSubject(freshSubject);
+                // 제목이 검색 임베딩 입력의 첫 항목이라, 바뀐 채로 두면 옛 제목으로 색인된 벡터가 남는다.
+                // embedding 을 비우면 JobEmbeddingIndexer 가 다음 주기에 다시 색인한다.
+                existing.setEmbedding(null);
                 changed = true;
             }
 

--- a/src/main/java/com/nklcbdty/api/crawler/content/ContentText.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/ContentText.java
@@ -1,0 +1,61 @@
+package com.nklcbdty.api.crawler.content;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+
+/**
+ * 본문 문자열 손질. 회사마다 HTML 이든 escape 된 HTML 이든 내려오는 모양이 달라 여기서 한 번에 정규화한다.
+ */
+public final class ContentText {
+
+    /** 본문이 이보다 짧으면 "못 가져온 것"으로 본다. #LI-DNI 같은 껍데기 응답을 거르기 위함. */
+    public static final int MIN_MEANINGFUL_LENGTH = 80;
+
+    private ContentText() {
+    }
+
+    /**
+     * HTML 을 읽을 수 있는 텍스트로 바꾼다.
+     *
+     * <p>{@code Jsoup.text()} 는 블록 요소를 공백 하나로 이어붙여 문단·목록이 전부 한 줄이 된다.
+     * 본문은 "자격요건 / 우대사항" 같은 목록이 핵심이라 줄바꿈을 살려야 읽히고, 임베딩에도 낫다.</p>
+     */
+    public static String htmlToText(String html) {
+        if (html == null || html.isBlank()) {
+            return "";
+        }
+        Document doc = Jsoup.parse(unescapeIfNeeded(html));
+        doc.select("script, style, noscript").remove();
+        doc.select("br").append("\\n");
+        doc.select("p, div, li, tr, h1, h2, h3, h4, h5, h6").append("\\n");
+        String text = doc.text().replace("\\n", "\n");
+        return normalize(text);
+    }
+
+    /** 이미 텍스트인 값(줄바꿈 있는 평문)을 손질한다. */
+    public static String normalize(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text
+            .replace(' ', ' ')      // &nbsp;
+            .replaceAll("[ \\t]+", " ")
+            .replaceAll(" *\n *", "\n")
+            .replaceAll("\n{3,}", "\n\n")
+            .trim();
+    }
+
+    /**
+     * Greenhouse 는 본문을 escape 된 HTML(&amp;lt;p&amp;gt;...)로 준다.
+     * 태그가 안 보이고 escape 만 보이면 한 번 풀어준 뒤 파싱한다.
+     */
+    private static String unescapeIfNeeded(String html) {
+        boolean looksEscaped = html.contains("&lt;") && !html.contains("<p") && !html.contains("<div");
+        return looksEscaped ? Parser.unescapeEntities(html, false) : html;
+    }
+
+    public static boolean isMeaningful(String text) {
+        return text != null && text.strip().length() >= MIN_MEANINGFUL_LENGTH;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/JobContent.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/JobContent.java
@@ -1,0 +1,80 @@
+package com.nklcbdty.api.crawler.content;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 공고 본문. {@code job_mst} 와 1:1 이며 PK 를 그대로 공유한다.
+ *
+ * <p>{@code job_mst} 에 컬럼을 붙이지 않고 별도 테이블로 뺀 이유가 두 가지 있다.
+ * <ul>
+ *   <li>{@code Job_mst} 는 nklcbdty-common jar 안에 있어 컬럼을 늘리려면 common 버전을 올리고
+ *       service·batch 를 함께 맞춰야 한다. 본문 수집은 service 안에서만 끝나는 일이다.</li>
+ *   <li>본문은 수십 KB 라, 목록 조회(전 행 SELECT)에 딸려오면 손해다. 분리해 두면 필요할 때만 읽는다.</li>
+ * </ul>
+ */
+@Entity
+@Table(name = "job_content")
+@Getter
+@Setter
+@NoArgsConstructor
+public class JobContent {
+
+    /** job_mst.id. 별도 시퀀스를 두지 않고 공유한다. */
+    @Id
+    @Column(name = "job_id")
+    private Long jobId;
+
+    @Column(name = "company_cd", length = 50)
+    private String companyCd;
+
+    // 실제 컬럼 타입(MEDIUMTEXT)은 JobContentSchemaInitializer 가 정한다.
+    // ddl-auto=none 이라 JPA 는 테이블을 만들지 않으므로, 여기서는 @Lob 으로 "긴 문자열"만 알려주면 된다.
+    // columnDefinition 에 MEDIUMTEXT 를 박으면 테스트용 H2 에서 DDL 이 깨진다.
+
+    /** 태그를 걷어낸 본문 텍스트. 검색·임베딩은 이 값을 쓴다. */
+    @Lob
+    @Column(name = "content")
+    private String content;
+
+    /** 원본 HTML. 화면에 그대로 보여줄 때를 위해 남긴다(원본이 텍스트면 null). */
+    @Lob
+    @Column(name = "content_html")
+    private String contentHtml;
+
+    /** content 의 SHA-256. 재수집 때 내용이 그대로면 UPDATE 를 만들지 않기 위한 것. */
+    @Column(name = "content_hash", length = 64)
+    private String contentHash;
+
+    /** 어느 fetcher 가 가져왔는지. 수집 방식이 바뀌었을 때 원인 추적용. */
+    @Column(name = "source", length = 60)
+    private String source;
+
+    /** 수집 실패 사유. 성공하면 null 로 지운다. */
+    @Column(name = "fail_reason", length = 300)
+    private String failReason;
+
+    /** 마지막 수집 시도 시각. 성공·실패 모두 갱신한다(실패한 공고를 매분 다시 때리지 않기 위함). */
+    @Column(name = "fetched_at")
+    private LocalDateTime fetchedAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public JobContent(Long jobId, String companyCd) {
+        this.jobId = jobId;
+        this.companyCd = companyCd;
+    }
+
+    public boolean hasContent() {
+        return content != null && !content.isBlank();
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/JobContentController.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/JobContentController.java
@@ -1,0 +1,35 @@
+package com.nklcbdty.api.crawler.content;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 수집된 공고 본문 조회. 목록 응답에는 싣지 않는다(본문이 커서 목록이 무거워진다). */
+@RestController
+@RequestMapping("/api/jobs")
+public class JobContentController {
+
+    private final JobContentService contentService;
+
+    public JobContentController(JobContentService contentService) {
+        this.contentService = contentService;
+    }
+
+    @GetMapping(value = "/{jobId}/content", produces = "application/json;charset=UTF-8")
+    public ResponseEntity<?> content(@PathVariable Long jobId) {
+        return contentService.find(jobId)
+            .filter(JobContent::hasContent)
+            .<ResponseEntity<?>>map(row -> ResponseEntity.ok(Map.of(
+                "jobId", row.getJobId(),
+                "companyCd", row.getCompanyCd() == null ? "" : row.getCompanyCd(),
+                "content", row.getContent(),
+                "source", row.getSource() == null ? "" : row.getSource(),
+                "updatedAt", String.valueOf(row.getUpdatedAt())
+            )))
+            .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/JobContentFetcher.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/JobContentFetcher.java
@@ -1,0 +1,49 @@
+package com.nklcbdty.api.crawler.content;
+
+import com.nklcbdty.common.vo.Job_mst;
+
+/**
+ * 회사별 공고 본문 수집 전략.
+ *
+ * <p>크롤러(=목록 수집)와 분리한 이유: 본문은 대부분 상세 API/페이지를 한 번 더 받아야 나오고,
+ * 목록 크롤은 이미 24분이 걸린다. 본문은 {@link JobContentIndexer} 가 뒤에서 천천히 채운다.
+ * 크롤러 코드를 건드리지 않으므로 크롤러가 개편돼도 이쪽은 그대로다.</p>
+ *
+ * <p>여러 구현이 {@code supports} 를 만족하면 {@code @Order} 가 낮은 것이 이긴다.
+ * 회사 전용 구현이 먼저 잡히고, 아무도 못 잡으면 {@code GenericHtmlContentFetcher} 가 받는다.</p>
+ */
+public interface JobContentFetcher {
+
+    boolean supports(Job_mst job);
+
+    /**
+     * 본문을 가져온다.
+     *
+     * @return 본문. 못 가져오면 null 을 돌려 다음 시도에 맡긴다(예외를 던져도 된다).
+     */
+    Fetched fetch(Job_mst job) throws Exception;
+
+    /** 수집 방식 식별자. {@code job_content.source} 에 남는다. */
+    String sourceName();
+
+    /**
+     * 수집 결과. html 은 원본이 HTML 일 때만 채운다.
+     *
+     * @param html 원본 HTML (없으면 null)
+     * @param text 태그를 걷어낸 본문 텍스트
+     */
+    record Fetched(String html, String text) {
+
+        public static Fetched ofHtml(String html, String text) {
+            return new Fetched(html, text);
+        }
+
+        public static Fetched ofText(String text) {
+            return new Fetched(null, text);
+        }
+
+        public boolean isEmpty() {
+            return text == null || text.isBlank();
+        }
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/JobContentIndexer.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/JobContentIndexer.java
@@ -1,0 +1,91 @@
+package com.nklcbdty.api.crawler.content;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 본문이 없는 공고를 조금씩 수집한다.
+ *
+ * <p>크롤(<code>/api/crawler</code>) 안에서 본문까지 받지 않는 이유: 목록 크롤만으로 이미 24분이
+ * 걸리고, 공고 하나마다 상세를 한 번 더 받으면 배치가 몇 배로 길어진다. {@code JobEmbeddingIndexer}
+ * 와 같은 방식으로 뒤에서 천천히 채운다. 신규 공고도 저장된 뒤 한 주기 안에 잡힌다.</p>
+ *
+ * <p>같은 사이트를 연달아 때리지 않도록 한 건마다 쉬어간다. 한 주기에 {@code BATCH_SIZE} 건만
+ * 처리하므로 3천여 건을 다 채우는 데 며칠이 걸리지만, 그 사이에도 최신 공고부터(id 내림차순)
+ * 채워진다.</p>
+ */
+@Slf4j
+@Service
+public class JobContentIndexer {
+
+    private static final int BATCH_SIZE = 20;
+    private static final long PAUSE_MS = 700L;
+
+    /** 이 기간이 지나면 다시 확인한다. 공고 본문은 자주 바뀌지 않는다. */
+    private static final int REFRESH_DAYS = 14;
+
+    private final JobContentRepository repository;
+    private final JobContentService contentService;
+
+    /** 로컬 개발에서 외부 사이트를 때리지 않도록 끌 수 있게 한다. */
+    private final boolean enabled;
+
+    public JobContentIndexer(JobContentRepository repository,
+                             JobContentService contentService,
+                             @Value("${crawler.content.indexer.enabled:true}") boolean enabled) {
+        this.repository = repository;
+        this.contentService = contentService;
+        this.enabled = enabled;
+    }
+
+    @Scheduled(fixedDelay = 120_000L, initialDelay = 90_000L)
+    public void indexBatch() {
+        if (!enabled) {
+            return;
+        }
+
+        List<Job_mst> targets;
+        try {
+            targets = repository.findNeedingContent(
+                LocalDateTime.now().minusDays(REFRESH_DAYS), PageRequest.of(0, BATCH_SIZE));
+        } catch (Exception e) {
+            log.warn("본문 수집 대상 조회 실패: {}", e.getMessage());
+            return;
+        }
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        long t0 = System.currentTimeMillis();
+        int updated = 0;
+        for (Job_mst job : targets) {
+            try {
+                if (contentService.collect(job)) {
+                    updated++;
+                }
+            } catch (Exception e) {
+                // collect 안에서 이미 실패를 기록한다. 여기까지 온 건 저장 자체가 실패한 경우다.
+                log.warn("본문 수집 처리 실패 jobId={}: {}", job.getId(), e.getMessage());
+            }
+            pause();
+        }
+        log.info("본문 수집 배치: {}/{}건 갱신 ({}ms)", updated, targets.size(), System.currentTimeMillis() - t0);
+    }
+
+    private void pause() {
+        try {
+            Thread.sleep(PAUSE_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/JobContentRepository.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/JobContentRepository.java
@@ -1,0 +1,37 @@
+package com.nklcbdty.api.crawler.content;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import com.nklcbdty.common.vo.Job_mst;
+
+@Repository
+public interface JobContentRepository extends JpaRepository<JobContent, Long> {
+
+    /**
+     * 본문 수집이 필요한 공고를 오래된 것부터 준다.
+     *
+     * <p>대상은 (1) 아직 한 번도 시도 안 한 공고, (2) 마지막 시도가 {@code before} 이전인 공고다.
+     * 실패한 공고도 (2) 로 다시 잡히지만 재시도 간격만큼은 쉬어간다 — 죽은 링크를 매분 때리지 않는다.
+     * 살아있는 공고(마감 전)만 본다. 이미 끝난 공고의 본문을 이제 와 긁을 이유가 없다.</p>
+     */
+    @Query("""
+        SELECT j FROM Job_mst j
+         WHERE j.subJobCdNm IS NOT NULL
+           AND j.jobDetailLink IS NOT NULL AND j.jobDetailLink <> ''
+           AND NOT EXISTS (
+                 SELECT 1 FROM JobContent c
+                  WHERE c.jobId = j.id AND c.fetchedAt > :before
+               )
+         ORDER BY j.id DESC
+        """)
+    List<Job_mst> findNeedingContent(@Param("before") LocalDateTime before, Pageable pageable);
+
+    long countByContentIsNotNull();
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/JobContentSchemaInitializer.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/JobContentSchemaInitializer.java
@@ -1,0 +1,75 @@
+package com.nklcbdty.api.crawler.content;
+
+import java.util.List;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@code spring.jpa.hibernate.ddl-auto=none} 이라 JPA 가 테이블을 만들지 않는다. 기동 시 직접 만든다.
+ *
+ * <p>{@code CREATE TABLE IF NOT EXISTS} 만 두지 않는 이유: 이 스키마({@code travel})는 다른
+ * 프로젝트와 공유라, 같은 이름의 테이블이 다른 모양으로 이미 있으면 CREATE 는 조용히 넘어가고
+ * 컬럼이 없는 채로 뜬다(2026-08-13 자유게시판 500 이 이 경우였다). 컬럼을 하나씩 확인해 채운다.</p>
+ */
+@Slf4j
+@Component
+public class JobContentSchemaInitializer implements ApplicationRunner {
+
+    private static final String CREATE_TABLE =
+        "CREATE TABLE IF NOT EXISTS job_content (" +
+        "  job_id BIGINT NOT NULL," +
+        "  company_cd VARCHAR(50) NULL," +
+        "  content MEDIUMTEXT NULL," +
+        "  content_html MEDIUMTEXT NULL," +
+        "  content_hash CHAR(64) NULL," +
+        "  source VARCHAR(60) NULL," +
+        "  fail_reason VARCHAR(300) NULL," +
+        "  fetched_at DATETIME NULL," +
+        "  updated_at DATETIME NULL," +
+        "  PRIMARY KEY (job_id)," +
+        "  KEY idx_job_content_fetched_at (fetched_at)" +
+        ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+    /** 이미 있는 테이블에 빠진 컬럼을 채운다. MariaDB 의 ADD COLUMN IF NOT EXISTS 를 쓴다. */
+    private static final List<String> ADD_COLUMNS = List.of(
+        "ALTER TABLE job_content ADD COLUMN IF NOT EXISTS company_cd VARCHAR(50) NULL",
+        "ALTER TABLE job_content ADD COLUMN IF NOT EXISTS content MEDIUMTEXT NULL",
+        "ALTER TABLE job_content ADD COLUMN IF NOT EXISTS content_html MEDIUMTEXT NULL",
+        "ALTER TABLE job_content ADD COLUMN IF NOT EXISTS content_hash CHAR(64) NULL",
+        "ALTER TABLE job_content ADD COLUMN IF NOT EXISTS source VARCHAR(60) NULL",
+        "ALTER TABLE job_content ADD COLUMN IF NOT EXISTS fail_reason VARCHAR(300) NULL",
+        "ALTER TABLE job_content ADD COLUMN IF NOT EXISTS fetched_at DATETIME NULL",
+        "ALTER TABLE job_content ADD COLUMN IF NOT EXISTS updated_at DATETIME NULL"
+    );
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JobContentSchemaInitializer(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            jdbcTemplate.execute(CREATE_TABLE);
+        } catch (Exception e) {
+            log.error("[JobContent] job_content 테이블 생성 실패: {}", e.getMessage(), e);
+            return;
+        }
+
+        for (String ddl : ADD_COLUMNS) {
+            try {
+                jdbcTemplate.execute(ddl);
+            } catch (Exception e) {
+                // 한 컬럼이 실패해도 나머지는 채운다. 어느 컬럼인지 남겨야 진단이 된다.
+                log.error("[JobContent] 컬럼 보정 실패: {} - {}", ddl, e.getMessage());
+            }
+        }
+        log.info("[JobContent] job_content 테이블 확인/생성 완료");
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/JobContentService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/JobContentService.java
@@ -1,0 +1,134 @@
+package com.nklcbdty.api.crawler.content;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 공고 하나의 본문을 받아 {@code job_content} 에 넣는다.
+ *
+ * <p>실패도 기록한다. 실패를 안 남기면 다음 주기에 같은 공고가 다시 대상으로 잡혀,
+ * 죽은 링크 몇 건이 큐를 계속 차지하고 뒤에 있는 공고가 영영 수집되지 않는다.</p>
+ */
+@Slf4j
+@Service
+public class JobContentService {
+
+    /** 본문이 이보다 짧으면 실패로 본다. 껍데기 응답·SPA 셸을 성공으로 저장하지 않기 위함. */
+    private static final int MIN_LENGTH = ContentText.MIN_MEANINGFUL_LENGTH;
+
+    /**
+     * 저장 상한. 전용 수집기는 1~7천 자인데, 범용 수집기가 본문 컨테이너를 못 찾고 페이지를 통째로
+     * 집으면 2만 자가 넘는다(카카오뱅크 실측 22,882자). 뒤쪽은 대개 푸터·추천공고라 잘라도 된다.
+     */
+    private static final int MAX_LENGTH = 20_000;
+
+    private final JobContentRepository repository;
+    private final List<JobContentFetcher> fetchers;
+
+    public JobContentService(JobContentRepository repository, List<JobContentFetcher> fetchers) {
+        this.repository = repository;
+        this.fetchers = fetchers;
+    }
+
+    /**
+     * 공고 하나를 수집해 저장한다.
+     *
+     * @return 본문을 새로 채웠거나 갱신했으면 true. 실패했거나 내용이 그대로면 false.
+     */
+    @Transactional
+    public boolean collect(Job_mst job) {
+        JobContent row = repository.findById(job.getId())
+            .orElseGet(() -> new JobContent(job.getId(), job.getCompanyCd()));
+        row.setCompanyCd(job.getCompanyCd());
+        row.setFetchedAt(LocalDateTime.now());
+
+        JobContentFetcher fetcher = fetcherFor(job);
+        if (fetcher == null) {
+            return saveFailure(row, "수집기 없음");
+        }
+        row.setSource(fetcher.sourceName());
+
+        JobContentFetcher.Fetched fetched;
+        try {
+            fetched = fetcher.fetch(job);
+        } catch (Exception e) {
+            log.warn("본문 수집 실패 jobId={} source={} - {}", job.getId(), fetcher.sourceName(), e.getMessage());
+            return saveFailure(row, abbreviate(e.getMessage()));
+        }
+
+        if (fetched == null || fetched.isEmpty()) {
+            return saveFailure(row, "본문 없음");
+        }
+        String text = fetched.text().strip();
+        if (text.length() < MIN_LENGTH) {
+            return saveFailure(row, "본문이 너무 짧음(" + text.length() + "자)");
+        }
+        if (text.length() > MAX_LENGTH) {
+            log.info("본문이 길어 잘라 저장 jobId={} source={} {}자 → {}자",
+                job.getId(), fetcher.sourceName(), text.length(), MAX_LENGTH);
+            text = text.substring(0, MAX_LENGTH);
+        }
+
+        String hash = sha256(text);
+        if (hash.equals(row.getContentHash()) && row.hasContent()) {
+            // 내용이 그대로다. fetchedAt 만 갱신해 재시도 큐에서 빠지게 한다.
+            row.setFailReason(null);
+            repository.save(row);
+            return false;
+        }
+
+        row.setContent(text);
+        row.setContentHtml(fetched.html());
+        row.setContentHash(hash);
+        row.setFailReason(null);
+        row.setUpdatedAt(LocalDateTime.now());
+        repository.save(row);
+        log.info("본문 수집 jobId={} source={} {}자", job.getId(), fetcher.sourceName(), text.length());
+        return true;
+    }
+
+    public Optional<JobContent> find(Long jobId) {
+        return repository.findById(jobId);
+    }
+
+    private JobContentFetcher fetcherFor(Job_mst job) {
+        return fetchers.stream()
+            .filter(f -> f.supports(job))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private boolean saveFailure(JobContent row, String reason) {
+        row.setFailReason(reason);
+        repository.save(row);
+        return false;
+    }
+
+    private String abbreviate(String message) {
+        if (message == null) {
+            return "알 수 없는 오류";
+        }
+        return message.length() <= 300 ? message : message.substring(0, 300);
+    }
+
+    private String sha256(String text) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(text.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 미지원", e);
+        }
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/fetcher/BaeminContentFetcher.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/fetcher/BaeminContentFetcher.java
@@ -1,0 +1,81 @@
+package com.nklcbdty.api.crawler.content.fetcher;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.json.JSONObject;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.content.ContentText;
+import com.nklcbdty.api.crawler.content.JobContentFetcher;
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 배민(우아한형제들) 본문.
+ *
+ * <p>상세페이지는 Next.js 클라이언트 렌더링이라 HTML 을 받아도 본문이 없다. 채용 API 를 쓴다.
+ * 주의: 상세 API 의 키는 목록의 {@code recruitSeq}(=annoId)가 아니라 {@code recruitNumber}(R26xxxxx)다.
+ * {@code /w1/recruits/25163} 은 {@code code=9002, data=null} 로 돌아온다.</p>
+ */
+@Component
+@Order(10)
+@Slf4j
+public class BaeminContentFetcher implements JobContentFetcher {
+
+    private static final String DETAIL_API = "https://career.woowahan.com/w1/recruits/%s";
+    private static final Pattern RECRUIT_NUMBER = Pattern.compile("/recruitment/([^/?#]+)/detail");
+
+    private final CrawlerCommonService commonService;
+
+    public BaeminContentFetcher(CrawlerCommonService commonService) {
+        this.commonService = commonService;
+    }
+
+    @Override
+    public boolean supports(Job_mst job) {
+        String link = job.getJobDetailLink();
+        return "BAEMIN".equalsIgnoreCase(job.getCompanyCd())
+            || (link != null && link.contains("career.woowahan.com"));
+    }
+
+    @Override
+    public Fetched fetch(Job_mst job) {
+        String recruitNumber = recruitNumberOf(job);
+        if (recruitNumber == null) {
+            log.warn("배민 본문: 링크에서 recruitNumber 를 못 찾음 link={}", job.getJobDetailLink());
+            return null;
+        }
+
+        String raw = commonService.fetchApiResponse(String.format(DETAIL_API, recruitNumber));
+        JSONObject data = new JSONObject(raw).optJSONObject("data");
+        if (data == null) {
+            log.warn("배민 본문: data 없음 recruitNumber={} 응답앞부분={}",
+                recruitNumber, raw == null ? "null" : raw.substring(0, Math.min(150, raw.length())));
+            return null;
+        }
+
+        String html = data.optString("recruitContents", "");
+        if (html.isBlank()) {
+            return null;
+        }
+        return Fetched.ofHtml(html, ContentText.htmlToText(html));
+    }
+
+    private String recruitNumberOf(Job_mst job) {
+        String link = job.getJobDetailLink();
+        if (link == null) {
+            return null;
+        }
+        Matcher m = RECRUIT_NUMBER.matcher(link);
+        return m.find() ? m.group(1) : null;
+    }
+
+    @Override
+    public String sourceName() {
+        return "baemin-api";
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/fetcher/GenericHtmlContentFetcher.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/fetcher/GenericHtmlContentFetcher.java
@@ -1,0 +1,97 @@
+package com.nklcbdty.api.crawler.content.fetcher;
+
+import java.util.List;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.content.ContentText;
+import com.nklcbdty.api.crawler.content.JobContentFetcher;
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 전용 수집기가 없는 회사의 본문. 상세페이지 HTML 에서 본문으로 보이는 덩어리를 골라낸다.
+ *
+ * <p>주 대상은 카카오(계열사마다 채용 시스템이 달라 호스트가 7개다 — recruiter.co.kr, ninehire,
+ * careers.kakao.com …)와 야놀자다. 계열사별 전용 수집기를 7개 만드는 대신, 흔한 본문 컨테이너를
+ * 순서대로 시도하고 없으면 body 에서 껍데기를 걷어낸다.</p>
+ *
+ * <p>서버 렌더링이 아니면(=SPA) 본문이 안 나온다. 그 경우 {@link com.nklcbdty.api.crawler.content.JobContentService}
+ * 가 "의미 있는 길이" 미달로 실패 처리하고, 나중에 그 회사 전용 수집기를 붙이면 된다.</p>
+ */
+@Component
+@Order(Integer.MAX_VALUE) // 아무도 안 잡을 때만
+@Slf4j
+public class GenericHtmlContentFetcher implements JobContentFetcher {
+
+    /** 앞에 있을수록 우선. 채용 사이트에서 흔한 본문 컨테이너들. */
+    private static final List<String> CONTENT_SELECTORS = List.of(
+        "[class*=jobDescription]", "[class*=job-description]", "[class*=recruit-detail]",
+        "[class*=jobDetail]", "[class*=job_detail]", "[class*=detail_content]",
+        "article", "main", "[role=main]", "#content", ".content"
+    );
+
+    /** 어느 컨테이너를 잡든 항상 걷어낼 것들. */
+    private static final String CHROME_SELECTOR =
+        "script, style, noscript, nav, header, footer, aside, form, iframe";
+
+    private final CrawlerCommonService commonService;
+
+    public GenericHtmlContentFetcher(CrawlerCommonService commonService) {
+        this.commonService = commonService;
+    }
+
+    @Override
+    public boolean supports(Job_mst job) {
+        String link = job.getJobDetailLink();
+        return link != null && link.startsWith("http");
+    }
+
+    @Override
+    public Fetched fetch(Job_mst job) throws Exception {
+        Document doc = commonService.jsoupConnect(job.getJobDetailLink()).get();
+        doc.select(CHROME_SELECTOR).remove();
+
+        Element best = null;
+        for (String selector : CONTENT_SELECTORS) {
+            Element candidate = longestMatch(doc, selector);
+            if (candidate != null && ContentText.isMeaningful(candidate.text())) {
+                best = candidate;
+                break;
+            }
+        }
+        if (best == null) {
+            best = doc.body();
+        }
+        if (best == null) {
+            return null;
+        }
+
+        String html = best.html();
+        return Fetched.ofHtml(html, ContentText.htmlToText(html));
+    }
+
+    /** 같은 선택자에 여러 개가 걸리면 텍스트가 가장 긴 것이 본문일 가능성이 높다. */
+    private Element longestMatch(Document doc, String selector) {
+        Element best = null;
+        int bestLength = 0;
+        for (Element element : doc.select(selector)) {
+            int length = element.text().length();
+            if (length > bestLength) {
+                best = element;
+                bestLength = length;
+            }
+        }
+        return best;
+    }
+
+    @Override
+    public String sourceName() {
+        return "generic-html";
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/fetcher/GreenhouseContentFetcher.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/fetcher/GreenhouseContentFetcher.java
@@ -1,0 +1,69 @@
+package com.nklcbdty.api.crawler.content.fetcher;
+
+import java.util.Map;
+
+import org.json.JSONObject;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.content.ContentText;
+import com.nklcbdty.api.crawler.content.JobContentFetcher;
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Greenhouse 공개 보드를 쓰는 회사(당근·쿠팡)의 본문.
+ *
+ * <p>{@code anno_id} 가 곧 Greenhouse job id(=gh_jid)라 그대로 상세를 부를 수 있다.
+ * 본문은 escape 된 HTML 로 오므로 {@link ContentText} 가 풀어서 텍스트로 바꾼다.</p>
+ */
+@Component
+@Order(20)
+@Slf4j
+public class GreenhouseContentFetcher implements JobContentFetcher {
+
+    private static final String DETAIL_API = "https://boards-api.greenhouse.io/v1/boards/%s/jobs/%s";
+
+    /** company_cd → Greenhouse 보드 이름. */
+    private static final Map<String, String> BOARDS = Map.of(
+        "DAANGN", "daangn",
+        "COUPANG", "coupang"
+    );
+
+    private final CrawlerCommonService commonService;
+
+    public GreenhouseContentFetcher(CrawlerCommonService commonService) {
+        this.commonService = commonService;
+    }
+
+    @Override
+    public boolean supports(Job_mst job) {
+        return boardOf(job) != null && job.getAnnoId() != null && !job.getAnnoId().isBlank();
+    }
+
+    @Override
+    public Fetched fetch(Job_mst job) {
+        String board = boardOf(job);
+        String raw = commonService.fetchApiResponse(
+            String.format(DETAIL_API, board, job.getAnnoId().trim()));
+
+        String html = new JSONObject(raw).optString("content", "");
+        if (html.isBlank()) {
+            log.warn("Greenhouse 본문 비어있음 board={} annoId={}", board, job.getAnnoId());
+            return null;
+        }
+        return Fetched.ofHtml(html, ContentText.htmlToText(html));
+    }
+
+    private String boardOf(Job_mst job) {
+        String companyCd = job.getCompanyCd();
+        return companyCd == null ? null : BOARDS.get(companyCd.toUpperCase());
+    }
+
+    @Override
+    public String sourceName() {
+        return "greenhouse-api";
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/fetcher/LineContentFetcher.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/fetcher/LineContentFetcher.java
@@ -1,0 +1,65 @@
+package com.nklcbdty.api.crawler.content.fetcher;
+
+import org.json.JSONObject;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.content.ContentText;
+import com.nklcbdty.api.crawler.content.JobContentFetcher;
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 라인 본문.
+ *
+ * <p>채용 사이트가 Gatsby 라 페이지마다 {@code page-data.json} 이 따로 있다.
+ * 목록 크롤러가 쓰는 {@code /page-data/ko/jobs/page-data.json} 과 같은 계열이고,
+ * 공고별 경로에 {@code strapiId}(=annoId)를 넣으면 본문({@code strapiJobs.content})이 나온다.</p>
+ */
+@Component
+@Order(40)
+@Slf4j
+public class LineContentFetcher implements JobContentFetcher {
+
+    private static final String PAGE_DATA = "https://careers.linecorp.com/page-data/ko/jobs/%s/page-data.json";
+
+    private final CrawlerCommonService commonService;
+
+    public LineContentFetcher(CrawlerCommonService commonService) {
+        this.commonService = commonService;
+    }
+
+    @Override
+    public boolean supports(Job_mst job) {
+        return "LINE".equalsIgnoreCase(job.getCompanyCd())
+            && job.getAnnoId() != null && !job.getAnnoId().isBlank();
+    }
+
+    @Override
+    public Fetched fetch(Job_mst job) {
+        String raw = commonService.fetchApiResponse(String.format(PAGE_DATA, job.getAnnoId().trim()));
+
+        JSONObject strapiJobs = new JSONObject(raw)
+            .optJSONObject("result");
+        strapiJobs = strapiJobs == null ? null : strapiJobs.optJSONObject("data");
+        strapiJobs = strapiJobs == null ? null : strapiJobs.optJSONObject("strapiJobs");
+
+        if (strapiJobs == null) {
+            log.warn("라인 본문: strapiJobs 없음 annoId={}", job.getAnnoId());
+            return null;
+        }
+
+        String html = strapiJobs.optString("content", "");
+        if (html.isBlank()) {
+            return null;
+        }
+        return Fetched.ofHtml(html, ContentText.htmlToText(html));
+    }
+
+    @Override
+    public String sourceName() {
+        return "line-page-data";
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/fetcher/NaverContentFetcher.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/fetcher/NaverContentFetcher.java
@@ -1,0 +1,60 @@
+package com.nklcbdty.api.crawler.content.fetcher;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.content.ContentText;
+import com.nklcbdty.api.crawler.content.JobContentFetcher;
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 네이버 본문.
+ *
+ * <p>{@code recruit.navercorp.com/rcrt/view.do?annoId=...} 는 서버 렌더링이라 HTML 에 본문이 그대로 있다.
+ * 다만 페이지 전체를 텍스트로 만들면 GNB·푸터가 절반이라, 본문 컨테이너({@code .detail_wrap})만 잘라낸다.</p>
+ */
+@Component
+@Order(50)
+@Slf4j
+public class NaverContentFetcher implements JobContentFetcher {
+
+    private static final String CONTENT_SELECTOR = ".detail_wrap";
+
+    private final CrawlerCommonService commonService;
+
+    public NaverContentFetcher(CrawlerCommonService commonService) {
+        this.commonService = commonService;
+    }
+
+    @Override
+    public boolean supports(Job_mst job) {
+        String link = job.getJobDetailLink();
+        return "NAVER".equalsIgnoreCase(job.getCompanyCd())
+            && link != null && link.contains("recruit.navercorp.com");
+    }
+
+    @Override
+    public Fetched fetch(Job_mst job) throws Exception {
+        Document doc = commonService.jsoupConnect(job.getJobDetailLink()).get();
+
+        Element body = doc.selectFirst(CONTENT_SELECTOR);
+        if (body == null) {
+            // 마크업이 바뀐 것이므로 조용히 넘기지 않는다. 전 공고가 한꺼번에 빈 본문이 된다.
+            log.warn("네이버 본문: {} 를 못 찾음 link={}", CONTENT_SELECTOR, job.getJobDetailLink());
+            return null;
+        }
+
+        String html = body.html();
+        return Fetched.ofHtml(html, ContentText.htmlToText(html));
+    }
+
+    @Override
+    public String sourceName() {
+        return "naver-html";
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/content/fetcher/TossContentFetcher.java
+++ b/src/main/java/com/nklcbdty/api/crawler/content/fetcher/TossContentFetcher.java
@@ -1,0 +1,66 @@
+package com.nklcbdty.api.crawler.content.fetcher;
+
+import org.json.JSONObject;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.content.ContentText;
+import com.nklcbdty.api.crawler.content.JobContentFetcher;
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 토스 본문.
+ *
+ * <p>토스 채용은 Greenhouse 를 쓰지만(링크가 {@code ?gh_jid=}) 공개 보드가 열려 있지 않아
+ * ({@code boards-api.greenhouse.io/v1/boards/toss} 404) 토스가 감싼 API 를 쓴다.
+ * 목록 API({@code /career/job-groups})에는 본문이 없고 상세에만 있다.</p>
+ *
+ * <p>본문이 {@code <p>#LI-DNI</p>} 처럼 껍데기만 오는 공고가 있다. 그런 건 수집 실패로 두고
+ * {@link GenericHtmlContentFetcher} 가 아니라 다음 주기에 다시 시도하게 둔다 — 토스 상세페이지도
+ * 클라이언트 렌더링이라 HTML 을 받아봐야 마찬가지다.</p>
+ */
+@Component
+@Order(30)
+@Slf4j
+public class TossContentFetcher implements JobContentFetcher {
+
+    private static final String DETAIL_API =
+        "https://api-public.toss.im/api/v3/ipd-eggnog/career/jobs/%s";
+
+    private final CrawlerCommonService commonService;
+
+    public TossContentFetcher(CrawlerCommonService commonService) {
+        this.commonService = commonService;
+    }
+
+    @Override
+    public boolean supports(Job_mst job) {
+        return "TOSS".equalsIgnoreCase(job.getCompanyCd())
+            && job.getAnnoId() != null && !job.getAnnoId().isBlank();
+    }
+
+    @Override
+    public Fetched fetch(Job_mst job) {
+        String raw = commonService.fetchApiResponse(String.format(DETAIL_API, job.getAnnoId().trim()));
+
+        JSONObject success = new JSONObject(raw).optJSONObject("success");
+        if (success == null) {
+            log.warn("토스 본문: success 없음 annoId={}", job.getAnnoId());
+            return null;
+        }
+
+        String html = success.optString("content", "");
+        if (html.isBlank()) {
+            return null;
+        }
+        return Fetched.ofHtml(html, ContentText.htmlToText(html));
+    }
+
+    @Override
+    public String sourceName() {
+        return "toss-api";
+    }
+}

--- a/src/main/java/com/nklcbdty/api/crawler/service/DaangnJobCrawlerService.java
+++ b/src/main/java/com/nklcbdty/api/crawler/service/DaangnJobCrawlerService.java
@@ -74,7 +74,9 @@ public class DaangnJobCrawlerService {
 
 					// Greenhouse job id. 구 크롤러의 ghId 와 같은 값이라 기존 DB row 와 그대로 매칭된다.
 					String annoId = item.opt("id") == null ? null : item.get("id").toString();
-					String annoSubject = item.optString("title", "");
+					// Greenhouse 의 title 은 "... (세일즈, Agency) " 처럼 끝에 공백이 붙어 내려오는 건이 있다.
+					// 그대로 저장하면 링크 점검 배치의 "HTML 에 공고명이 있는가" 판정이 항상 실패한다.
+					String annoSubject = item.optString("title", "").strip();
 
 					if (annoId == null || annoId.isBlank() || annoSubject.isBlank()) {
 						log.warn("당근 공고 필수값 누락으로 건너뜀 (index={}, id={})", i, annoId);

--- a/src/test/java/com/nklcbdty/api/crawler/common/CrawlerCommonServiceExistingRowTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/common/CrawlerCommonServiceExistingRowTest.java
@@ -170,6 +170,48 @@ class CrawlerCommonServiceExistingRowTest {
     }
 
     @Test
+    void 회사가_공고명을_바꾸면_기존_row_의_공고명도_따라간다() {
+        // 당근이 "A | B" → "A - B" 로 제목을 일괄 변경했는데 DB 만 옛 제목으로 남아,
+        // 링크 점검 배치가 상세페이지 HTML 에서 그 제목을 못 찾고 매일 종료 처리했다.
+        Job_mst existing = job("5296522003", "Software Engineer, Backend | 부동산");
+        existing.setSubJobCdNm("Backend");
+        existing.setEmbedding(new byte[] { 1, 2, 3 }); // 옛 제목으로 색인된 벡터
+
+        Job_mst crawled = job("5296522003", "Software Engineer, Backend - 부동산");
+        crawled.setSubJobCdNm("Backend");
+
+        when(crawlerRepository.findAllByAnnoIdIn(anyList())).thenReturn(List.of(existing));
+        when(crawlerRepository.findAllByCompanyCd("DAANGN")).thenReturn(List.of(existing));
+
+        service.getNotSaveJobItem("DAANGN", List.of(crawled));
+
+        verify(crawlerRepository).saveAll(savedCaptor.capture());
+        Job_mst updated = savedCaptor.getValue().get(0);
+        assertEquals("Software Engineer, Backend - 부동산", updated.getAnnoSubject());
+        assertNull(updated.getEmbedding(), "제목이 바뀌었으면 다시 색인되도록 임베딩을 비운다");
+    }
+
+    @Test
+    void 공고명_앞뒤_공백만_다른_경우는_갱신하지_않는다() {
+        // Greenhouse 는 제목 끝에 공백을 붙여 내려주기도 한다. 같은 제목으로 보고 쓰기를 만들지 않는다.
+        Job_mst existing = job("7568233003", "Sales & Account Manager - 로컬 잡스");
+        existing.setSubJobCdNm("Backend");
+        existing.setEndDate("2999-12-31 00:00:00");
+
+        Job_mst crawled = job("7568233003", "Sales & Account Manager - 로컬 잡스 ");
+        crawled.setSubJobCdNm("Backend");
+        crawled.setEndDate("2999-12-31 00:00:00");
+
+        when(crawlerRepository.findAllByAnnoIdIn(anyList())).thenReturn(List.of(existing));
+        when(crawlerRepository.findAllByCompanyCd("DAANGN")).thenReturn(List.of(existing));
+
+        service.getNotSaveJobItem("DAANGN", List.of(crawled));
+
+        verify(crawlerRepository, never()).saveAll(anyList());
+        assertEquals("Sales & Account Manager - 로컬 잡스", existing.getAnnoSubject());
+    }
+
+    @Test
     void 신규_공고는_기존_row_갱신_대상이_아니다() {
         Job_mst crawled = job("999", "새로 올라온 공고");
 

--- a/src/test/java/com/nklcbdty/api/crawler/content/ContentTextTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/content/ContentTextTest.java
@@ -1,0 +1,57 @@
+package com.nklcbdty.api.crawler.content;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ContentTextTest {
+
+    @Test
+    void 블록_요소는_줄바꿈으로_끊는다() {
+        String html = "<p>주요업무</p><ul><li>서버 개발</li><li>운영</li></ul>";
+
+        String text = ContentText.htmlToText(html);
+
+        // Jsoup.text() 만 쓰면 "주요업무 서버 개발 운영" 한 줄이 된다. 목록이 살아야 읽힌다.
+        assertEquals("주요업무\n서버 개발\n운영", text);
+    }
+
+    @Test
+    void 스크립트와_스타일은_본문에서_뺀다() {
+        String html = "<div><script>var a=1;</script><style>.a{color:red}</style><p>자격요건</p></div>";
+
+        assertEquals("자격요건", ContentText.htmlToText(html));
+    }
+
+    @Test
+    void escape_된_HTML_도_풀어서_읽는다() {
+        // Greenhouse 는 본문을 이 모양으로 준다.
+        String escaped = "&lt;p&gt;주요업무&lt;/p&gt;&lt;p&gt;백엔드 개발&lt;/p&gt;";
+
+        assertEquals("주요업무\n백엔드 개발", ContentText.htmlToText(escaped));
+    }
+
+    @Test
+    void 빈_줄과_중복_공백을_정리한다() {
+        String html = "<p>가</p><p></p><p></p><p></p><p>나</p>";
+
+        String text = ContentText.htmlToText(html);
+
+        assertFalse(text.contains("\n\n\n"), "빈 줄이 3줄 이상 이어지면 안 된다: " + text.replace("\n", "\\n"));
+    }
+
+    @Test
+    void 짧은_껍데기_본문은_의미없음으로_본다() {
+        // 토스 일부 공고가 실제로 이렇게만 내려온다.
+        assertFalse(ContentText.isMeaningful(ContentText.htmlToText("<p>#LI-DNI</p>")));
+        assertTrue(ContentText.isMeaningful("가".repeat(ContentText.MIN_MEANINGFUL_LENGTH)));
+    }
+
+    @Test
+    void null_과_빈_문자열은_빈_본문이다() {
+        assertEquals("", ContentText.htmlToText(null));
+        assertEquals("", ContentText.htmlToText("   "));
+    }
+}

--- a/src/test/java/com/nklcbdty/api/crawler/content/JobContentRepositoryTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/content/JobContentRepositoryTest.java
@@ -1,0 +1,130 @@
+package com.nklcbdty.api.crawler.content;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+
+import com.nklcbdty.common.vo.Job_mst;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * {@code findNeedingContent} 의 JPQL 검증.
+ *
+ * <p>{@code @Query} 로 쓴 JPQL 은 앱 기동 시점에 파싱된다 — 틀리면 배포가 그대로 장애가 된다.
+ * 운영 DB 없이 미리 걸러내려고 인메모리 DB 로 실제 실행해 본다.</p>
+ */
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:jobcontent;DB_CLOSE_DELAY=-1;MODE=MySQL",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+    "spring.autoconfigure.exclude="
+        + "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,"
+        + "org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration,"
+        + "org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration,"
+        + "org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration,"
+        + "org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration"
+})
+@Import(JobContentRepositoryTest.QuerydslTestConfig.class)
+class JobContentRepositoryTest {
+
+    /**
+     * {@code @EnableJpaRepositories} 가 common jar 의 리포지토리까지 함께 올린다.
+     * 그중 QueryDSL 을 쓰는 구현체가 JPAQueryFactory 를 요구하는데, JPA 슬라이스에는 그 빈이 없다.
+     */
+    @TestConfiguration
+    static class QuerydslTestConfig {
+        @Bean
+        JPAQueryFactory jpaQueryFactory(EntityManager em) {
+            return new JPAQueryFactory(em);
+        }
+    }
+
+    @Autowired
+    private JobContentRepository repository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Job_mst job(String subJob, String link) {
+        Job_mst job = new Job_mst();
+        job.setCompanyCd("BAEMIN");
+        job.setAnnoId("a" + System.nanoTime());
+        job.setAnnoSubject("서버 개발자");
+        job.setSubJobCdNm(subJob);
+        job.setJobDetailLink(link);
+        em.persist(job);
+        return job;
+    }
+
+    private void content(Long jobId, LocalDateTime fetchedAt) {
+        JobContent row = new JobContent(jobId, "BAEMIN");
+        row.setFetchedAt(fetchedAt);
+        em.persist(row);
+    }
+
+    @Test
+    void 아직_수집_안_한_공고를_준다() {
+        Job_mst target = job("Backend", "https://example.com/1");
+        em.flush();
+
+        List<Job_mst> result = repository.findNeedingContent(
+            LocalDateTime.now().minusDays(14), PageRequest.of(0, 10));
+
+        assertEquals(1, result.size());
+        assertEquals(target.getId(), result.get(0).getId());
+    }
+
+    @Test
+    void 최근에_수집한_공고는_빼고_오래된_건_다시_준다() {
+        Job_mst fresh = job("Backend", "https://example.com/fresh");
+        Job_mst stale = job("Backend", "https://example.com/stale");
+        em.flush();
+        content(fresh.getId(), LocalDateTime.now().minusDays(1));
+        content(stale.getId(), LocalDateTime.now().minusDays(30));
+        em.flush();
+
+        List<Job_mst> result = repository.findNeedingContent(
+            LocalDateTime.now().minusDays(14), PageRequest.of(0, 10));
+
+        assertEquals(List.of(stale.getId()), result.stream().map(Job_mst::getId).toList());
+    }
+
+    @Test
+    void 미분류_공고와_링크없는_공고는_대상이_아니다() {
+        job(null, "https://example.com/unclassified");
+        job("Backend", "");
+        job("Backend", null);
+        em.flush();
+
+        assertTrue(repository.findNeedingContent(
+            LocalDateTime.now().minusDays(14), PageRequest.of(0, 10)).isEmpty());
+    }
+
+    @Test
+    void 한_번에_가져올_건수를_제한한다() {
+        for (int i = 0; i < 5; i++) {
+            job("Backend", "https://example.com/" + i);
+        }
+        em.flush();
+
+        assertEquals(2, repository.findNeedingContent(
+            LocalDateTime.now().minusDays(14), PageRequest.of(0, 2)).size());
+    }
+}

--- a/src/test/java/com/nklcbdty/api/crawler/content/JobContentServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/content/JobContentServiceTest.java
@@ -1,0 +1,144 @@
+package com.nklcbdty.api.crawler.content;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.nklcbdty.common.vo.Job_mst;
+
+class JobContentServiceTest {
+
+    @Mock
+    private JobContentRepository repository;
+
+    @Captor
+    private ArgumentCaptor<JobContent> savedCaptor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(repository.save(any(JobContent.class))).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    private Job_mst job() {
+        Job_mst job = new Job_mst();
+        job.setId(1L);
+        job.setCompanyCd("BAEMIN");
+        job.setAnnoId("25163");
+        job.setJobDetailLink("https://career.woowahan.com/recruitment/R2605009/detail");
+        return job;
+    }
+
+    /** 테스트용 수집기. supports/결과를 원하는 대로 만든다. */
+    private JobContentFetcher fetcher(String name, boolean supports, JobContentFetcher.Fetched result, RuntimeException error) {
+        return new JobContentFetcher() {
+            @Override
+            public boolean supports(Job_mst j) {
+                return supports;
+            }
+
+            @Override
+            public Fetched fetch(Job_mst j) {
+                if (error != null) {
+                    throw error;
+                }
+                return result;
+            }
+
+            @Override
+            public String sourceName() {
+                return name;
+            }
+        };
+    }
+
+    private String longBody() {
+        return "주요업무\n" + "백엔드 서비스를 개발합니다. ".repeat(10);
+    }
+
+    @Test
+    void 앞에_있는_수집기가_이긴다() {
+        when(repository.findById(1L)).thenReturn(Optional.empty());
+        JobContentService service = new JobContentService(repository, List.of(
+            fetcher("전용", true, JobContentFetcher.Fetched.ofText(longBody()), null),
+            fetcher("범용", true, JobContentFetcher.Fetched.ofText("다른 본문 " + longBody()), null)));
+
+        assertTrue(service.collect(job()));
+
+        org.mockito.Mockito.verify(repository).save(savedCaptor.capture());
+        assertEquals("전용", savedCaptor.getValue().getSource());
+    }
+
+    @Test
+    void 수집기가_예외를_던지면_실패로_기록하고_본문은_비운다() {
+        when(repository.findById(1L)).thenReturn(Optional.empty());
+        JobContentService service = new JobContentService(repository, List.of(
+            fetcher("전용", true, null, new IllegalStateException("502 Bad Gateway"))));
+
+        assertFalse(service.collect(job()));
+
+        org.mockito.Mockito.verify(repository).save(savedCaptor.capture());
+        JobContent saved = savedCaptor.getValue();
+        assertEquals("502 Bad Gateway", saved.getFailReason());
+        assertNull(saved.getContent());
+        // 실패도 fetchedAt 을 남겨야 다음 주기에 같은 공고만 다시 잡히지 않는다.
+        assertNotNull(saved.getFetchedAt());
+    }
+
+    @Test
+    void 본문이_너무_짧으면_실패다() {
+        when(repository.findById(1L)).thenReturn(Optional.empty());
+        JobContentService service = new JobContentService(repository, List.of(
+            fetcher("전용", true, JobContentFetcher.Fetched.ofText("#LI-DNI"), null)));
+
+        assertFalse(service.collect(job()));
+
+        org.mockito.Mockito.verify(repository).save(savedCaptor.capture());
+        assertNull(savedCaptor.getValue().getContent());
+        assertTrue(savedCaptor.getValue().getFailReason().contains("너무 짧음"));
+    }
+
+    @Test
+    void 내용이_그대로면_본문을_다시_쓰지_않는다() {
+        JobContentService service = new JobContentService(repository, List.of(
+            fetcher("전용", true, JobContentFetcher.Fetched.ofText(longBody()), null)));
+
+        // 먼저 한 번 수집해 해시가 박힌 row 를 만든다.
+        when(repository.findById(1L)).thenReturn(Optional.empty());
+        service.collect(job());
+        org.mockito.Mockito.verify(repository).save(savedCaptor.capture());
+        JobContent existing = savedCaptor.getValue();
+        java.time.LocalDateTime firstUpdatedAt = existing.getUpdatedAt();
+
+        // 같은 본문으로 다시 수집.
+        when(repository.findById(1L)).thenReturn(Optional.of(existing));
+        assertFalse(service.collect(job()), "내용이 같으면 갱신이 아니다");
+        assertEquals(firstUpdatedAt, existing.getUpdatedAt(), "updatedAt 이 그대로여야 한다");
+    }
+
+    @Test
+    void 지원하는_수집기가_없으면_실패로_남긴다() {
+        when(repository.findById(1L)).thenReturn(Optional.empty());
+        JobContentService service = new JobContentService(repository, List.of(
+            fetcher("전용", false, JobContentFetcher.Fetched.ofText(longBody()), null)));
+
+        assertFalse(service.collect(job()));
+
+        org.mockito.Mockito.verify(repository).save(savedCaptor.capture());
+        assertEquals("수집기 없음", savedCaptor.getValue().getFailReason());
+    }
+}

--- a/src/test/java/com/nklcbdty/api/crawler/content/LiveContentFetcherCheck.java
+++ b/src/test/java/com/nklcbdty/api/crawler/content/LiveContentFetcherCheck.java
@@ -1,0 +1,99 @@
+package com.nklcbdty.api.crawler.content;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.content.fetcher.BaeminContentFetcher;
+import com.nklcbdty.api.crawler.content.fetcher.GenericHtmlContentFetcher;
+import com.nklcbdty.api.crawler.content.fetcher.GreenhouseContentFetcher;
+import com.nklcbdty.api.crawler.content.fetcher.LineContentFetcher;
+import com.nklcbdty.api.crawler.content.fetcher.NaverContentFetcher;
+import com.nklcbdty.api.crawler.content.fetcher.TossContentFetcher;
+import com.nklcbdty.common.vo.Job_mst;
+
+/**
+ * 실제 채용 사이트를 호출해 수집기가 본문을 가져오는지 눈으로 확인하는 용도.
+ *
+ * <p>단위 테스트가 아니다(외부 의존·비결정적). 채용 사이트 마크업이 바뀌어 본문이 안 잡힐 때
+ * {@code ./gradlew test --tests "*LiveContentFetcherCheck*"} 로 켜서 회사별로 어디가 깨졌는지 본다.
+ * 평소에는 {@code @Disabled} 로 꺼 둔다.</p>
+ */
+@org.junit.jupiter.api.Disabled("실제 채용 사이트를 호출한다. 필요할 때 수동으로 켠다")
+class LiveContentFetcherCheck {
+
+    private final CrawlerCommonService common = new CrawlerCommonService(null, null, null);
+
+    private Job_mst job(String companyCd, String annoId, String link) {
+        Job_mst job = new Job_mst();
+        job.setId(1L);
+        job.setCompanyCd(companyCd);
+        job.setAnnoId(annoId);
+        job.setJobDetailLink(link);
+        return job;
+    }
+
+    // 윈도우 콘솔 코드페이지에서 한글이 깨져 결과를 UTF-8 파일로 남긴다.
+    private final StringBuilder report = new StringBuilder();
+
+    private void check(JobContentFetcher fetcher, Job_mst job) {
+        try {
+            JobContentFetcher.Fetched fetched = fetcher.fetch(job);
+            if (fetched == null || fetched.isEmpty()) {
+                report.append(String.format("  %-18s %-8s FAIL 본문 없음%n", fetcher.sourceName(), job.getCompanyCd()));
+                return;
+            }
+            String text = fetched.text().strip();
+            report.append(String.format("  %-18s %-8s %s %d자 | %s%n",
+                fetcher.sourceName(), job.getCompanyCd(),
+                ContentText.isMeaningful(text) ? "OK  " : "SHORT",
+                text.length(),
+                text.replace("\n", " / ").substring(0, Math.min(90, text.length()))));
+        } catch (Exception e) {
+            report.append(String.format("  %-18s %-8s FAIL %s%n", fetcher.sourceName(), job.getCompanyCd(), e.getMessage()));
+        }
+    }
+
+    private void writeReport() {
+        try {
+            java.nio.file.Path out = java.nio.file.Path.of("build", "live-content-check.txt");
+            java.nio.file.Files.createDirectories(out.getParent());
+            java.nio.file.Files.writeString(out, report.toString(), java.nio.charset.StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("리포트 기록 실패", e);
+        }
+    }
+
+    @Test
+    void 회사별_본문_수집_확인() {
+        report.append("=== 공고 본문 수집 실측 ===\n");
+
+        check(new BaeminContentFetcher(common),
+            job("BAEMIN", "25163", "https://career.woowahan.com/recruitment/R2605009/detail"));
+
+        check(new GreenhouseContentFetcher(common),
+            job("DAANGN", "6045408003", "https://careers.daangn.com/jobs/role/6045408003/"));
+
+        check(new GreenhouseContentFetcher(common),
+            job("COUPANG", "6137112", "https://www.coupang.jobs/kr/jobs/6137112/x/?gh_jid=6137112"));
+
+        check(new TossContentFetcher(common),
+            job("TOSS", "6619423003", "https://toss.im/career/job-detail?gh_jid=6619423003"));
+
+        check(new LineContentFetcher(common),
+            job("LINE", "3049", "https://careers.linecorp.com/ko/jobs/3049"));
+
+        check(new NaverContentFetcher(common),
+            job("NAVER", "30005210", "https://recruit.navercorp.com/rcrt/view.do?annoId=30005210"));
+
+        GenericHtmlContentFetcher generic = new GenericHtmlContentFetcher(common);
+        for (Job_mst kakao : List.of(
+            job("KAKAO", "257469", "https://kakaobank.recruiter.co.kr/app/jobnotice/view?systemKindCode=MRS2&jobnoticeSn=257469"),
+            job("YANOLJA", "1", "https://careers.yanolja.co/"))) {
+            check(generic, kakao);
+        }
+
+        writeReport();
+    }
+}


### PR DESCRIPTION
## 증상

당근 개발 공고가 목록에 2~7건만 뜬다. 채용 사이트에 들어가면 25건 넘게 살아 있다.
배민은 아예 0건. (`/api/list?company=DAANGN` 7건, `BAEMIN` 0건 — 2026-08-13 확인)

## 원인 — 이 PR 이 고치는 것 (당근)

링크 점검 배치는 **상세페이지 HTML 에 DB 의 공고명 문자열이 들어있는가**로 생존을 판정한다.
그런데 크롤이 기존 row 를 갱신할 때 `endDate` / `subJobCdNm` / `jobDetailLink` 만 손대고
`annoSubject` 는 손대지 않았다.

당근이 제목을 `A | B` → `A - B` 로 일괄 변경한 뒤, DB 만 옛 제목으로 남았다:

| DB 제목 | 현재 페이지 제목 | HTML 매칭 |
|---|---|---|
| `Software Engineer, Backend \| 부동산` | `Software Engineer, Backend - 부동산` | ❌ |
| `Software Engineer, Frontend \| 커뮤니티 (당근 모임)` | `Software Engineer, Frontend - 커뮤니티 (모임)` | ❌ |
| `Application Security Engineer` | `Lead Security Engineer - 인프라 (보안, Offensive Security)` | ❌ |

07:00 크롤이 `endDate` 를 되살리면 09:30 링크 점검이 다시 죽이는 하루 주기가 된다.
아침에는 보이고 저녁에는 사라지는 이유. 오늘 기준 당근 개발 공고 17건 중 **12건**이 이 상태였다.

상세페이지 HTML 에 **현재 제목은 그대로 들어있다** — 제목만 맞추면 살아남는다.

## 수정

- 크롤에 잡힌 제목이 기존 row 와 다르면 `annoSubject` 를 갱신한다.
  제목은 검색 임베딩 입력의 첫 항목이라 `embedding` 을 비워 `JobEmbeddingIndexer` 가 재색인하게 했다.
- Greenhouse 는 `title` 끝에 공백을 붙여 내려주는 건이 있다(`"... (세일즈, Agency) "`).
  그대로 저장하면 HTML 매칭이 항상 실패하므로 당근 크롤러에서 `strip()` 한다.
  앞뒤 공백만 다른 경우는 같은 제목으로 보고 불필요한 UPDATE 를 만들지 않는다.

## 검증

- 신규 테스트 2건 (`CrawlerCommonServiceExistingRowTest`)
  - 제목이 바뀌면 기존 row 의 `annoSubject` 가 갱신되고 `embedding` 이 비워진다
  - 앞뒤 공백만 다르면 `saveAll` 이 호출되지 않는다
- 기존 테스트 회귀 없음 (`AdminSubscriptionServiceTest` 2건 실패는 main 에서도 동일하게 실패하는 기존 건)
- 운영에서 `/api/crawler?company=daangn` 수동 호출로 당근 7건 → 26건 복구 확인

## 이 PR 로 안 고쳐지는 것 (배민)

배민은 **batch 저장소 배포 문제**다. `BaeminLivenessChecker`(2026-08-04, `59fb66f`)가 운영에 없다.
`nklcbdty-batch` 의 `Build and Publish Docker Image` 워크플로가 **`disabled_manually`** 상태라
6/11 이후 한 번도 안 돌았고, Docker Hub `ejy1024/nklcbdty-batch:latest` 는 **2026-06-10** 이 마지막이다.
batch 재배포가 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added job announcement content collection and storage.
  - Added automatic content refresh for missing or outdated announcements.
  - Added an API endpoint to view stored announcement content.
  - Added support for retrieving content from multiple recruiting platforms, with a general web-page fallback.
  - Improved HTML-to-text conversion for clearer, readable announcement content.

- **Bug Fixes**
  - Updated stored job announcement titles when crawled titles change.
  - Removed trailing whitespace from imported job titles.
  - Refreshed search indexing when a title changes, while avoiding unnecessary updates for whitespace-only differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->