### PR TITLE
🐛 Fix: 로그인이 1~2시간마다 풀리던 문제 — 리프레시 회전 버그 수정 + 30일 유지

### DIFF
--- a/src/main/java/com/nklcbdty/api/auth/service/AuthService.java
+++ b/src/main/java/com/nklcbdty/api/auth/service/AuthService.java
@@ -19,23 +19,21 @@ public class AuthService {
     }
 
     public TokenResponse refreshAccessToken(String userId, String refreshToken) {
-        validateRefreshToken(userId, refreshToken);
         utilityNklcb.validToken(refreshToken);
+        if (!tokenService.isRefreshTokenValid(userId, refreshToken)) {
+            throw new InvalidTokenException("Invalid Refresh Token");
+        }
 
         // 새로운 Access Token 및 Refresh Token 생성
         String newAccessToken = utilityNklcb.generateToken(userId, false);
         String newRefreshToken = utilityNklcb.generateToken(userId, true);
 
-        // Redis에 새로운 Refresh Token 저장
-        tokenService.saveRefreshToken(userId, refreshToken);
+        // 새 Refresh Token 을 저장하고 방금 쓴 토큰은 무효화한다.
+        // (예전에는 여기서 새 토큰 대신 옛 토큰을 다시 저장해서, 클라이언트가 받은
+        //  새 토큰이 저장소와 어긋나 두 번째 갱신부터 전부 실패 → 강제 로그아웃됐다)
+        tokenService.rotateRefreshToken(userId, refreshToken, newRefreshToken);
 
         return createTokenResponse(newAccessToken, newRefreshToken);
-    }
-    private void validateRefreshToken(String userId, String refreshToken) {
-        String storedRefreshToken = tokenService.getRefreshToken(userId);
-        if (!refreshToken.equals(storedRefreshToken)) {
-            throw new InvalidTokenException("Invalid Refresh Token");
-        }
     }
     private TokenResponse createTokenResponse(String accessToken, String refreshToken) {
         TokenResponse response = new TokenResponse();

--- a/src/main/java/com/nklcbdty/api/auth/service/TokenService.java
+++ b/src/main/java/com/nklcbdty/api/auth/service/TokenService.java
@@ -1,25 +1,43 @@
 package com.nklcbdty.api.auth.service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.HexFormat;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.nklcbdty.api.common.UtilityNklcb;
 import com.nklcbdty.api.user.repository.RefreshTokenRepository;
 import com.nklcbdty.api.user.vo.RefreshTokenVo;
 
-import io.lettuce.core.RedisConnectionException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 리프레시 토큰 저장·검증.
+ *
+ * <p>DB(refresh_tokens)가 진실의 원천이고 Redis 는 빠른 조회용 캐시다.
+ * 예전에는 Redis 에만 의존해서 Redis 가 비면(재시작·유실) 갱신이 전부 실패해
+ * 사용자가 1시간마다 로그아웃되는 문제가 있었다.</p>
+ *
+ * <p>DB 검증은 userId+토큰해시 단위라 기기(브라우저)마다 각자의 리프레시 토큰이
+ * 유효하다 — 다른 기기에서 로그인해도 기존 기기가 로그아웃되지 않는다.</p>
+ */
 @Slf4j
 @Service
 public class TokenService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final long REFRESH_TOKEN_EXPIRATION_DAYS = 7;
+    private final long REFRESH_TOKEN_EXPIRATION_DAYS = UtilityNklcb.REFRESH_TOKEN_EXPIRATION_DAYS;
+    /** 여러 탭이 같은 토큰으로 동시에 갱신을 부르면 한쪽은 회전 직후의 옛 토큰을 내민다. 그 유예 시간. */
+    private static final long ROTATED_TOKEN_GRACE_SECONDS = 60;
 
     @Autowired
     public TokenService(RedisTemplate<String, Object> redisTemplate, RefreshTokenRepository refreshTokenRepository) {
@@ -28,45 +46,94 @@ public class TokenService {
     }
 
     public void saveRefreshToken(String userId, String refreshToken) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiresAt = now.plusDays(REFRESH_TOKEN_EXPIRATION_DAYS);
+        String ipAddress = null;
+        String userAgent = null;
+
         try {
-            redisTemplate.opsForValue().set(userId + ":refreshToken", refreshToken);
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            ipAddress = request.getRemoteAddr();
+            userAgent = request.getHeader("User-Agent");
+        } catch (IllegalStateException e) {
+            log.warn("Cannot get HttpServletRequest outside of web request context: {}", e.getMessage());
+        }
 
-            LocalDateTime now = LocalDateTime.now();
-            LocalDateTime expiresAt = now.plusDays(REFRESH_TOKEN_EXPIRATION_DAYS);
-            String ipAddress = null;
-            String userAgent = null;
-
-            try {
-                HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-                ipAddress = request.getRemoteAddr();
-                userAgent = request.getHeader("User-Agent");
-            } catch (IllegalStateException e) {
-                log.warn("Cannot get HttpServletRequest outside of web request context: {}", e.getMessage());
-            }
-            
-            String hashedRefreshToken = hashToken(refreshToken); // 별도의 해싱 유틸리티 필요
-            
+        try {
             RefreshTokenVo refreshTokenEntity = RefreshTokenVo.builder()
                 .userId(userId)
-                .token(hashedRefreshToken) // 해싱된 토큰 저장
-                .issuedAt(now) // 발급 시각
-                .expiresAt(expiresAt) // 만료 시각
-                .isRevoked(false) // 처음 발급될 때는 무효화되지 않음
-                .ipAddress(ipAddress) // IP 주소
-                .userAgent(userAgent) // User-Agent
+                .token(hashToken(refreshToken)) // 원문 대신 해시를 저장
+                .issuedAt(now)
+                .expiresAt(expiresAt)
+                .isRevoked(false)
+                .ipAddress(ipAddress)
+                .userAgent(userAgent)
                 .build();
             refreshTokenRepository.save(refreshTokenEntity);
-
-            log.info("Redis token created: {}, {}. token saved for userId: {}", userId + ":refreshToken", refreshToken, userId);
-        } catch (RedisConnectionException e) {
-            log.info("error {}", e.getMessage());
         } catch (Exception e) {
-            log.info("error {}", e.getMessage());
+            // DB 저장이 실패하면 Redis 가 비었을 때 갱신이 실패한다. 반드시 로그로 남긴다.
+            log.error("refresh token DB save failed for userId {}: {}", userId, e.getMessage());
+        }
+
+        try {
+            redisTemplate.opsForValue()
+                .set(userId + ":refreshToken", refreshToken, Duration.ofDays(REFRESH_TOKEN_EXPIRATION_DAYS));
+            log.info("refresh token saved for userId: {}", userId);
+        } catch (Exception e) {
+            log.warn("refresh token Redis save failed (DB fallback will be used) for userId {}: {}", userId, e.getMessage());
+        }
+    }
+
+    /**
+     * 리프레시 토큰이 이 사용자에게 발급된 유효한 토큰인지 확인한다.
+     * Redis 에 있으면 바로 통과, 없으면 DB 에서 해시로 찾는다.
+     */
+    public boolean isRefreshTokenValid(String userId, String refreshToken) {
+        if (userId == null || refreshToken == null) {
+            return false;
+        }
+        if (refreshToken.equals(getRefreshToken(userId))) {
+            return true;
+        }
+
+        try {
+            LocalDateTime now = LocalDateTime.now();
+            return refreshTokenRepository
+                .findFirstByUserIdAndTokenOrderByIdDesc(userId, hashToken(refreshToken))
+                .filter(t -> t.getExpiresAt().isAfter(now))
+                .filter(t -> !t.isRevoked()
+                    || (t.getRevokedAt() != null
+                        && t.getRevokedAt().isAfter(now.minusSeconds(ROTATED_TOKEN_GRACE_SECONDS))))
+                .isPresent();
+        } catch (Exception e) {
+            log.error("refresh token DB lookup failed for userId {}: {}", userId, e.getMessage());
+            return false;
+        }
+    }
+
+    /** 갱신 성공 시 새 토큰을 저장하고 방금 쓴 옛 토큰은 무효화한다(유예 시간 동안은 통과). */
+    public void rotateRefreshToken(String userId, String oldRefreshToken, String newRefreshToken) {
+        saveRefreshToken(userId, newRefreshToken);
+        try {
+            refreshTokenRepository
+                .findFirstByUserIdAndTokenAndIsRevokedFalseOrderByIdDesc(userId, hashToken(oldRefreshToken))
+                .ifPresent(t -> {
+                    t.setRevoked(true);
+                    t.setRevokedAt(LocalDateTime.now());
+                    refreshTokenRepository.save(t);
+                });
+        } catch (Exception e) {
+            log.warn("old refresh token revoke failed for userId {}: {}", userId, e.getMessage());
         }
     }
 
     private String hashToken(String token) {
-        return "hashed_" + token;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(token.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
     }
 
     public String getRefreshToken(String userId) {

--- a/src/main/java/com/nklcbdty/api/common/UtilityNklcb.java
+++ b/src/main/java/com/nklcbdty/api/common/UtilityNklcb.java
@@ -14,6 +14,9 @@ import javax.crypto.SecretKey; // 추가해야 할 import
 
 @Component
 public class UtilityNklcb {
+    /** 한 번 로그인하면 이 기간 동안 로그인이 유지된다. TokenService 의 DB 만료 시각도 이 값을 쓴다. */
+    public static final long REFRESH_TOKEN_EXPIRATION_DAYS = 30;
+
     @Value("${jwt.secret}")
     private String SECRET_KEY;
 
@@ -39,7 +42,7 @@ public class UtilityNklcb {
         Date expiryDate;
 
         if (isRefreshToken) {
-            expiryDate = new Date(now.getTime() + 604_800_000); // 7일 후 만료
+            expiryDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION_DAYS * 24L * 60 * 60 * 1000); // 30일 후 만료
         } else {
             expiryDate = new Date(now.getTime() + 3_600_000); // 1시간 후 만료
         }

--- a/src/main/java/com/nklcbdty/api/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/nklcbdty/api/user/repository/RefreshTokenRepository.java
@@ -1,9 +1,16 @@
 package com.nklcbdty.api.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nklcbdty.api.user.vo.RefreshTokenVo;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenVo, Long> {
 
+    /** 검증용: 이 사용자에게 이 토큰(해시)이 발급된 적 있는지. 회전 직후 재검증을 위해 무효화된 행도 찾는다. */
+    Optional<RefreshTokenVo> findFirstByUserIdAndTokenOrderByIdDesc(String userId, String token);
+
+    /** 회전용: 방금 쓴 옛 토큰 중 아직 무효화되지 않은 행. */
+    Optional<RefreshTokenVo> findFirstByUserIdAndTokenAndIsRevokedFalseOrderByIdDesc(String userId, String token);
 }

--- a/src/test/java/com/nklcbdty/api/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/auth/service/AuthServiceTest.java
@@ -1,0 +1,53 @@
+package com.nklcbdty.api.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nklcbdty.api.auth.dto.TokenResponse;
+import com.nklcbdty.api.common.UtilityNklcb;
+import com.nklcbdty.api.exception.InvalidTokenException;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private UtilityNklcb utilityNklcb;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void 갱신에_성공하면_클라이언트에_준_새_리프레시_토큰을_그대로_저장한다() {
+        // 예전 버그: 새 토큰을 응답으로 주고 저장은 옛 토큰을 해서
+        // 두 번째 갱신부터 전부 실패 → 1~2시간마다 강제 로그아웃됐다.
+        when(tokenService.isRefreshTokenValid("kakao@1", "old-refresh")).thenReturn(true);
+        when(utilityNklcb.generateToken("kakao@1", false)).thenReturn("new-access");
+        when(utilityNklcb.generateToken("kakao@1", true)).thenReturn("new-refresh");
+
+        TokenResponse response = authService.refreshAccessToken("kakao@1", "old-refresh");
+
+        assertThat(response.getAccessToken()).isEqualTo("new-access");
+        assertThat(response.getRefreshToken()).isEqualTo("new-refresh");
+        // 저장(회전)되는 토큰 = 응답으로 나간 토큰
+        verify(tokenService).rotateRefreshToken("kakao@1", "old-refresh", "new-refresh");
+    }
+
+    @Test
+    void 저장소에_없는_리프레시_토큰이면_거부한다() {
+        when(tokenService.isRefreshTokenValid("kakao@1", "stolen-refresh")).thenReturn(false);
+
+        assertThatThrownBy(() -> authService.refreshAccessToken("kakao@1", "stolen-refresh"))
+            .isInstanceOf(InvalidTokenException.class);
+    }
+}

--- a/src/test/java/com/nklcbdty/api/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/auth/service/TokenServiceTest.java
@@ -1,0 +1,145 @@
+package com.nklcbdty.api.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.nklcbdty.api.user.repository.RefreshTokenRepository;
+import com.nklcbdty.api.user.vo.RefreshTokenVo;
+
+/**
+ * 로그인 유지의 핵심인 리프레시 토큰 검증을 고정한다.
+ * 특히 "Redis 가 비어 있어도 DB 로 검증된다"가 깨지면
+ * 사용자가 1시간마다 로그아웃되는 장애가 재발한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    private RefreshTokenVo dbRow(boolean revoked, LocalDateTime revokedAt, LocalDateTime expiresAt) {
+        return RefreshTokenVo.builder()
+            .id(1L)
+            .userId("kakao@1")
+            .token("stored-hash")
+            .issuedAt(LocalDateTime.now().minusDays(1))
+            .expiresAt(expiresAt)
+            .isRevoked(revoked)
+            .revokedAt(revokedAt)
+            .build();
+    }
+
+    @Test
+    void 레디스가_비어_있어도_DB에_유효한_토큰이_있으면_통과한다() {
+        // Redis 는 스텁하지 않는다(= 비어 있음/장애 상황과 동일)
+        when(refreshTokenRepository.findFirstByUserIdAndTokenOrderByIdDesc(eq("kakao@1"), anyString()))
+            .thenReturn(Optional.of(dbRow(false, null, LocalDateTime.now().plusDays(10))));
+
+        assertThat(tokenService.isRefreshTokenValid("kakao@1", "refresh-token")).isTrue();
+    }
+
+    @Test
+    void 레디스에_같은_토큰이_있으면_DB를_보지_않고_통과한다() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("kakao@1:refreshToken")).thenReturn("refresh-token");
+
+        assertThat(tokenService.isRefreshTokenValid("kakao@1", "refresh-token")).isTrue();
+    }
+
+    @Test
+    void DB에도_없는_토큰은_거부한다() {
+        when(refreshTokenRepository.findFirstByUserIdAndTokenOrderByIdDesc(eq("kakao@1"), anyString()))
+            .thenReturn(Optional.empty());
+
+        assertThat(tokenService.isRefreshTokenValid("kakao@1", "refresh-token")).isFalse();
+    }
+
+    @Test
+    void 만료된_토큰은_거부한다() {
+        when(refreshTokenRepository.findFirstByUserIdAndTokenOrderByIdDesc(eq("kakao@1"), anyString()))
+            .thenReturn(Optional.of(dbRow(false, null, LocalDateTime.now().minusMinutes(1))));
+
+        assertThat(tokenService.isRefreshTokenValid("kakao@1", "refresh-token")).isFalse();
+    }
+
+    @Test
+    void 회전_직후의_옛_토큰은_유예시간_안에서만_통과한다() {
+        // 동시 401 을 받은 다른 탭이 옛 토큰으로 갱신을 다시 부르는 상황
+        when(refreshTokenRepository.findFirstByUserIdAndTokenOrderByIdDesc(eq("kakao@1"), anyString()))
+            .thenReturn(Optional.of(dbRow(true, LocalDateTime.now().minusSeconds(5), LocalDateTime.now().plusDays(10))));
+        assertThat(tokenService.isRefreshTokenValid("kakao@1", "refresh-token")).isTrue();
+
+        when(refreshTokenRepository.findFirstByUserIdAndTokenOrderByIdDesc(eq("kakao@1"), anyString()))
+            .thenReturn(Optional.of(dbRow(true, LocalDateTime.now().minusMinutes(5), LocalDateTime.now().plusDays(10))));
+        assertThat(tokenService.isRefreshTokenValid("kakao@1", "refresh-token")).isFalse();
+    }
+
+    @Test
+    void 저장할_때_원문이_아니라_해시를_DB에_남기고_만료는_30일이다() {
+        tokenService.saveRefreshToken("kakao@1", "refresh-token");
+
+        ArgumentCaptor<RefreshTokenVo> captor = ArgumentCaptor.forClass(RefreshTokenVo.class);
+        verify(refreshTokenRepository).save(captor.capture());
+        RefreshTokenVo saved = captor.getValue();
+        assertThat(saved.getToken()).isNotEqualTo("refresh-token").hasSize(64); // SHA-256 hex
+        assertThat(saved.getExpiresAt()).isAfter(LocalDateTime.now().plusDays(29));
+    }
+
+    @Test
+    void 회전하면_새_토큰을_저장하고_옛_토큰_행을_무효화한다() {
+        RefreshTokenVo oldRow = dbRow(false, null, LocalDateTime.now().plusDays(10));
+        when(refreshTokenRepository.findFirstByUserIdAndTokenAndIsRevokedFalseOrderByIdDesc(eq("kakao@1"), anyString()))
+            .thenReturn(Optional.of(oldRow));
+
+        tokenService.rotateRefreshToken("kakao@1", "old-refresh", "new-refresh");
+
+        ArgumentCaptor<RefreshTokenVo> captor = ArgumentCaptor.forClass(RefreshTokenVo.class);
+        verify(refreshTokenRepository, atLeastOnce()).save(captor.capture());
+        List<RefreshTokenVo> savedAll = captor.getAllValues();
+
+        // 새 토큰 행이 저장됐다
+        assertThat(savedAll).anySatisfy(v -> {
+            assertThat(v.isRevoked()).isFalse();
+            assertThat(v.getToken()).hasSize(64);
+        });
+        // 옛 행은 무효화됐다
+        assertThat(oldRow.isRevoked()).isTrue();
+        assertThat(oldRow.getRevokedAt()).isNotNull();
+    }
+
+    @Test
+    void 레디스가_죽어도_저장은_예외를_내지_않는다() {
+        when(redisTemplate.opsForValue()).thenThrow(new RuntimeException("redis down"));
+
+        tokenService.saveRefreshToken("kakao@1", "refresh-token");
+
+        verify(refreshTokenRepository).save(any(RefreshTokenVo.class));
+    }
+}

--- a/src/test/java/com/nklcbdty/api/user/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/nklcbdty/api/user/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.nklcbdty.api.user.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import com.nklcbdty.api.user.vo.RefreshTokenVo;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * 파생 쿼리(IsRevokedFalse 등)는 부팅 시점에 파싱되므로,
+ * 여기서 깨지면 배포 직후 애플리케이션이 아예 뜨지 않는다. H2 로 실제 파싱·동작을 고정한다.
+ */
+@DataJpaTest(properties = {
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    // 본 설정은 MariaDBDialect 로 고정돼 있어 H2 가 DDL 을 못 알아듣는다
+    "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+})
+@Import(RefreshTokenRepositoryTest.QuerydslTestConfig.class)
+class RefreshTokenRepositoryTest {
+
+    /** JPA 슬라이스에는 QuerydslConfig 가 없어서 다른 repository 구현체가 못 뜬다. 여기서 보충한다. */
+    @TestConfiguration
+    static class QuerydslTestConfig {
+        @Bean
+        JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+            return new JPAQueryFactory(entityManager);
+        }
+    }
+
+    @Autowired
+    private RefreshTokenRepository repository;
+
+    private RefreshTokenVo save(String userId, String hash, boolean revoked) {
+        return repository.save(RefreshTokenVo.builder()
+            .userId(userId)
+            .token(hash)
+            .issuedAt(LocalDateTime.now())
+            .expiresAt(LocalDateTime.now().plusDays(30))
+            .isRevoked(revoked)
+            .build());
+    }
+
+    @Test
+    @DisplayName("userId+토큰해시로 최신 행을 찾는다 — 무효화된 행도 검증용으로는 조회된다")
+    void findByUserIdAndToken() {
+        save("local@1", "hash-a", true);
+        save("local@1", "hash-a", false);
+        save("local@2", "hash-b", false);
+
+        Optional<RefreshTokenVo> found = repository.findFirstByUserIdAndTokenOrderByIdDesc("local@1", "hash-a");
+        assertThat(found).isPresent();
+        assertThat(found.get().isRevoked()).isFalse(); // 최신(id 큰) 행
+
+        assertThat(repository.findFirstByUserIdAndTokenOrderByIdDesc("local@1", "hash-b")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("회전용 조회는 무효화되지 않은 행만 찾는다")
+    void findNotRevoked() {
+        save("local@1", "hash-a", true);
+        assertThat(repository.findFirstByUserIdAndTokenAndIsRevokedFalseOrderByIdDesc("local@1", "hash-a")).isEmpty();
+
+        save("local@1", "hash-a", false);
+        assertThat(repository.findFirstByUserIdAndTokenAndIsRevokedFalseOrderByIdDesc("local@1", "hash-a")).isPresent();
+    }
+}


### PR DESCRIPTION
## 문제

로그인이 1~2시간마다 풀린다. 액세스 토큰(1시간) 만료 후 갱신이 이어져야 하는데, 갱신 경로에 버그가 겹쳐 있었다.

## 원인과 수정

1. **회전 버그 (핵심)** — `AuthService.refreshAccessToken` 이 새 리프레시 토큰을 응답으로 주면서 저장소에는 **방금 쓴 옛 토큰**을 다시 저장했다. 클라이언트가 가진 새 토큰과 저장소가 어긋나 **두 번째 갱신부터 전부 실패 → 강제 로그아웃**. 이제 새 토큰을 저장하고 옛 토큰은 무효화한다(동시 갱신 대비 60초 유예).
2. **Redis 단독 의존** — Redis 가 재시작·유실되면 갱신이 전부 실패했다. DB(`refresh_tokens`, 운영에 이미 존재·기록 중)를 진실의 원천으로 삼고 Redis 는 캐시로만 쓴다. 부수 효과로 검증이 토큰 단위가 되어 **다른 기기에서 로그인해도 기존 기기가 안 풀린다** (기존에는 Redis 키가 userId 당 1개라 마지막 로그인이 이전 기기를 죽였다).
3. **수명 7일 → 30일** — 한 번 로그인하면 한 달 유지.

DB에는 원문 대신 SHA-256 해시를 저장한다(기존 `"hashed_" + token` 자리표시자 대체 — 기존 행은 해시가 안 맞지만 어차피 검증에 쓰인 적이 없어 영향 없음, 만료 후 자연 소멸).

## 테스트

- `AuthServiceTest` — 회전 시 저장되는 토큰 = 응답으로 나간 토큰(회귀 방지), 무효 토큰 거부
- `TokenServiceTest` — Redis 비어도 DB 폴백 통과, 만료/무효화 거부, 유예 시간, 해시 저장, Redis 장애 내성
- `RefreshTokenRepositoryTest` (H2) — 파생 쿼리가 부팅 시점에 깨지지 않음을 고정
- `contextLoads` 실패는 로컬 환경변수 부재(`URL must start with 'jdbc'`)로 기존부터 실패하던 것

## 배포 메모

- 프론트 짝 PR: kingle1024/nklcbdty-ui 의 `claude/extend-login-session` (일시 오류에 로그아웃하지 않도록)
- CloudType 은 수동 재시작 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved refresh-token validation and rejection of invalid or unknown tokens.
  * Added secure token storage with expiration, revocation, and rotation support.
  * Extended refresh-token validity to 30 days with a brief rotation grace period.
  * Improved resilience when caching services are unavailable.

* **Bug Fixes**
  * Refreshing a token now replaces and revokes the consumed token.

* **Tests**
  * Added coverage for validation, expiration, revocation, rotation, persistence, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->