### PR TITLE
✅ Test: AdminSubscriptionServiceTest 를 EmailService 단일 진입점에 맞게 수정

### DIFF
--- a/src/test/java/com/nklcbdty/api/admin/service/AdminSubscriptionServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/admin/service/AdminSubscriptionServiceTest.java
@@ -1,9 +1,11 @@
 package com.nklcbdty.api.admin.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,8 +15,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 import com.nklcbdty.api.admin.dto.AdminSubscriptionDetailDto;
 import com.nklcbdty.api.admin.dto.AdminSubscriptionPageResponse;
@@ -195,25 +195,27 @@ class AdminSubscriptionServiceTest {
     }
 
     @Test
-    @DisplayName("sendJobEmail: 발송 대상 이메일이 있으면 EmailService.sendEmail로 본문을 발송한다")
-    void sendJobEmail_dispatchesMail() {
-        when(emailService.sendEmail(eq(List.of("kakao@1"))))
-            .thenReturn(Map.of("user@test.com", "<html>본문</html>"));
+    @DisplayName("sendJobEmail: 메일 조립·발송을 EmailService 단일 진입점(sendJobDailyEmails)에 위임한다")
+    void sendJobEmail_delegatesToSingleEntryPoint() {
+        when(emailService.sendJobDailyEmails(eq(List.of("kakao@1")))).thenReturn(1);
 
         service.sendJobEmail("kakao@1");
 
-        verify(emailService).sendEmail(eq("user@test.com"), any(String.class), eq("<html>본문</html>"));
+        verify(emailService).sendJobDailyEmails(eq(List.of("kakao@1")));
+        // 제목 생성·수신자별 발송·대상 없을 때 건너뛰기는 EmailService 책임이므로
+        // 관리자 경로에서 직접 발송하지 않는다 (자동 메일과 정책이 갈라지던 원인)
+        verify(emailService, never()).sendEmail(any(String.class), any(String.class), any(String.class));
     }
 
     @Test
-    @DisplayName("sendJobEmail: 발송할 컨텐츠가 없으면 EmailService.sendEmail(to,...)을 호출하지 않는다")
-    void sendJobEmail_skipsWhenEmpty() {
-        when(emailService.sendEmail(eq(List.of("kakao@1")))).thenReturn(Map.of());
+    @DisplayName("sendJobEmail: 발송이 실패해도 @Async 호출자로 예외를 전파하지 않는다")
+    void sendJobEmail_swallowsException() {
+        when(emailService.sendJobDailyEmails(eq(List.of("kakao@1"))))
+            .thenThrow(new RuntimeException("smtp down"));
 
-        service.sendJobEmail("kakao@1");
+        assertThatCode(() -> service.sendJobEmail("kakao@1")).doesNotThrowAnyException();
 
-        verify(emailService, org.mockito.Mockito.never())
-            .sendEmail(any(String.class), any(String.class), any(String.class));
+        verify(emailService).sendJobDailyEmails(eq(List.of("kakao@1")));
     }
 
     @Test


### PR DESCRIPTION
## 문제

`main` 에서 테스트 1건이 계속 실패하고 있었다. 게시판 작업과는 무관한, 원래 있던 실패다.

`AdminSubscriptionServiceTest > sendJobEmail: 발송 대상 이메일로 지정한 EmailService.sendEmail을 실제로 발송한다`

```
Wanted but not invoked:
emailService.sendEmail("user@test.com", <any String>, "<html>본문</html>");
However, there was exactly 1 interaction with this mock:
emailService.sendJobDailyEmails([kakao@1]);
```

## 원인

중복 메일 수정(`8e026c7`)이 아니라 그보다 앞선 **`308c879` "EmailService 단일 진입점 통합"** 이다. `8e026c7` 은 `AdminSubscriptionService` 를 건드리지 않았다.

`308c879` 가 `sendJobEmail` 안의 제목 조립 + 수신자 루프를 걷어내고 `emailService.sendJobDailyEmails(List.of(userId))` 한 줄로 바꿨는데, 그 커밋이 테스트를 함께 고치지 않아 테스트만 옛 호출을 계속 기대하고 있었다.

## 판단: 구현이 맞다 → 테스트를 고쳤다

되돌리면 안 되는 이유 두 가지:

1. **통합 목적 자체가 정책 공유다.** 수동(관리자)/자동(batch) 메일이 제목·경력 필터·종료 공고 제외·중복 제거를 같은 경로에서 처리하게 만든 것이 `308c879` 의 목적이다. 관리자 경로에서 다시 직접 조립하면 정책이 또 갈라진다.
2. **걷어낸 옛 코드에는 실제 버그가 있었다.** 제목을 `LocalDate.now().plusDays(1)` 로 만들어 **내일 날짜**가 찍혔다. 통합된 `JobEmailContentBuilder.buildDailyTitle()` 은 오늘 날짜를 쓴다. 되돌리면 이 버그가 같이 돌아온다.

## 변경

- `sendJobEmail_dispatchesMail` → `sendJobEmail_delegatesToSingleEntryPoint`
  `sendJobDailyEmails(List.of(userId))` 위임을 검증하고, 관리자 경로가 `sendEmail(to, subject, body)` 를 직접 부르지 않는다는 것도 `never()` 로 못박았다.
- `sendJobEmail_skipsWhenEmpty` → `sendJobEmail_swallowsException`
  "대상 없으면 건너뛴다" 는 이제 `EmailService` 책임이라 이 클래스에서 검증할 수 없다. 대신 `sendJobEmail` 에 남아있는 유일한 로직 — `@Async` 호출자로 예외를 흘리지 않는 try/catch — 을 검증한다.

프로덕션 코드 변경은 없다. 테스트 파일 한 개만 바뀐다.

## 검증

`./gradlew test --offline` — **126개 통과, 0 실패.** `AdminSubscriptionServiceTest` 10개 전부 통과.

다만 `NklcbdtyApplicationTests.contextLoads` 는 이 환경에서 실패한다:

```
Failed to instantiate [com.zaxxer.hikari.HikariDataSource]: URL must start with 'jdbc'
```

`application.properties` 가 `spring.datasource.url=${DATASOURCE_URL}` 인데 `src/test/resources` 에 오버라이드가 없어서, 환경변수 없이 돌리면 컨텍스트 로딩이 깨진다. **이 PR 과 무관하다** — 변경을 stash 하고 돌려도 똑같이 실패하는 것을 확인했다. 그래서 이 1건만 제외하고 나머지 126개를 돌렸다.

> 후속 과제로 남길 만한 것: `src/test/resources/application.properties` 에 테스트용 datasource(H2 등)를 두면 `contextLoads` 가 환경변수 없이도 돌아간다. 이번 범위 밖이라 손대지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
