### PR TITLE
✨ Feat: 나의 채용 캘린더 API (/api/my-calendar)

### DIFF
--- a/src/main/java/com/nklcbdty/api/mycalendar/config/MyCalendarSchemaInitializer.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/config/MyCalendarSchemaInitializer.java
@@ -1,0 +1,138 @@
+package com.nklcbdty.api.mycalendar.config;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * spring.jpa.hibernate.ddl-auto=none 이므로 JPA 가 테이블을 만들지 않는다.
+ * 앱 기동 시 my_calendar_entry 가 없으면 생성한다.
+ *
+ * <p>이 DB(travel 스키마)는 다른 프로젝트와 함께 쓴다. 같은 이름의 테이블이 다른 모양으로 이미
+ * 있으면 CREATE TABLE IF NOT EXISTS 는 조용히 넘어가고, 기동은 성공하는데 이 API 만 500 이 난다
+ * (2026-08-13 게시판이 실제로 그렇게 죽었다). 그래서 생성 뒤에 이 코드가 쓰는 컬럼을 하나씩 채우고
+ * 마지막에 자기점검을 한다. {@code BoardSchemaInitializer} 와 같은 방식이다.</p>
+ */
+@Slf4j
+@Component
+public class MyCalendarSchemaInitializer implements ApplicationRunner {
+
+    /**
+     * MyCalendarEntry 엔티티가 쓰는 컬럼. 이미 있는 테이블에 뒤늦게 붙일 수 있어야 하므로
+     * NOT NULL 인 컬럼에는 반드시 DEFAULT 를 준다(기존 행을 채울 값이 있어야 한다).
+     */
+    private static final Map<String, String> ENTRY_COLUMNS = new LinkedHashMap<>();
+    static {
+        ENTRY_COLUMNS.put("user_id", "VARCHAR(255) NOT NULL DEFAULT ''");
+        ENTRY_COLUMNS.put("apply_date", "DATE NOT NULL DEFAULT '2000-01-01'");
+        ENTRY_COLUMNS.put("company_name", "VARCHAR(100) NOT NULL DEFAULT ''");
+        ENTRY_COLUMNS.put("url", "VARCHAR(1000) NULL");
+        ENTRY_COLUMNS.put("memo", "VARCHAR(2000) NULL");
+        ENTRY_COLUMNS.put("insert_dts", "DATETIME NULL");
+        ENTRY_COLUMNS.put("update_dts", "DATETIME NULL");
+    }
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public MyCalendarSchemaInitializer(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        final String ddl =
+            "CREATE TABLE IF NOT EXISTS my_calendar_entry (" +
+            "  id BIGINT NOT NULL AUTO_INCREMENT," +
+            "  user_id VARCHAR(255) NOT NULL," +
+            "  apply_date DATE NOT NULL," +
+            "  company_name VARCHAR(100) NOT NULL," +
+            "  url VARCHAR(1000) NULL," +
+            "  memo VARCHAR(2000) NULL," +
+            "  insert_dts DATETIME NULL," +
+            "  update_dts DATETIME NULL," +
+            "  PRIMARY KEY (id)," +
+            // 월별 조회가 유일한 조회 패턴이다.
+            "  KEY idx_my_calendar_user_date (user_id, apply_date)" +
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+        try {
+            jdbcTemplate.execute(ddl);
+            log.info("[MyCalendar] my_calendar_entry 테이블 확인/생성 완료");
+        } catch (Exception e) {
+            log.error("[MyCalendar] my_calendar_entry 테이블 생성 실패: {}", e.getMessage(), e);
+        }
+
+        // 위 CREATE 는 IF NOT EXISTS 라, 테이블이 이미 다른 모양으로 있으면 아무 일도 하지 않는다.
+        // MariaDB 10.0+ 의 ADD COLUMN IF NOT EXISTS 라 여러 번 기동해도 안전하다.
+        ENTRY_COLUMNS.forEach(this::addColumnIfMissing);
+
+        verifySchema();
+    }
+
+    private void addColumnIfMissing(String column, String definition) {
+        try {
+            jdbcTemplate.execute(
+                "ALTER TABLE my_calendar_entry ADD COLUMN IF NOT EXISTS " + column + " " + definition);
+        } catch (Exception e) {
+            log.error("[MyCalendar] my_calendar_entry.{} 컬럼 추가 실패: {}", column, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 스키마가 코드와 맞는지 기동 시 실제로 확인한다. 어긋나 있어도 기동은 막지 않되
+     * (캘린더 하나 때문에 서비스 전체를 내릴 이유는 없다) 로그로 알린다.
+     */
+    private void verifySchema() {
+        if (selectsOk() & noBlockingLegacyColumns()) {
+            log.info("[MyCalendar] my_calendar_entry 스키마 확인 완료");
+        }
+    }
+
+    /** 엔티티가 읽는 컬럼을 전부 넣어 조회해 본다. 하나라도 없으면 Unknown column 으로 실패한다. */
+    private boolean selectsOk() {
+        try {
+            jdbcTemplate.queryForList(
+                "SELECT id, " + String.join(", ", ENTRY_COLUMNS.keySet()) + " FROM my_calendar_entry LIMIT 1");
+            return true;
+        } catch (Exception e) {
+            log.error("[MyCalendar] my_calendar_entry 스키마가 코드와 맞지 않는다 — 캘린더 API 가 500 을 낸다: {}",
+                e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 이 코드가 모르는 컬럼 중 "NOT NULL + 기본값 없음" 이 있으면 INSERT 가 통째로 실패한다
+     * (STRICT_TRANS_TABLES: Field '...' doesn't have a default value). 남의 프로젝트가 만든
+     * 컬럼일 수 있어 마음대로 고치지 않고, 어떤 컬럼 때문인지만 정확히 남긴다.
+     */
+    private boolean noBlockingLegacyColumns() {
+        try {
+            final List<String> blocking = new ArrayList<>(jdbcTemplate.queryForList(
+                "SELECT column_name FROM information_schema.columns "
+                    + "WHERE table_schema = DATABASE() AND table_name = 'my_calendar_entry' "
+                    + "  AND is_nullable = 'NO' AND column_default IS NULL "
+                    + "  AND extra NOT LIKE '%auto_increment%'",
+                String.class));
+            blocking.removeAll(ENTRY_COLUMNS.keySet());
+            blocking.remove("id");
+            if (blocking.isEmpty()) {
+                return true;
+            }
+            log.error("[MyCalendar] my_calendar_entry 에 이 코드가 모르는 필수 컬럼이 있다 {} — 일정 저장이 500 을"
+                + " 낸다. 해당 컬럼에 DEFAULT 를 주거나 NULL 을 허용해야 한다.", blocking);
+            return false;
+        } catch (Exception e) {
+            log.error("[MyCalendar] my_calendar_entry 컬럼 점검 실패: {}", e.getMessage(), e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/controller/MyCalendarController.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/controller/MyCalendarController.java
@@ -1,0 +1,153 @@
+package com.nklcbdty.api.mycalendar.controller;
+
+import java.time.YearMonth;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryDto;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryRequest;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarMonthDto;
+import com.nklcbdty.api.mycalendar.exception.MyCalendarNotFoundException;
+import com.nklcbdty.api.mycalendar.service.MyCalendarService;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * 나의 채용 캘린더. 내가 지원할 회사를 달력에 적어 두는 개인 메모다.
+ *
+ * <ul>
+ *   <li>GET    /api/my-calendar/entries?year=&month=  : 그 달에 적어 둔 일정</li>
+ *   <li>POST   /api/my-calendar/entries               : 등록</li>
+ *   <li>PUT    /api/my-calendar/entries/{entryId}     : 수정</li>
+ *   <li>DELETE /api/my-calendar/entries/{entryId}     : 삭제</li>
+ *   <li>GET    /api/my-calendar/company-name?url=     : URL 로 회사명 추측(입력 도우미)</li>
+ * </ul>
+ *
+ * <p>이 경로는 {@code AllowedPaths} 에 <b>없다</b>. 그래서 {@code AuthFilter} 가 유효한 토큰을
+ * 요구하고, 토큰이 없으면 컨트롤러까지 오지도 못한다(401). 사용자 구분은 필터가 넣어 둔
+ * {@code userId} 속성으로 한다 — 공개 게시판처럼 헤더를 직접 파싱할 이유가 없다.</p>
+ */
+@RestController
+@RequestMapping("/api/my-calendar")
+public class MyCalendarController {
+
+    // 잘못된 값으로 엉뚱한 달을 조회하는 것을 막는 상식적인 범위. 공개 캘린더와 같은 기준이다.
+    private static final int MIN_YEAR = 2000;
+    private static final int MAX_YEAR = 2100;
+
+    private final MyCalendarService myCalendarService;
+
+    public MyCalendarController(MyCalendarService myCalendarService) {
+        this.myCalendarService = myCalendarService;
+    }
+
+    @GetMapping("/entries")
+    public ResponseEntity<MyCalendarMonthDto> entries(
+        @RequestParam(required = false) Integer year,
+        @RequestParam(required = false) Integer month,
+        HttpServletRequest httpRequest
+    ) {
+        return ResponseEntity.ok(myCalendarService.getMonth(userId(httpRequest), targetMonth(year, month)));
+    }
+
+    @PostMapping("/entries")
+    public ResponseEntity<MyCalendarEntryDto> create(
+        @RequestBody MyCalendarEntryRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        return ResponseEntity.ok(myCalendarService.create(userId(httpRequest), request));
+    }
+
+    @PutMapping("/entries/{entryId}")
+    public ResponseEntity<MyCalendarEntryDto> update(
+        @PathVariable Long entryId,
+        @RequestBody MyCalendarEntryRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        return ResponseEntity.ok(myCalendarService.update(userId(httpRequest), entryId, request));
+    }
+
+    @DeleteMapping("/entries/{entryId}")
+    public ResponseEntity<Map<String, Object>> delete(
+        @PathVariable Long entryId,
+        HttpServletRequest httpRequest
+    ) {
+        myCalendarService.delete(userId(httpRequest), entryId);
+        return ResponseEntity.ok(Map.of("status", "deleted", "entryId", entryId));
+    }
+
+    /**
+     * URL 에서 회사명을 추측한다. 추측 실패는 오류가 아니므로 200 에 {@code companyName: null} 을 준다.
+     * (값이 {@code null} 일 수 있어 {@code Map.of} 대신 {@code HashMap} 을 쓴다)
+     */
+    @GetMapping("/company-name")
+    public ResponseEntity<Map<String, String>> companyName(@RequestParam(required = false) String url) {
+        final Map<String, String> body = new HashMap<>();
+        body.put("companyName", myCalendarService.guessCompanyName(url));
+        return ResponseEntity.ok(body);
+    }
+
+    private YearMonth targetMonth(Integer year, Integer month) {
+        final YearMonth thisMonth = YearMonth.now();
+        final int targetYear = year != null ? year : thisMonth.getYear();
+        final int targetMonth = month != null ? month : thisMonth.getMonthValue();
+
+        if (targetMonth < 1 || targetMonth > 12) {
+            throw new IllegalArgumentException("month 는 1~12 여야 합니다. (요청값: " + targetMonth + ")");
+        }
+        if (targetYear < MIN_YEAR || targetYear > MAX_YEAR) {
+            throw new IllegalArgumentException(
+                "year 는 " + MIN_YEAR + "~" + MAX_YEAR + " 여야 합니다. (요청값: " + targetYear + ")");
+        }
+        return YearMonth.of(targetYear, targetMonth);
+    }
+
+    /**
+     * AuthFilter 가 넣어 둔 로그인 사용자. 필터를 통과했으면 반드시 있지만,
+     * 누군가 이 경로를 공개 목록에 올리는 순간 남의 일정이 섞여 나가므로 그때는 401 로 막는다.
+     */
+    private String userId(HttpServletRequest request) {
+        final Object userId = request.getAttribute("userId");
+        if (userId == null || userId.toString().isBlank()) {
+            throw new MyCalendarUnauthorizedException();
+        }
+        return userId.toString();
+    }
+
+    @ExceptionHandler(MyCalendarUnauthorizedException.class)
+    public ResponseEntity<Map<String, String>> handleUnauthorized() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                             .body(Collections.singletonMap("message", "로그인이 필요합니다."));
+    }
+
+    @ExceptionHandler(MyCalendarNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNotFound(MyCalendarNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                             .body(Collections.singletonMap("message", e.getMessage()));
+    }
+
+    /** 잘못된 입력은 400. 이 컨트롤러 안에서만 처리해 다른 API 의 예외 처리에 영향을 주지 않는다. */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidInput(IllegalArgumentException e) {
+        return ResponseEntity.badRequest()
+                             .body(Collections.singletonMap("message", e.getMessage()));
+    }
+
+    /** 필터를 지나왔는데도 사용자를 알 수 없는 경우. 이 컨트롤러 밖에서 쓸 일이 없어 안에 둔다. */
+    static class MyCalendarUnauthorizedException extends RuntimeException {
+    }
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarDayDto.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarDayDto.java
@@ -1,0 +1,28 @@
+package com.nklcbdty.api.mycalendar.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Getter;
+
+/**
+ * 내 일정이 하나 이상 있는 하루. 비어 있는 날은 응답에 담지 않는다(빈 칸은 프론트가 그린다).
+ * 공개 채용 캘린더의 {@code CalendarDayDto} 와 같은 모양이라 프론트가 같은 방식으로 그린다.
+ */
+@Getter
+public class MyCalendarDayDto {
+
+    /** yyyy-MM-dd */
+    private final String date;
+    /** 1(월) ~ 7(일). 요일 색 처리에 쓴다. */
+    private final int dayOfWeek;
+    private final int count;
+    private final List<MyCalendarEntryDto> entries;
+
+    public MyCalendarDayDto(LocalDate date, List<MyCalendarEntryDto> entries) {
+        this.date = date.toString();
+        this.dayOfWeek = date.getDayOfWeek().getValue();
+        this.count = entries.size();
+        this.entries = entries;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarEntryDto.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarEntryDto.java
@@ -1,0 +1,25 @@
+package com.nklcbdty.api.mycalendar.dto;
+
+import com.nklcbdty.api.mycalendar.vo.MyCalendarEntry;
+
+import lombok.Getter;
+
+/** 달력 한 칸에 들어가는 내 일정 1건. */
+@Getter
+public class MyCalendarEntryDto {
+
+    private final Long id;
+    /** yyyy-MM-dd */
+    private final String applyDate;
+    private final String companyName;
+    private final String url;
+    private final String memo;
+
+    public MyCalendarEntryDto(MyCalendarEntry entry) {
+        this.id = entry.getId();
+        this.applyDate = entry.getApplyDate().toString();
+        this.companyName = entry.getCompanyName();
+        this.url = entry.getUrl();
+        this.memo = entry.getMemo();
+    }
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarEntryRequest.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarEntryRequest.java
@@ -1,0 +1,22 @@
+package com.nklcbdty.api.mycalendar.dto;
+
+import lombok.Data;
+
+/**
+ * 일정 등록·수정 요청.
+ *
+ * <p>필수는 {@code applyDate}(어느 칸인지)와 {@code companyName} 뿐이다.
+ * URL·메모는 나중에 채워 넣을 수 있게 비워 둘 수 있다.</p>
+ */
+@Data
+public class MyCalendarEntryRequest {
+
+    /** yyyy-MM-dd */
+    private String applyDate;
+
+    private String companyName;
+
+    private String url;
+
+    private String memo;
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarMonthDto.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarMonthDto.java
@@ -1,0 +1,37 @@
+package com.nklcbdty.api.mycalendar.dto;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import lombok.Getter;
+
+/**
+ * 한 달치 내 채용 캘린더 응답.
+ *
+ * <p>달의 칸 배치를 {@code firstDayOfWeek}/{@code lengthOfMonth} 로 프론트가 계산하는 것까지
+ * 공개 채용 캘린더({@code CalendarMonthDto})와 같다.</p>
+ */
+@Getter
+public class MyCalendarMonthDto {
+
+    private final int year;
+    private final int month;
+    /** 1일의 요일 (1=월 ~ 7=일) */
+    private final int firstDayOfWeek;
+    /** 그 달의 일수 */
+    private final int lengthOfMonth;
+    /** 이 달에 적어 둔 일정 총 건수 */
+    private final int totalCount;
+    private final List<MyCalendarDayDto> days;
+
+    public MyCalendarMonthDto(YearMonth yearMonth, int totalCount, List<MyCalendarDayDto> days) {
+        this.year = yearMonth.getYear();
+        this.month = yearMonth.getMonthValue();
+        final LocalDate firstDay = yearMonth.atDay(1);
+        this.firstDayOfWeek = firstDay.getDayOfWeek().getValue();
+        this.lengthOfMonth = yearMonth.lengthOfMonth();
+        this.totalCount = totalCount;
+        this.days = days;
+    }
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/exception/MyCalendarNotFoundException.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/exception/MyCalendarNotFoundException.java
@@ -1,0 +1,12 @@
+package com.nklcbdty.api.mycalendar.exception;
+
+/**
+ * 그 일정이 없거나 내 것이 아닐 때. 두 경우를 구분하지 않는다 —
+ * 구분해서 알려주면 남의 일정 id 가 존재하는지 떠볼 수 있다.
+ */
+public class MyCalendarNotFoundException extends RuntimeException {
+
+    public MyCalendarNotFoundException() {
+        super("일정을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/repository/MyCalendarEntryRepository.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/repository/MyCalendarEntryRepository.java
@@ -1,0 +1,22 @@
+package com.nklcbdty.api.mycalendar.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nklcbdty.api.mycalendar.vo.MyCalendarEntry;
+
+public interface MyCalendarEntryRepository extends JpaRepository<MyCalendarEntry, Long> {
+
+    /** 그 달에 적어 둔 내 일정. 날짜 오름차순, 같은 날은 등록순. */
+    List<MyCalendarEntry> findByUserIdAndApplyDateBetweenOrderByApplyDateAscIdAsc(
+        String userId, LocalDate from, LocalDate to);
+
+    /**
+     * 수정·삭제 전 소유자 확인용. id 만으로 찾으면 남의 일정을 건드릴 수 있어
+     * 언제나 userId 를 함께 건다.
+     */
+    Optional<MyCalendarEntry> findByIdAndUserId(Long id, String userId);
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/service/CompanyNameGuesser.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/service/CompanyNameGuesser.java
@@ -1,0 +1,260 @@
+package com.nklcbdty.api.mycalendar.service;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import com.nklcbdty.api.crawler.common.CompanyEnums;
+
+/**
+ * 공고 주소에서 회사명을 추측한다. "나의 채용 캘린더" 에서 URL 만 붙여넣어도 회사명이 채워지도록.
+ *
+ * <p>어디까지나 입력 도우미다. 확신할 수 없으면 억지로 만들지 않고 {@code null} 을 돌려주고,
+ * 회사명은 사용자가 직접 적는다(회사명이 이 화면의 유일한 필수값인 이유이기도 하다).</p>
+ *
+ * <p>추측 순서:</p>
+ * <ol>
+ *   <li>사람인·원티드 같은 <b>채용 사이트</b> 주소면 포기한다 — 도메인에서 뽑으면 "사람인" 이 나온다.</li>
+ *   <li>그린하우스·레버 같은 <b>채용 솔루션(ATS)</b> 주소면 정해진 자리에서 회사 슬러그를 꺼낸다.</li>
+ *   <li>그 외에는 호스트에서 careers/recruit 같은 접두 라벨을 걷어내고 남는 첫 라벨을 쓴다.</li>
+ * </ol>
+ *
+ * <p>이렇게 얻은 슬러그가 우리가 아는 회사면({@link CompanyEnums}) 한글 회사명으로 바꾼다.
+ * 모르는 회사면 슬러그를 사람이 읽을 만하게 다듬어서 준다(stripe → Stripe).</p>
+ */
+public final class CompanyNameGuesser {
+
+    /**
+     * 회사가 아니라 "채용 사이트"·문서 도구인 주소. 여기서는 도메인이 회사를 알려주지 않는다.
+     * 호스트 전체와 등록 도메인 양쪽으로 비교하므로 둘 중 편한 쪽으로 적으면 된다
+     * (open.kakao.com 은 막고 careers.kakao.com 은 살려야 해서 호스트 단위 항목이 필요하다).
+     */
+    private static final Set<String> JOB_BOARD_DOMAINS = Set.of(
+        "saramin.co.kr", "jobkorea.co.kr", "wanted.co.kr", "jumpit.co.kr", "programmers.co.kr",
+        "rocketpunch.com", "catch.co.kr", "incruit.com", "jobplanet.co.kr", "worknet.go.kr",
+        "linkedin.com", "indeed.com", "glassdoor.com", "wellfound.com", "remoteok.com",
+        "notion.site", "notion.so", "docs.google.com", "forms.gle", "bit.ly",
+        "naver.me", "open.kakao.com"
+    );
+
+    /** 경로 첫 조각이 회사 슬러그인 ATS. 예: boards.greenhouse.io/<b>toss</b>/jobs/123 */
+    private static final Set<String> PATH_SLUG_ATS_HOSTS = Set.of(
+        "boards.greenhouse.io", "job-boards.greenhouse.io", "boards.eu.greenhouse.io",
+        "jobs.lever.co", "jobs.eu.lever.co",
+        "jobs.ashbyhq.com",
+        "apply.workable.com",
+        "careers.smartrecruiters.com",
+        "jobs.jobvite.com"
+    );
+
+    /** 맨 앞 라벨이 회사 슬러그인 ATS. 예: <b>yanolja</b>.wd102.myworkdayjobs.com */
+    private static final List<String> SUBDOMAIN_SLUG_ATS_SUFFIXES = List.of(
+        "myworkdayjobs.com", "recruitee.com", "teamtailor.com", "workable.com",
+        "bamboohr.com", "applytojob.com", "breezy.hr", "icims.com", "taleo.net",
+        "personio.de", "personio.com", "factorialhr.com", "hibob.com"
+    );
+
+    /**
+     * 회사명이 아니라 "채용" 을 뜻하는 접두 라벨. careers.kakao.com 에서 kakao 를 꺼내기 위해 걷어낸다.
+     * (전부 걷어내서 남는 게 없으면 걷어내기 전 값을 쓴다 — jobs.jobs 같은 경우)
+     */
+    private static final Set<String> RECRUITING_LABELS = Set.of(
+        "www", "m", "ko", "kr", "en", "us", "global",
+        "career", "careers", "recruit", "recruiting", "recruitment",
+        "job", "jobs", "apply", "hire", "hiring", "talent", "people",
+        "join", "work", "employment", "boards", "board"
+    );
+
+    /**
+     * 슬러그 → 한글 회사명. {@link CompanyEnums} 의 채용 페이지 주소를 같은 규칙으로 돌려서 만든다.
+     * enum 에 회사가 추가되면 여기도 저절로 따라온다.
+     */
+    private static final Map<String, String> KNOWN_COMPANY_NAMES = buildKnownCompanyNames();
+
+    /**
+     * 같은 회사의 다른 도메인. 위 자동 생성 표는 채용 페이지 주소 하나만 알기 때문에
+     * (예: 네이버는 recruit.<b>navercorp</b>.com) 흔히 쓰는 다른 표기를 손으로 채워 둔다.
+     */
+    private static final Map<String, String> COMPANY_ALIASES = Map.ofEntries(
+        Map.entry("naver", "네이버"),
+        Map.entry("navercorp", "네이버"),
+        Map.entry("line", "라인"),
+        Map.entry("linecorp", "라인"),
+        Map.entry("linepluscorp", "라인"),
+        Map.entry("woowahan", "배달의민족"),
+        Map.entry("woowa", "배달의민족"),
+        Map.entry("woowabros", "배달의민족"),
+        Map.entry("baemin", "배달의민족"),
+        Map.entry("coupang", "쿠팡"),
+        Map.entry("daangn", "당근마켓"),
+        Map.entry("karrot", "당근마켓"),
+        Map.entry("toss", "토스"),
+        Map.entry("tossbank", "토스뱅크"),
+        Map.entry("yanolja", "야놀자"),
+        Map.entry("kakaobank", "카카오뱅크"),
+        Map.entry("kakaopay", "카카오페이"),
+        Map.entry("kakaoenterprise", "카카오엔터프라이즈"),
+        Map.entry("kakaostyle", "카카오스타일"),
+        Map.entry("nexon", "넥슨"),
+        Map.entry("ncsoft", "엔씨소프트"),
+        Map.entry("krafton", "크래프톤"),
+        Map.entry("kakaogames", "카카오게임즈")
+    );
+
+    private CompanyNameGuesser() {
+    }
+
+    /**
+     * @param url 사용자가 붙여넣은 주소. 스킴이 없어도(careers.kakao.com/jobs) 된다.
+     * @return 추측한 회사명. 추측할 수 없으면 null.
+     */
+    public static String guess(String url) {
+        final String slug = slugOf(url);
+        if (slug == null) {
+            return null;
+        }
+        final String known = KNOWN_COMPANY_NAMES.get(slug);
+        if (known != null) {
+            return known;
+        }
+        final String alias = COMPANY_ALIASES.get(slug);
+        return alias != null ? alias : prettify(slug);
+    }
+
+    /** 주소에서 회사 슬러그(영문 소문자)를 꺼낸다. 못 꺼내면 null. */
+    private static String slugOf(String url) {
+        final URI uri = parse(url);
+        if (uri == null) {
+            return null;
+        }
+        final String host = hostOf(uri);
+        if (host == null
+            || JOB_BOARD_DOMAINS.contains(host)
+            || JOB_BOARD_DOMAINS.contains(registrableDomain(host))) {
+            return null;
+        }
+
+        if (PATH_SLUG_ATS_HOSTS.contains(host)) {
+            return normalize(firstPathSegment(uri));
+        }
+
+        final String[] labels = host.split("\\.");
+        for (String suffix : SUBDOMAIN_SLUG_ATS_SUFFIXES) {
+            // 맨 앞 라벨이 곧 회사 — 단 apply.workable.com 처럼 접두 라벨이 앞에 오면 회사가 아니다.
+            if (host.endsWith("." + suffix) && !RECRUITING_LABELS.contains(labels[0])) {
+                return normalize(labels[0]);
+            }
+        }
+
+        return normalize(firstMeaningfulLabel(labels));
+    }
+
+    /**
+     * careers/recruit 같은 접두 라벨을 걷어내고 첫 라벨을 고른다.
+     * 전부 걷어내지고 남는 게 없으면(예: jobs.co.kr) 걷어내기 전 첫 라벨로 되돌린다.
+     */
+    private static String firstMeaningfulLabel(String[] labels) {
+        for (String label : labels) {
+            if (!RECRUITING_LABELS.contains(label)) {
+                return label;
+            }
+        }
+        return labels[0];
+    }
+
+    /** 스킴이 없으면 붙여서 파싱한다. 사용자는 careers.kakao.com 처럼 붙여넣는 일이 잦다. */
+    private static URI parse(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        final String trimmed = url.trim();
+        final String withScheme = trimmed.matches("(?i)^[a-z][a-z0-9+.-]*://.*") ? trimmed : "https://" + trimmed;
+        try {
+            return URI.create(withScheme);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static String hostOf(URI uri) {
+        final String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            return null;
+        }
+        final String lower = host.toLowerCase(Locale.ROOT);
+        // IP 주소는 회사를 알려주지 않는다.
+        return lower.matches("[0-9.]+") ? null : lower;
+    }
+
+    /**
+     * 채용 사이트 판별용 등록 도메인. co.kr·go.kr 처럼 2단계 국가 도메인은 라벨 3개까지 본다.
+     * (완전한 public suffix 목록이 필요한 일이 아니라 이 정도로 충분하다)
+     */
+    private static String registrableDomain(String host) {
+        final String[] labels = host.split("\\.");
+        if (labels.length < 2) {
+            return host;
+        }
+        final boolean twoLevelTld = labels.length >= 3
+            && labels[labels.length - 1].length() == 2
+            && labels[labels.length - 2].length() <= 3;
+        final int take = twoLevelTld ? 3 : 2;
+        return String.join(".", Arrays.copyOfRange(labels, labels.length - take, labels.length));
+    }
+
+    private static String firstPathSegment(URI uri) {
+        final String path = uri.getPath();
+        if (path == null) {
+            return null;
+        }
+        for (String segment : path.split("/")) {
+            if (!segment.isBlank()) {
+                return segment;
+            }
+        }
+        return null;
+    }
+
+    /** 슬러그로 쓸 수 있는 값만 통과시킨다(영문/숫자/하이픈). 순수 숫자나 빈 값은 회사가 아니다. */
+    private static String normalize(String candidate) {
+        if (candidate == null) {
+            return null;
+        }
+        final String lower = candidate.toLowerCase(Locale.ROOT).trim();
+        if (!lower.matches("[a-z0-9-]{2,}") || lower.matches("[0-9-]+")) {
+            return null;
+        }
+        return lower;
+    }
+
+    /** 모르는 회사의 슬러그를 사람이 읽을 만하게. my-company → My Company */
+    private static String prettify(String slug) {
+        final StringBuilder result = new StringBuilder();
+        for (String word : slug.split("-")) {
+            if (word.isEmpty()) {
+                continue;
+            }
+            if (result.length() > 0) {
+                result.append(' ');
+            }
+            result.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+        }
+        return result.length() == 0 ? null : result.toString();
+    }
+
+    private static Map<String, String> buildKnownCompanyNames() {
+        final Map<String, String> names = new LinkedHashMap<>();
+        for (CompanyEnums company : CompanyEnums.values()) {
+            final String slug = slugOf(company.getCareerPageUrl());
+            if (slug != null) {
+                names.putIfAbsent(slug, company.getCompanyNm());
+            }
+        }
+        return new HashMap<>(names);
+    }
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/service/MyCalendarService.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/service/MyCalendarService.java
@@ -1,0 +1,165 @@
+package com.nklcbdty.api.mycalendar.service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nklcbdty.api.mycalendar.dto.MyCalendarDayDto;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryDto;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryRequest;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarMonthDto;
+import com.nklcbdty.api.mycalendar.exception.MyCalendarNotFoundException;
+import com.nklcbdty.api.mycalendar.repository.MyCalendarEntryRepository;
+import com.nklcbdty.api.mycalendar.vo.MyCalendarEntry;
+
+/**
+ * 나의 채용 캘린더. 내가 지원할 회사를 달력에 적어 두는 개인 메모다.
+ *
+ * <p>모든 메서드가 {@code userId} 를 첫 인자로 받고 저장소 조회에도 반드시 함께 건다.
+ * 이 API 는 캐싱하지 않는다 — 사람마다 다른 데이터라 캐시가 섞이면 남의 일정이 보인다.</p>
+ */
+@Service
+public class MyCalendarService {
+
+    /** 엔티티 컬럼 길이와 맞춘다. 넘치면 DB 에서 잘리거나 500 이 나므로 여기서 400 으로 막는다. */
+    private static final int MAX_COMPANY_NAME_LENGTH = 100;
+    private static final int MAX_URL_LENGTH = 1000;
+    private static final int MAX_MEMO_LENGTH = 2000;
+
+    private final MyCalendarEntryRepository entryRepository;
+
+    public MyCalendarService(MyCalendarEntryRepository entryRepository) {
+        this.entryRepository = entryRepository;
+    }
+
+    /** 그 달에 적어 둔 내 일정을 날짜별로 모아 준다. */
+    @Transactional(readOnly = true)
+    public MyCalendarMonthDto getMonth(String userId, YearMonth yearMonth) {
+        final List<MyCalendarEntry> entries =
+            entryRepository.findByUserIdAndApplyDateBetweenOrderByApplyDateAscIdAsc(
+                userId, yearMonth.atDay(1), yearMonth.atEndOfMonth());
+
+        // TreeMap: 날짜 오름차순. 하루 안에서는 조회 순서(등록순)를 유지한다.
+        final Map<LocalDate, List<MyCalendarEntryDto>> byDate = new TreeMap<>();
+        for (MyCalendarEntry entry : entries) {
+            byDate.computeIfAbsent(entry.getApplyDate(), key -> new ArrayList<>())
+                  .add(new MyCalendarEntryDto(entry));
+        }
+
+        final List<MyCalendarDayDto> days = new ArrayList<>();
+        for (Map.Entry<LocalDate, List<MyCalendarEntryDto>> day : byDate.entrySet()) {
+            days.add(new MyCalendarDayDto(day.getKey(), day.getValue()));
+        }
+
+        return new MyCalendarMonthDto(yearMonth, entries.size(), days);
+    }
+
+    @Transactional
+    public MyCalendarEntryDto create(String userId, MyCalendarEntryRequest request) {
+        final MyCalendarEntry entry = new MyCalendarEntry();
+        entry.setUserId(userId);
+        apply(entry, request);
+        return new MyCalendarEntryDto(entryRepository.save(entry));
+    }
+
+    @Transactional
+    public MyCalendarEntryDto update(String userId, Long entryId, MyCalendarEntryRequest request) {
+        final MyCalendarEntry entry = mine(userId, entryId);
+        apply(entry, request);
+        return new MyCalendarEntryDto(entryRepository.save(entry));
+    }
+
+    @Transactional
+    public void delete(String userId, Long entryId) {
+        entryRepository.delete(mine(userId, entryId));
+    }
+
+    /** URL 에서 회사명을 추측한다. 추측할 수 없으면 null — 호출부가 사용자에게 직접 입력하게 둔다. */
+    public String guessCompanyName(String url) {
+        return CompanyNameGuesser.guess(url);
+    }
+
+    private MyCalendarEntry mine(String userId, Long entryId) {
+        return entryRepository.findByIdAndUserId(entryId, userId)
+                              .orElseThrow(MyCalendarNotFoundException::new);
+    }
+
+    /** 요청값을 검증해서 엔티티에 옮긴다. 등록·수정이 같은 규칙을 쓰도록 한 곳에 모았다. */
+    private void apply(MyCalendarEntry entry, MyCalendarEntryRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("요청 내용이 비어 있습니다.");
+        }
+        entry.setApplyDate(parseDate(request.getApplyDate()));
+        entry.setCompanyName(requireCompanyName(request.getCompanyName()));
+        entry.setUrl(normalizeUrl(request.getUrl()));
+        entry.setMemo(trimToNull(request.getMemo(), MAX_MEMO_LENGTH, "메모"));
+    }
+
+    private LocalDate parseDate(String applyDate) {
+        if (isBlank(applyDate)) {
+            throw new IllegalArgumentException("날짜를 선택해 주세요.");
+        }
+        try {
+            return LocalDate.parse(applyDate.trim());
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)");
+        }
+    }
+
+    private String requireCompanyName(String companyName) {
+        if (isBlank(companyName)) {
+            throw new IllegalArgumentException("회사명을 입력해 주세요.");
+        }
+        final String trimmed = companyName.trim();
+        if (trimmed.length() > MAX_COMPANY_NAME_LENGTH) {
+            throw new IllegalArgumentException("회사명은 " + MAX_COMPANY_NAME_LENGTH + "자를 넘을 수 없습니다.");
+        }
+        return trimmed;
+    }
+
+    /**
+     * 스킴 없이 적어도(careers.kakao.com) 링크로 열리도록 https:// 를 붙여 준다.
+     * javascript: 같은 위험한 스킴은 링크로 걸면 안 되므로 http/https 만 허용한다.
+     */
+    private String normalizeUrl(String url) {
+        final String trimmed = trimToNull(url, MAX_URL_LENGTH, "URL");
+        if (trimmed == null) {
+            return null;
+        }
+
+        // 스킴에 점이 들어가는 일은 실제로 없으므로 점을 빼고 본다 —
+        // 그래야 "careers.kakao.com:8080/jobs" 같은 포트 표기를 스킴으로 오해하지 않는다.
+        final boolean hasScheme = trimmed.matches("(?is)^[a-z][a-z0-9+-]*:.*");
+        if (hasScheme && !trimmed.matches("(?is)^https?://.*")) {
+            throw new IllegalArgumentException("URL 은 http:// 또는 https:// 주소만 넣을 수 있습니다.");
+        }
+
+        final String normalized = hasScheme ? trimmed : "https://" + trimmed;
+        if (normalized.length() > MAX_URL_LENGTH) {
+            throw new IllegalArgumentException("URL 이 너무 깁니다.");
+        }
+        return normalized;
+    }
+
+    private String trimToNull(String value, int maxLength, String fieldName) {
+        if (isBlank(value)) {
+            return null;
+        }
+        final String trimmed = value.trim();
+        if (trimmed.length() > maxLength) {
+            throw new IllegalArgumentException(fieldName + " 은(는) " + maxLength + "자를 넘을 수 없습니다.");
+        }
+        return trimmed;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/vo/MyCalendarEntry.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/vo/MyCalendarEntry.java
@@ -1,0 +1,59 @@
+package com.nklcbdty.api.mycalendar.vo;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+/**
+ * "나의 채용 캘린더" 한 칸. 사용자가 직접 적어 넣는 지원 예정 회사다.
+ *
+ * <p>공개 채용 캘린더({@code /api/calendar/deadlines})가 크롤링한 공고의 마감일을 보여주는 것과 달리,
+ * 이쪽은 크롤링 대상이 아닌 회사도 적을 수 있어야 하므로 {@code job_mst} 와 엮지 않는다.</p>
+ *
+ * <p>남의 일정이 보이면 안 되므로 조회·수정·삭제는 모두 {@code userId} 로 한정한다.
+ * 게시판과 달리 soft delete 를 쓰지 않는다 — 남이 볼 일이 없는 개인 메모라 되살릴 이유가 없다.</p>
+ */
+@Entity
+@Table(name = "my_calendar_entry")
+@Data
+public class MyCalendarEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 토큰 subject 와 같은 값("kakao@{id}" 또는 "local@{id}") */
+    @Column(nullable = false)
+    private String userId;
+
+    /** 달력에서 이 일정이 찍히는 날 */
+    @Column(nullable = false)
+    private LocalDate applyDate;
+
+    /** 유일한 필수 입력값 */
+    @Column(nullable = false, length = 100)
+    private String companyName;
+
+    /** 공고 주소. 없어도 된다. */
+    @Column(nullable = true, length = 1000)
+    private String url;
+
+    @Column(nullable = true, length = 2000)
+    private String memo;
+
+    @CreationTimestamp
+    private LocalDateTime insertDts;
+
+    @UpdateTimestamp
+    private LocalDateTime updateDts;
+}

--- a/src/test/java/com/nklcbdty/api/common/security/AllowedPathsTest.java
+++ b/src/test/java/com/nklcbdty/api/common/security/AllowedPathsTest.java
@@ -54,4 +54,16 @@ class AllowedPathsTest {
         assertThat(isPublic("/mypage")).isFalse();
         assertThat(isPublic("/api/admin/subscriptions")).isFalse();
     }
+
+    /**
+     * 개인 일정이라 공개되면 남의 캘린더가 그대로 보인다. 경로가 비슷해서
+     * 공개인 {@code /api/calendar/**} 에 딸려 들어가기 쉬우므로 못박아 둔다.
+     */
+    @Test
+    @DisplayName("나의 채용 캘린더는 공개 목록에 없다 — 공개 채용 캘린더와 다른 경로다")
+    void myCalendarStaysPrivate() {
+        assertThat(isPublic("/api/my-calendar/entries")).isFalse();
+        assertThat(isPublic("/api/my-calendar/entries/12")).isFalse();
+        assertThat(isPublic("/api/my-calendar/company-name")).isFalse();
+    }
 }

--- a/src/test/java/com/nklcbdty/api/mycalendar/service/CompanyNameGuesserTest.java
+++ b/src/test/java/com/nklcbdty/api/mycalendar/service/CompanyNameGuesserTest.java
@@ -1,0 +1,73 @@
+package com.nklcbdty.api.mycalendar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * URL → 회사명 추측. 틀린 이름을 자신 있게 채워 넣는 것보다 비워 두는 게 낫다는 것이
+ * 이 클래스의 원칙이라, "포기해야 하는 경우" 도 함께 고정한다.
+ */
+class CompanyNameGuesserTest {
+
+    @Test
+    @DisplayName("우리가 아는 회사의 채용 페이지는 한글 회사명으로 준다")
+    void knownCompaniesBecomeKoreanNames() {
+        assertThat(CompanyNameGuesser.guess("https://careers.kakao.com/jobs/P-12345")).isEqualTo("카카오");
+        assertThat(CompanyNameGuesser.guess("https://recruit.navercorp.com/rcrt/list.do")).isEqualTo("네이버");
+        assertThat(CompanyNameGuesser.guess("https://career.woowahan.com/recruitment/R2312")).isEqualTo("배달의민족");
+        assertThat(CompanyNameGuesser.guess("https://careers.daangn.com/jobs/1234")).isEqualTo("당근마켓");
+        assertThat(CompanyNameGuesser.guess("https://toss.im/career/job-detail?job_id=1")).isEqualTo("토스");
+        assertThat(CompanyNameGuesser.guess("https://www.coupang.jobs/kr/jobs/12345/")).isEqualTo("쿠팡");
+        assertThat(CompanyNameGuesser.guess("https://careers.linecorp.com/ko/jobs/1234")).isEqualTo("라인");
+    }
+
+    @Test
+    @DisplayName("채용 솔루션(ATS) 주소는 정해진 자리에서 회사 슬러그를 꺼낸다")
+    void atsUrlsYieldTheTenantSlug() {
+        // 경로 첫 조각이 회사
+        assertThat(CompanyNameGuesser.guess("https://boards.greenhouse.io/stripe/jobs/4567")).isEqualTo("Stripe");
+        assertThat(CompanyNameGuesser.guess("https://job-boards.greenhouse.io/coupang/jobs/1")).isEqualTo("쿠팡");
+        assertThat(CompanyNameGuesser.guess("https://jobs.lever.co/figma/abc-def")).isEqualTo("Figma");
+        assertThat(CompanyNameGuesser.guess("https://jobs.ashbyhq.com/linear/xyz")).isEqualTo("Linear");
+        assertThat(CompanyNameGuesser.guess("https://apply.workable.com/some-startup/j/ABC/")).isEqualTo("Some Startup");
+        // 맨 앞 라벨이 회사 (야놀자 채용은 Workday 를 쓴다)
+        assertThat(CompanyNameGuesser.guess("https://yanolja.wd102.myworkdayjobs.com/ko-KR/External_Yanolja"))
+            .isEqualTo("야놀자");
+    }
+
+    @Test
+    @DisplayName("careers/recruit 같은 접두 라벨은 회사명이 아니라 걷어낸다")
+    void recruitingLabelsAreStripped() {
+        assertThat(CompanyNameGuesser.guess("https://careers.spotify.com/job/1")).isEqualTo("Spotify");
+        assertThat(CompanyNameGuesser.guess("https://www.jobs.datadog.com/")).isEqualTo("Datadog");
+        assertThat(CompanyNameGuesser.guess("https://recruit.example.co.kr/apply")).isEqualTo("Example");
+    }
+
+    @Test
+    @DisplayName("스킴을 빼고 붙여넣어도 알아본다")
+    void schemeIsOptional() {
+        assertThat(CompanyNameGuesser.guess("careers.kakao.com/jobs")).isEqualTo("카카오");
+    }
+
+    @Test
+    @DisplayName("사람인·원티드 같은 채용 사이트 주소는 회사를 알 수 없으므로 비워 둔다")
+    void jobBoardsGiveUp() {
+        assertThat(CompanyNameGuesser.guess("https://www.saramin.co.kr/zf_user/jobs/relay/view?rec_idx=1")).isNull();
+        assertThat(CompanyNameGuesser.guess("https://www.wanted.co.kr/wd/123456")).isNull();
+        assertThat(CompanyNameGuesser.guess("https://www.jobkorea.co.kr/Recruit/GI_Read/1")).isNull();
+        assertThat(CompanyNameGuesser.guess("https://career.programmers.co.kr/job_positions/1")).isNull();
+        assertThat(CompanyNameGuesser.guess("https://www.linkedin.com/jobs/view/123")).isNull();
+        assertThat(CompanyNameGuesser.guess("https://docs.google.com/forms/d/e/abc/viewform")).isNull();
+    }
+
+    @Test
+    @DisplayName("주소가 비었거나 회사를 읽을 수 없으면 null (사용자가 직접 적는다)")
+    void unreadableUrlsGiveUp() {
+        assertThat(CompanyNameGuesser.guess(null)).isNull();
+        assertThat(CompanyNameGuesser.guess("   ")).isNull();
+        assertThat(CompanyNameGuesser.guess("그냥 메모")).isNull();
+        assertThat(CompanyNameGuesser.guess("https://192.168.0.10/jobs")).isNull();
+    }
+}

--- a/src/test/java/com/nklcbdty/api/mycalendar/service/MyCalendarServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/mycalendar/service/MyCalendarServiceTest.java
@@ -1,0 +1,205 @@
+package com.nklcbdty.api.mycalendar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryDto;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryRequest;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarMonthDto;
+import com.nklcbdty.api.mycalendar.exception.MyCalendarNotFoundException;
+import com.nklcbdty.api.mycalendar.repository.MyCalendarEntryRepository;
+import com.nklcbdty.api.mycalendar.vo.MyCalendarEntry;
+
+@ExtendWith(MockitoExtension.class)
+class MyCalendarServiceTest {
+
+    private static final String ME = "local@me";
+    private static final String SOMEONE_ELSE = "kakao@999";
+
+    @Mock
+    private MyCalendarEntryRepository entryRepository;
+
+    @InjectMocks
+    private MyCalendarService service;
+
+    private static MyCalendarEntryRequest request(String date, String company, String url, String memo) {
+        MyCalendarEntryRequest request = new MyCalendarEntryRequest();
+        request.setApplyDate(date);
+        request.setCompanyName(company);
+        request.setUrl(url);
+        request.setMemo(memo);
+        return request;
+    }
+
+    private static MyCalendarEntry entry(Long id, String userId, LocalDate date, String company) {
+        MyCalendarEntry entry = new MyCalendarEntry();
+        entry.setId(id);
+        entry.setUserId(userId);
+        entry.setApplyDate(date);
+        entry.setCompanyName(company);
+        return entry;
+    }
+
+    // ------------------------------------------------------------------- 등록
+
+    @Test
+    @DisplayName("회사명만 있으면 저장된다 — URL·메모는 선택값")
+    void createRequiresOnlyCompanyName() {
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        MyCalendarEntryDto created = service.create(ME, request("2026-09-01", "카카오", null, null));
+
+        assertThat(created.getCompanyName()).isEqualTo("카카오");
+        assertThat(created.getApplyDate()).isEqualTo("2026-09-01");
+        assertThat(created.getUrl()).isNull();
+        assertThat(created.getMemo()).isNull();
+    }
+
+    @Test
+    @DisplayName("일정은 언제나 요청한 사용자 것으로 저장된다")
+    void createStampsTheOwner() {
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        service.create(ME, request("2026-09-01", "카카오", null, null));
+
+        ArgumentCaptor<MyCalendarEntry> saved = ArgumentCaptor.forClass(MyCalendarEntry.class);
+        verify(entryRepository).save(saved.capture());
+        assertThat(saved.getValue().getUserId()).isEqualTo(ME);
+    }
+
+    @Test
+    @DisplayName("회사명이 없거나 공백뿐이면 400")
+    void companyNameIsRequired() {
+        assertThatThrownBy(() -> service.create(ME, request("2026-09-01", null, null, null)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("회사명");
+        assertThatThrownBy(() -> service.create(ME, request("2026-09-01", "   ", null, null)))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(entryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("날짜가 없거나 형식이 틀리면 400")
+    void applyDateMustBeValid() {
+        assertThatThrownBy(() -> service.create(ME, request(null, "카카오", null, null)))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> service.create(ME, request("2026/09/01", "카카오", null, null)))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(entryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("스킴 없이 적은 URL 에는 https:// 를 붙여 준다 — 그래야 링크로 열린다")
+    void urlGetsHttpsPrefix() {
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        MyCalendarEntryDto created =
+            service.create(ME, request("2026-09-01", "카카오", "careers.kakao.com/jobs/1", null));
+
+        assertThat(created.getUrl()).isEqualTo("https://careers.kakao.com/jobs/1");
+    }
+
+    @Test
+    @DisplayName("http/https 가 아닌 스킴은 거부한다 — 링크로 걸면 위험하다")
+    void nonHttpSchemesAreRejected() {
+        assertThatThrownBy(() ->
+            service.create(ME, request("2026-09-01", "카카오", "javascript:alert(1)", null)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("http");
+
+        verify(entryRepository, never()).save(any());
+    }
+
+    // ------------------------------------------------------------- 조회 / 수정 / 삭제
+
+    @Test
+    @DisplayName("그 달 일정을 날짜별로 모아 준다 — 같은 날은 한 칸에 함께")
+    void getMonthGroupsByDate() {
+        when(entryRepository.findByUserIdAndApplyDateBetweenOrderByApplyDateAscIdAsc(
+            ME, LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 30)))
+            .thenReturn(List.of(
+                entry(1L, ME, LocalDate.of(2026, 9, 3), "카카오"),
+                entry(2L, ME, LocalDate.of(2026, 9, 3), "네이버"),
+                entry(3L, ME, LocalDate.of(2026, 9, 20), "토스")));
+
+        MyCalendarMonthDto month = service.getMonth(ME, YearMonth.of(2026, 9));
+
+        assertThat(month.getTotalCount()).isEqualTo(3);
+        assertThat(month.getLengthOfMonth()).isEqualTo(30);
+        assertThat(month.getDays()).hasSize(2);
+        assertThat(month.getDays().get(0).getDate()).isEqualTo("2026-09-03");
+        assertThat(month.getDays().get(0).getCount()).isEqualTo(2);
+        assertThat(month.getDays().get(1).getDate()).isEqualTo("2026-09-20");
+    }
+
+    @Test
+    @DisplayName("남의 일정은 수정할 수 없다")
+    void updateOnlyTouchesMyOwnEntry() {
+        when(entryRepository.findByIdAndUserId(7L, SOMEONE_ELSE)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            service.update(SOMEONE_ELSE, 7L, request("2026-09-01", "카카오", null, null)))
+            .isInstanceOf(MyCalendarNotFoundException.class);
+
+        verify(entryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("남의 일정은 삭제할 수 없다")
+    void deleteOnlyTouchesMyOwnEntry() {
+        when(entryRepository.findByIdAndUserId(7L, SOMEONE_ELSE)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.delete(SOMEONE_ELSE, 7L))
+            .isInstanceOf(MyCalendarNotFoundException.class);
+
+        verify(entryRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("내 일정은 수정된다")
+    void updateChangesMyEntry() {
+        MyCalendarEntry mine = entry(7L, ME, LocalDate.of(2026, 9, 1), "카카오");
+        when(entryRepository.findByIdAndUserId(7L, ME)).thenReturn(Optional.of(mine));
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        MyCalendarEntryDto updated =
+            service.update(ME, 7L, request("2026-09-05", "토스", null, "1차 면접"));
+
+        assertThat(updated.getCompanyName()).isEqualTo("토스");
+        assertThat(updated.getApplyDate()).isEqualTo("2026-09-05");
+        assertThat(updated.getMemo()).isEqualTo("1차 면접");
+    }
+
+    @Test
+    @DisplayName("id 만으로 일정을 찾지 않는다 — 언제나 userId 를 함께 건다")
+    void lookupsAreAlwaysScopedByUser() {
+        when(entryRepository.findByIdAndUserId(anyLong(), anyString()))
+            .thenReturn(Optional.of(entry(7L, ME, LocalDate.of(2026, 9, 1), "카카오")));
+
+        service.delete(ME, 7L);
+
+        verify(entryRepository).findByIdAndUserId(7L, ME);
+        verify(entryRepository, never()).findById(anyLong());
+    }
+}


### PR DESCRIPTION
마이페이지의 "나의 채용 캘린더" 화면이 쓸 백엔드. 내가 지원할 회사를 달력에 적어 두는 개인 메모다.

프론트 PR 과 짝이라 **이 PR 을 먼저 머지**해야 한다.

## API
| 메서드 | 경로 | 설명 |
| --- | --- | --- |
| GET | `/api/my-calendar/entries?year=&month=` | 그 달에 적어 둔 일정(날짜별로 묶어서) |
| POST | `/api/my-calendar/entries` | 등록 |
| PUT | `/api/my-calendar/entries/{entryId}` | 수정 |
| DELETE | `/api/my-calendar/entries/{entryId}` | 삭제 |
| GET | `/api/my-calendar/company-name?url=` | URL 로 회사명 추측(입력 도우미) |

필수 입력값은 회사명뿐이다. URL·메모는 비워 둘 수 있고, 날짜는 어느 칸인지라 당연히 필요하다.

## 왜 공개 채용 캘린더와 따로 두나
`/api/calendar/**` 는 크롤링한 공고의 마감일을 보여주는 공개 화면이고, 이쪽은 크롤링 대상이 아닌 회사도 적을 수 있어야 해서 `job_mst` 와 엮지 않고 `my_calendar_entry` 테이블을 따로 뒀다. 응답 모양(`firstDayOfWeek`/`lengthOfMonth`/`days`)은 프론트가 같은 방식으로 그리도록 공개 캘린더와 맞췄다.

## 접근 제어
경로를 `AllowedPaths` 에 넣지 **않아** `AuthFilter` 가 토큰을 요구한다. 개인 일정이라 공개되면 남의 캘린더가 그대로 보이는데, 경로가 공개인 `/api/calendar/**` 와 비슷해 딸려 들어가기 쉬워서 `AllowedPathsTest` 로 못박았다.

- 조회·수정·삭제는 모두 `userId` 를 함께 걸어 남의 일정을 건드릴 수 없다
- 남의 일정에는 존재 여부를 알려주지 않으려고 404 로 답한다
- 개인 데이터라 캐싱하지 않는다 — 캐시가 섞이면 남의 일정이 보인다
- URL 은 http/https 만 허용한다(`javascript:` 를 링크로 걸면 안 된다). 스킴 없이 적으면 `https://` 를 붙여 준다

## 회사명 추측
입력 도우미일 뿐이라 확신할 수 없으면 `null` 을 준다(회사명이 유일한 필수값인 이유).

1. 사람인·원티드 같은 **채용 사이트**는 도메인이 회사를 알려주지 않아 포기
2. 그린하우스·레버·Workday 같은 **ATS** 는 정해진 자리에서 회사 슬러그를 꺼냄
3. 그 외에는 호스트에서 `careers`/`recruit` 같은 접두 라벨을 걷어내고 남는 첫 라벨

아는 회사는 한글 이름으로 바꾼다. 이 표는 `CompanyEnums` 의 채용 페이지 주소를 같은 규칙으로 돌려 만들어서, enum 에 회사가 추가되면 저절로 따라온다.

## 스키마
이 DB(travel)는 다른 프로젝트와 공유한다. 게시판이 2026-08-13 에 겪은 장애(같은 이름 테이블이 다른 모양으로 이미 있어 API 만 500)를 되풀이하지 않도록, 테이블 생성 뒤 컬럼 자가복구와 기동 시 자기점검을 함께 넣었다.

## 테스트
`MyCalendarServiceTest` 12건, `CompanyNameGuesserTest` 6건, `AllowedPathsTest` 에 비공개 확인 1건 추가 — 전부 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a personal recruitment calendar for viewing, creating, editing, and deleting application entries.
  * Added monthly calendar summaries with daily entry counts and details.
  * Added company-name suggestions based on recruitment URLs.
  * Added validation and normalization for dates, company names, URLs, and optional notes.
  * Added clear responses for unauthorized access, invalid requests, and missing entries.

* **Bug Fixes**
  * Ensured calendar data remains private and scoped to the signed-in account.

* **Tests**
  * Added coverage for calendar operations, validation, URL handling, company suggestions, and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->