### PR TITLE
✨ Feat: /api/version — 지금 떠 있는 빌드를 확인할 수 있게

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,12 @@ dependencies {
 
 }
 
+// /api/version 이 읽는 META-INF/build-info.properties 를 만든다(빌드 시각·버전).
+// 배포가 실제로 반영됐는지 판단하는 유일한 수단이라 빌드 산출물에 반드시 들어가야 한다.
+springBoot {
+    buildInfo()
+}
+
 test {
     useJUnitPlatform()
 }

--- a/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
+++ b/src/main/java/com/nklcbdty/api/common/security/AllowedPaths.java
@@ -39,6 +39,8 @@ public enum AllowedPaths {
     JOBS("/api/jobs/**"),
     // 관리자 로그인만 공개. 그 외 /api/admin/** 은 AuthFilter 에서 ADMIN 역할 토큰을 요구한다.
     ADMIN_LOGIN("/api/admin/login"),
+    // 지금 떠 있는 빌드 확인용(빌드/기동 시각). 배포가 실제로 반영됐는지 보려면 인증 없이 열려 있어야 한다.
+    VERSION("/api/version"),
     ;
 
     private final String path;

--- a/src/main/java/com/nklcbdty/api/common/version/VersionController.java
+++ b/src/main/java/com/nklcbdty/api/common/version/VersionController.java
@@ -1,0 +1,74 @@
+package com.nklcbdty.api.common.version;
+
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 지금 운영에 떠 있는 빌드가 무엇인지 알려준다.
+ *
+ * <p>왜 필요한가: GitHub Actions 가 초록이어도 CloudType 이 새 이미지를 안 가져가는 일이 있다.
+ * batch 는 2026-05-25 이전 코드로 몇 달을 돌았고(`/actuator/scheduledtasks` 의 cron 이 소스와
+ * 달라서 겨우 알아냈다), service 는 actuator 가 전부 401 이라 그마저도 못 본다. 그래서
+ * "머지했는데 왜 그대로냐"를 매번 추측으로 판단했다. 이 엔드포인트가 그걸 끝낸다.</p>
+ *
+ * <p>{@code startedAt} 은 JVM 시작 시각이다. 배포 시각과 같아야 한다 — 배포했는데 이 값이
+ * 며칠 전이면 컨테이너가 교체되지 않은 것이다.</p>
+ *
+ * <p>인증 없이 열어 둔다({@code AllowedPaths.VERSION}). 빌드 시각과 기동 시각뿐이라
+ * 노출해도 되는 정보다.</p>
+ */
+@RestController
+@RequestMapping("/api")
+public class VersionController {
+
+    private final ObjectProvider<BuildProperties> buildProperties;
+
+    public VersionController(ObjectProvider<BuildProperties> buildProperties) {
+        this.buildProperties = buildProperties;
+    }
+
+    @GetMapping(value = "/version", produces = "application/json;charset=UTF-8")
+    public Map<String, Object> version() {
+        Instant startedAt = Instant.ofEpochMilli(ManagementFactory.getRuntimeMXBean().getStartTime());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        // build-info.properties 가 없으면(로컬에서 bootRun 등) null 로 둔다. 없어도 기동은 돼야 한다.
+        BuildProperties build = buildProperties.getIfAvailable();
+        body.put("buildTime", build == null ? null : kst(build.getTime()));
+        body.put("version", build == null ? null : build.getVersion());
+        body.put("startedAt", kst(startedAt));
+        body.put("uptime", humanize(Duration.between(startedAt, Instant.now())));
+        return body;
+    }
+
+    private String kst(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+        return ZonedDateTime.ofInstant(instant, ZoneId.of("Asia/Seoul")).toString();
+    }
+
+    private String humanize(Duration d) {
+        long days = d.toDays();
+        long hours = d.toHoursPart();
+        long minutes = d.toMinutesPart();
+        if (days > 0) {
+            return days + "일 " + hours + "시간 " + minutes + "분";
+        }
+        if (hours > 0) {
+            return hours + "시간 " + minutes + "분";
+        }
+        return minutes + "분";
+    }
+}

--- a/src/test/java/com/nklcbdty/api/common/version/VersionControllerTest.java
+++ b/src/test/java/com/nklcbdty/api/common/version/VersionControllerTest.java
@@ -1,0 +1,109 @@
+package com.nklcbdty.api.common.version;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.info.BuildProperties;
+
+import com.nklcbdty.api.common.security.AllowedPaths;
+
+class VersionControllerTest {
+
+    /** BuildProperties 가 없을 때도 동작해야 한다(로컬 bootRun). */
+    private ObjectProvider<BuildProperties> absent() {
+        return new ObjectProvider<>() {
+            @Override
+            public BuildProperties getObject() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public BuildProperties getObject(Object... args) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public BuildProperties getIfAvailable() {
+                return null;
+            }
+
+            @Override
+            public BuildProperties getIfUnique() {
+                return null;
+            }
+        };
+    }
+
+    private ObjectProvider<BuildProperties> present(BuildProperties props) {
+        return new ObjectProvider<>() {
+            @Override
+            public BuildProperties getObject() {
+                return props;
+            }
+
+            @Override
+            public BuildProperties getObject(Object... args) {
+                return props;
+            }
+
+            @Override
+            public BuildProperties getIfAvailable() {
+                return props;
+            }
+
+            @Override
+            public BuildProperties getIfUnique() {
+                return props;
+            }
+        };
+    }
+
+    @Test
+    void 빌드정보가_있으면_빌드시각과_버전을_알려준다() {
+        Properties p = new Properties();
+        p.setProperty("version", "0.0.1-SNAPSHOT");
+        p.setProperty("time", "2026-08-18T09:30:00Z");
+
+        Map<String, Object> body = new VersionController(present(new BuildProperties(p))).version();
+
+        assertEquals("0.0.1-SNAPSHOT", body.get("version"));
+        assertNotNull(body.get("buildTime"));
+        // KST 로 환산해 보여준다. 09:30Z → 18:30+09:00
+        assertTrue(String.valueOf(body.get("buildTime")).contains("18:30"),
+            "KST 로 보여야 한다: " + body.get("buildTime"));
+    }
+
+    @Test
+    void 빌드정보가_없어도_기동시각은_알려준다() {
+        Map<String, Object> body = new VersionController(absent()).version();
+
+        assertNull(body.get("buildTime"));
+        assertNull(body.get("version"));
+        assertNotNull(body.get("startedAt"), "배포 반영 판단의 핵심 값이라 항상 있어야 한다");
+        assertNotNull(body.get("uptime"));
+    }
+
+    @Test
+    void 기동시각은_현재보다_과거다() {
+        Map<String, Object> body = new VersionController(absent()).version();
+
+        String startedAt = String.valueOf(body.get("startedAt"));
+        assertTrue(ZonedDateTime.parse(startedAt).toInstant().isBefore(Instant.now().plusSeconds(1)),
+            "startedAt=" + startedAt);
+    }
+
+    @Test
+    void 인증_없이_열려_있어야_한다() {
+        // 필터에 막히면 배포 확인 수단이 사라진다.
+        assertTrue(java.util.Arrays.asList(AllowedPaths.getAllowedPaths()).contains("/api/version"));
+    }
+}


### PR DESCRIPTION
## 왜

머지·배포했는데 동작이 그대로일 때, **배포가 반영되지 않은 것인지 코드가 잘못된 것인지 가릴 방법이 없다.**

- batch 는 2026-05-25 이전 코드로 몇 달을 돌았다. `/actuator/scheduledtasks` 의 cron 이 소스(`0 30 9`)와 다른 것(`0 30 7`)을 보고서야 알아냈다.
- service 는 actuator 가 전부 401 이라 그마저도 못 본다 — `health` · `info` · `env` · `beans` 모두 401 확인.
- 실제 사례: 2026-08-18, 배민 복구 스케줄러([PR #218](https://github.com/kingle1024/nklcbdty-service/pull/218))가 09:00 에 돌지 않았다. 배포 미반영인지 스케줄러 버그인지 판단할 근거가 없었다.

## 무엇

```
GET /api/version
{
  "buildTime": "2026-08-18T18:05:35.458+09:00[Asia/Seoul]",
  "version":   "0.0.1-SNAPSHOT",
  "startedAt": "2026-08-18T18:20:11.325+09:00[Asia/Seoul]",
  "uptime":    "12분"
}
```

`startedAt` 이 핵심이다. JVM 시작 시각이므로 **배포했는데 이 값이 며칠 전이면 컨테이너가 교체되지 않은 것**이다.

- `build.gradle` 에 `springBoot { buildInfo() }` → `META-INF/build-info.properties` 생성 (`build.time` 확인 완료)
- `BuildProperties` 가 없어도(로컬 `bootRun`) 기동되게 `ObjectProvider` 로 받는다
- `AllowedPaths` 에 등록해 인증 없이 공개. 빌드·기동 시각뿐이라 노출해도 되고, 막히면 이 엔드포인트의 존재 의미가 없다

## 검증

- 신규 테스트 4건: 빌드정보 있을 때 KST 환산 / 없어도 `startedAt` 은 나옴 / `startedAt` 이 현재보다 과거 / `AllowedPaths` 에 등록돼 있음
- 전체 205건 중 실패 1건은 `contextLoads` — 로컬에 `DATASOURCE_URL` 이 없어 나는 기존 실패다 (main 에서도 동일)
- `./gradlew bootJar` 로 `build-info.properties` 실제 생성 확인

머지 후 이 엔드포인트가 404 면, 배포 파이프라인이 초록인데도 컨테이너에 반영되지 않는다는 뜻이 된다 — 그 자체가 답이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
