### PR TITLE
🚨 Fix: 배민 공고가 매일 사라지던 문제 — 링크 점검 후 재크롤로 복구

### DIFF
--- a/src/main/java/com/nklcbdty/api/crawler/recovery/BaeminRecoveryScheduler.java
+++ b/src/main/java/com/nklcbdty/api/crawler/recovery/BaeminRecoveryScheduler.java
@@ -1,0 +1,86 @@
+package com.nklcbdty.api.crawler.recovery;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.interfaces.JobCrawler;
+import com.nklcbdty.common.vo.Job_mst;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 링크 점검 배치가 매일 죽여 놓은 배민 공고를 다시 살린다.
+ *
+ * <p><b>이건 우회다.</b> 제대로 된 자리는 batch 저장소의 {@code BaeminLivenessChecker}(2026-08-04)이고,
+ * 그건 배민 채용 API 로 생존을 판정해 애초에 종료 처리를 하지 않는다. 그런데 그 코드가 운영에
+ * 배포되지 않는다 — CloudType 의 batch 앱이 새 이미지를 안 가져간다. 배포된 코드가 옛것이라는 건
+ * 링크 점검 cron 으로 확인할 수 있다(소스는 {@code 0 30 9}, 운영은 {@code 0 30 7}):</p>
+ *
+ * <pre>
+ * curl -s https://port-0-nklcbdty-batch-m6qh1fte0c037b76.sel4.cloudtype.app/actuator/scheduledtasks
+ * </pre>
+ *
+ * <p>배민 상세페이지는 Next.js 클라이언트 렌더링이라 원본 HTML 에 공고명이 없다. 링크 점검은
+ * "상세페이지 HTML 에 공고명이 있는가"로 판정하므로 살아있는 공고를 전부 종료로 찍는다.
+ * 07:00 크롤이 살리면 07:30 링크 점검이 다시 죽이는 하루 주기가 된다(운영 실행 이력 기준
+ * 링크 점검은 07:30~08:23, 이어서 08:23 에 메일). 그래서 점검이 끝난 뒤에 한 번 더 크롤해
+ * 되살린다.</p>
+ *
+ * <p>크롤 결과에 있는 공고는 {@code CrawlerCommonService#getNotSaveJobItem} 이 endDate 를 최신값
+ * (배민은 {@code 2999-12-31})으로 되돌린다. 즉 이 스케줄러는 크롤을 한 번 더 부르는 것 말고
+ * 하는 일이 없다 — 배민 채용 API 한 번 호출이라 3초면 끝난다.</p>
+ *
+ * <p>batch 가 제대로 배포되면 이 작업은 아무것도 바꾸지 않는 무해한 중복이 된다.
+ * 그때 {@code crawler.recovery.baemin.enabled=false} 로 끄거나 지우면 된다.</p>
+ */
+@Slf4j
+@Service
+public class BaeminRecoveryScheduler {
+
+    private final JobCrawler baeminJobCrawlerService;
+    private final CrawlerCommonService commonService;
+    private final boolean enabled;
+
+    public BaeminRecoveryScheduler(
+        @Qualifier("baeminJobCrawlerService") JobCrawler baeminJobCrawlerService,
+        CrawlerCommonService commonService,
+        @Value("${crawler.recovery.baemin.enabled:true}") boolean enabled) {
+
+        this.baeminJobCrawlerService = baeminJobCrawlerService;
+        this.commonService = commonService;
+        this.enabled = enabled;
+    }
+
+    /** 링크 점검(07:30~08:23)과 메일(08:23)이 모두 끝난 뒤. */
+    @Scheduled(cron = "${crawler.recovery.baemin.cron:0 0 9 * * *}", zone = "Asia/Seoul")
+    public void recover() {
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            List<Job_mst> items = baeminJobCrawlerService.crawlJobs().get();
+            if (items == null) {
+                log.warn("배민 공고 복구: 크롤 결과가 null");
+                return;
+            }
+            // 신규 공고는 여기서 저장된다. 기존 행의 endDate 되살리기는 crawlJobs() 안에서 이미 끝난다.
+            commonService.refineJobItemBygemini(items);
+            commonService.saveAll(items);
+            log.info("배민 공고 복구 크롤 완료 — 신규 {}건", items.size());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("배민 공고 복구 중단됨");
+        } catch (ExecutionException e) {
+            log.error("배민 공고 복구 실패: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("배민 공고 복구 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/test/java/com/nklcbdty/api/crawler/recovery/BaeminRecoverySchedulerTest.java
+++ b/src/test/java/com/nklcbdty/api/crawler/recovery/BaeminRecoverySchedulerTest.java
@@ -1,0 +1,79 @@
+package com.nklcbdty.api.crawler.recovery;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.nklcbdty.api.crawler.common.CrawlerCommonService;
+import com.nklcbdty.api.crawler.interfaces.JobCrawler;
+import com.nklcbdty.common.vo.Job_mst;
+
+class BaeminRecoverySchedulerTest {
+
+    @Mock
+    private JobCrawler baeminJobCrawlerService;
+    @Mock
+    private CrawlerCommonService commonService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    private Job_mst job() {
+        Job_mst job = new Job_mst();
+        job.setAnnoId("25497");
+        job.setAnnoSubject("Server(배차시스템)");
+        return job;
+    }
+
+    @Test
+    void 크롤을_다시_돌려_공고를_되살린다() {
+        when(baeminJobCrawlerService.crawlJobs())
+            .thenReturn(CompletableFuture.completedFuture(List.of(job())));
+
+        new BaeminRecoveryScheduler(baeminJobCrawlerService, commonService, true).recover();
+
+        verify(baeminJobCrawlerService).crawlJobs();
+        verify(commonService).saveAll(anyList());
+    }
+
+    @Test
+    void 꺼두면_아무것도_하지_않는다() {
+        new BaeminRecoveryScheduler(baeminJobCrawlerService, commonService, false).recover();
+
+        verify(baeminJobCrawlerService, never()).crawlJobs();
+        verify(commonService, never()).saveAll(anyList());
+    }
+
+    @Test
+    void 크롤이_실패해도_예외를_밖으로_던지지_않는다() {
+        // 스케줄러에서 예외가 새면 다음 주기가 아니라 그 실행만 죽는다. 로그만 남기고 넘어가야 한다.
+        when(baeminJobCrawlerService.crawlJobs())
+            .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("배민 API 502")));
+
+        new BaeminRecoveryScheduler(baeminJobCrawlerService, commonService, true).recover();
+
+        verify(commonService, never()).saveAll(anyList());
+    }
+
+    @Test
+    void 신규가_없어도_캐시를_비우도록_저장을_부른다() {
+        // saveAll 에 @CacheEvict 가 걸려 있다. 되살린 기존 행이 목록에 다시 보이려면 캐시를 비워야 한다.
+        when(baeminJobCrawlerService.crawlJobs())
+            .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+        new BaeminRecoveryScheduler(baeminJobCrawlerService, commonService, true).recover();
+
+        verify(commonService).saveAll(anyList());
+    }
+}


### PR DESCRIPTION
## 증상

배민 공고가 아침 이후로 목록에 0건. 채용 사이트에는 10건이 멀쩡히 살아 있다.
(`/api/list?company=BAEMIN` → `[]`, 2026-08-17 확인)

## 원인

배민 상세페이지는 Next.js 클라이언트 렌더링이라 **원본 HTML 에 공고명이 없다.**
링크 점검 배치는 "상세페이지 HTML 에 공고명 문자열이 있는가"로 생존을 판정하므로,
살아있는 공고를 전부 종료(`end_date = 어제 23:59:59`)로 찍는다.

운영 배치 실행 이력(`BATCH_JOB_EXECUTION`) 기준 하루 주기:

```
crawlerBatchJob     07:00 → 07:24   공고 되살아남
linkValidatorJob    07:30 → 08:23   전부 다시 죽음
emailBatchJob       08:23 → 08:23
```

`job_mst` 의 배민 261행 중 **249행**이 검증기에 종료 처리된 이력이 있다.

## 왜 batch 를 안 고치고 여기서 고치나

제대로 된 자리는 batch 저장소의 `BaeminLivenessChecker`(2026-08-04, `59fb66f`)다.
배민 채용 API 로 생존을 판정해 애초에 종료 처리를 하지 않는다. **그런데 그게 운영에 배포되지 않는다.**

배포된 코드가 옛것이라는 직접 증거 — 링크 점검 cron 이 소스는 `0 30 9` 인데 운영은 `0 30 7` 이다:

```bash
curl -s https://port-0-nklcbdty-batch-m6qh1fte0c037b76.sel4.cloudtype.app/actuator/scheduledtasks
```

`0 30 7` 은 2026-05-25 (`ba45e23`) 이전 코드다. 이미지는 2026-08-13 에 Docker Hub 에 푸시됐는데
CloudType 의 batch 앱이 3일째 안 가져간다. 서비스 저장소 배포는 정상이다.

## 수정

링크 점검과 메일이 모두 끝난 **09:00 KST 에 배민 크롤을 한 번 더** 돌린다.
크롤 결과에 있는 공고는 `CrawlerCommonService#getNotSaveJobItem` 이 `endDate` 를 최신값
(배민은 `2999-12-31`)으로 되돌리므로, 배민 채용 API 한 번 호출(실측 3초)이면 끝난다.

`crawler.recovery.baemin.enabled` / `crawler.recovery.baemin.cron` 으로 끄고 켜고 시간 조정 가능.

**이건 우회다.** batch 가 제대로 배포되면 아무것도 바꾸지 않는 무해한 중복이 되고, 그때 끄거나 지우면 된다.
그 사실과 근거를 클래스 주석에 남겨 뒀다.

## 검증

- 신규 테스트 4건: 재크롤·저장 호출 / 꺼두면 무동작 / 크롤 실패가 밖으로 안 샘 / 신규 0건이어도 캐시 무효화를 위해 `saveAll` 호출
- 전체 201건 중 실패 1건은 `contextLoads` — 로컬에 `DATASOURCE_URL` 이 없어 나는 기존 실패다 (main 에서도 동일)
- 운영에서 같은 경로(`/api/crawler?company=baemin`)를 수동 호출해 배민 0건 → 9건 복구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)