### PR TITLE
🔒 Fix: 리프레시 토큰을 Redis 에 원문으로 저장하지 않는다

### DIFF
--- a/src/main/java/com/nklcbdty/api/auth/service/TokenService.java
+++ b/src/main/java/com/nklcbdty/api/auth/service/TokenService.java
@@ -29,6 +29,10 @@ import lombok.extern.slf4j.Slf4j;
  *
  * <p>DB 검증은 userId+토큰해시 단위라 기기(브라우저)마다 각자의 리프레시 토큰이
  * 유효하다 — 다른 기기에서 로그인해도 기존 기기가 로그아웃되지 않는다.</p>
+ *
+ * <p>DB·Redis 어느 쪽에도 토큰 원문은 남기지 않는다. Redis 는 "이 토큰이 유효한가"만
+ * 알면 되므로 해시를 키에 담고 존재 여부만 본다 — 덤프(RDB/AOF)가 유출돼도
+ * 그 값으로 로그인할 수 없다.</p>
  */
 @Slf4j
 @Service
@@ -77,7 +81,7 @@ public class TokenService {
 
         try {
             redisTemplate.opsForValue()
-                .set(userId + ":refreshToken", refreshToken, Duration.ofDays(REFRESH_TOKEN_EXPIRATION_DAYS));
+                .set(cacheKey(userId, refreshToken), "1", Duration.ofDays(REFRESH_TOKEN_EXPIRATION_DAYS));
             log.info("refresh token saved for userId: {}", userId);
         } catch (Exception e) {
             log.warn("refresh token Redis save failed (DB fallback will be used) for userId {}: {}", userId, e.getMessage());
@@ -92,7 +96,7 @@ public class TokenService {
         if (userId == null || refreshToken == null) {
             return false;
         }
-        if (refreshToken.equals(getRefreshToken(userId))) {
+        if (isCached(userId, refreshToken)) {
             return true;
         }
 
@@ -114,6 +118,12 @@ public class TokenService {
     /** 갱신 성공 시 새 토큰을 저장하고 방금 쓴 옛 토큰은 무효화한다(유예 시간 동안은 통과). */
     public void rotateRefreshToken(String userId, String oldRefreshToken, String newRefreshToken) {
         saveRefreshToken(userId, newRefreshToken);
+        // 캐시는 토큰별 키라 덮어써지지 않는다. 지우지 않으면 무효화한 토큰이 빠른 경로로 계속 통과한다.
+        try {
+            redisTemplate.delete(cacheKey(userId, oldRefreshToken));
+        } catch (Exception e) {
+            log.warn("old refresh token cache delete failed for userId {}: {}", userId, e.getMessage());
+        }
         try {
             refreshTokenRepository
                 .findFirstByUserIdAndTokenAndIsRevokedFalseOrderByIdDesc(userId, hashToken(oldRefreshToken))
@@ -136,17 +146,16 @@ public class TokenService {
         }
     }
 
-    public String getRefreshToken(String userId) {
+    /** 값이 아니라 키로 판별한다 — 캐시에 토큰 원문이 남지 않는다. */
+    private String cacheKey(String userId, String refreshToken) {
+        return "refresh:" + userId + ":" + hashToken(refreshToken);
+    }
+
+    private boolean isCached(String userId, String refreshToken) {
         try {
-            Object token = redisTemplate.opsForValue().get(userId + ":refreshToken");
-
-            if (token == null) {
-                return null;
-            }
-
-            return (String)redisTemplate.opsForValue().get(userId + ":refreshToken");
+            return Boolean.TRUE.equals(redisTemplate.hasKey(cacheKey(userId, refreshToken)));
         } catch (Exception e) {
-            return null;
+            return false;
         }
     }
 }

--- a/src/test/java/com/nklcbdty/api/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/auth/service/TokenServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -67,10 +68,33 @@ class TokenServiceTest {
 
     @Test
     void 레디스에_같은_토큰이_있으면_DB를_보지_않고_통과한다() {
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get("kakao@1:refreshToken")).thenReturn("refresh-token");
+        when(redisTemplate.hasKey(anyString())).thenReturn(true);
 
         assertThat(tokenService.isRefreshTokenValid("kakao@1", "refresh-token")).isTrue();
+    }
+
+    @Test
+    void 캐시에는_토큰_원문이_아니라_해시가_담긴다() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        tokenService.saveRefreshToken("kakao@1", "refresh-token");
+
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(key.capture(), any(), any(Duration.class));
+        assertThat(key.getValue()).startsWith("refresh:kakao@1:").doesNotContain("refresh-token");
+        assertThat(key.getValue().substring("refresh:kakao@1:".length())).hasSize(64);
+    }
+
+    @Test
+    void 회전하면_옛_토큰의_캐시_키를_지운다() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        tokenService.rotateRefreshToken("kakao@1", "old-refresh", "new-refresh");
+
+        // 지우지 않으면 무효화한 토큰이 TTL 동안 빠른 경로로 계속 통과한다
+        ArgumentCaptor<String> deleted = ArgumentCaptor.forClass(String.class);
+        verify(redisTemplate).delete(deleted.capture());
+        assertThat(deleted.getValue()).startsWith("refresh:kakao@1:").doesNotContain("old-refresh");
     }
 
     @Test


### PR DESCRIPTION
## 왜

DB(`refresh_tokens`)에는 이미 SHA-256 해시로 저장하고 있었는데, Redis 캐시에는 `{userId}:refreshToken` 키에 **토큰 원문**이 그대로 들어가고 있었다. Redis 덤프(RDB/AOF)가 유출되거나 `MONITOR` 로 값이 새면 그 토큰으로 바로 로그인이 된다.

리프레시 토큰을 Redis 에 두는 것 자체는 문제가 아니다(TTL 있고 폐기 가능한 자격증명은 Redis 의 정석 용도). 원문으로 두는 게 문제였다.

## 무엇

캐시는 "이 토큰이 유효한가"만 알면 되므로 해시를 키에 담고 존재 여부만 본다.

- 키 `refresh:{userId}:{sha256(token)}`, 값은 `"1"` — 원문은 어디에도 안 남는다
- 검증은 `hasKey` (원문 비교 제거)
- **회전 시 옛 토큰의 캐시 키를 삭제.** 토큰별 키라 예전처럼 덮어써지지 않아서, 지우지 않으면 무효화한 토큰이 TTL(30일) 동안 빠른 경로로 계속 통과한다
- 쓰이지 않던 `public getRefreshToken` 제거

부수 효과로 기기별 토큰이 각각 캐시된다. 예전엔 유저당 키 하나를 덮어써서 두 번째 기기는 매번 DB 까지 내려갔다.

## 배포 영향

없음. 기존 `{userId}:refreshToken` 키는 새 코드가 읽지 않고 TTL 로 사라진다. 로그인 중인 사용자는 첫 갱신 때 캐시 미스 → DB 폴백으로 통과하므로 **로그아웃되지 않는다**.

## 테스트

`TokenServiceTest` 에 2개 추가 — 캐시 키에 원문이 안 들어가는지, 회전 시 옛 키를 지우는지. 기존 8개 통과.

전체 199개 중 `NklcbdtyApplicationTests.contextLoads` 1개 실패는 이 변경과 무관한 기존 실패다(로컬에 `DB_URL` 환경변수가 없어 `URL must start with 'jdbc'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Refresh tokens are no longer stored in plaintext in Redis.
  * Cached refresh-token entries now use hashed, token-specific keys and existence markers.
  * Token rotation removes the previous cached token before revocation.
  * Refresh-token expiration continues to be enforced through cache TTLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->