### PR TITLE
✅ Test: 관리자 메일 경로가 EmailService 를 우회하지 못하게 검증 두 줄 추가

### DIFF
--- a/src/test/java/com/nklcbdty/api/admin/service/AdminSubscriptionServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/admin/service/AdminSubscriptionServiceTest.java
@@ -1,9 +1,11 @@
 package com.nklcbdty.api.admin.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -198,6 +200,9 @@ class AdminSubscriptionServiceTest {
         service.sendJobEmail("kakao@1");
 
         verify(emailService).sendJobDailyEmails(eq(List.of("kakao@1")));
+        // 제목 생성·수신자별 발송·대상 없을 때 건너뛰기는 EmailService 책임이다.
+        // 관리자 경로가 다시 직접 조립하면 자동(batch) 메일과 정책이 갈라진다.
+        verify(emailService, never()).sendEmail(any(String.class), any(String.class), any(String.class));
     }
 
     @Test
@@ -206,7 +211,8 @@ class AdminSubscriptionServiceTest {
         when(emailService.sendJobDailyEmails(eq(List.of("kakao@1"))))
             .thenThrow(new RuntimeException("smtp down"));
 
-        service.sendJobEmail("kakao@1");
+        // @Async 로 도는 메서드라 예외를 흘리면 호출자가 알 수 없는 곳에서 죽는다
+        assertThatCode(() -> service.sendJobEmail("kakao@1")).doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
`d5a8439` 로 `sendJobEmail` 테스트가 위임 검증으로 바뀐 것에 회귀 가드 두 가지만 얹는다. **프로덕션 코드 변경은 없다** — 테스트 파일 한 개, +7/-1.

## 1. `never()` 로 우회 경로를 막는다

위임 호출만 확인하면 "`sendJobDailyEmails` 도 부르고 `sendEmail(to, subject, body)` 도 직접 부르는" 상태를 잡지 못한다.

```java
verify(emailService).sendJobDailyEmails(eq(List.of("kakao@1")));
verify(emailService, never()).sendEmail(any(String.class), any(String.class), any(String.class));
```

`308c879` 가 단일 진입점으로 통합한 이유가 수동(관리자)/자동(batch) 메일이 제목·경력 필터·종료 공고 제외·중복 제거 정책을 공유하게 만드는 것이었다. 관리자 경로가 다시 직접 조립하는 방향으로 돌아가면 정책이 또 갈라지므로 못박아둔다.

가드가 실제로 무는지 확인했다 — `AdminSubscriptionService.sendJobEmail` 에 `emailService.sendEmail("x@test.com", "t", "b")` 한 줄을 넣자 테스트가 깨졌고, 확인 후 원복했다.

## 2. `assertThatCode` 로 의도를 남긴다

```java
assertThatCode(() -> service.sendJobEmail("kakao@1")).doesNotThrowAnyException();
```

기존에는 `service.sendJobEmail("kakao@1")` 을 호출만 하고 아무것도 단언하지 않아서, 본문만 봐서는 무엇을 검증하는 테스트인지 알 수 없었다(예외가 나면 테스트가 깨지긴 하지만 암묵적이다). `@Async` 메서드라 예외를 흘리면 호출자가 알 수 없는 곳에서 죽는다는 의도를 코드에 남긴다.

## 검증

`./gradlew test --offline` — **167개 중 실패 1개.** 실패한 건 `NklcbdtyApplicationTests.contextLoads` 뿐이고, 이 변경과 무관하다:

```
Failed to instantiate [com.zaxxer.hikari.HikariDataSource]: URL must start with 'jdbc'
```

`application.properties` 가 `spring.datasource.url=${DATASOURCE_URL}` 인데 `src/test/resources` 오버라이드가 없어서 환경변수 없는 셸에서는 main 도 똑같이 실패한다(이 브랜치 없이 main 에서 돌려 확인했다). `AdminSubscriptionServiceTest` 10개는 전부 통과.

> 후속 과제: `src/test/resources/application.properties` 에 테스트용 datasource(H2 등)를 두면 `contextLoads` 가 환경변수 없이도 돌아간다. 이번 범위 밖이라 손대지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
