### PR TITLE
🚨 Fix: 배민 되살리기를 Actions 워크플로로 — 컨테이너 배포를 안 기다리게

### DIFF
--- a/.github/workflows/baemin-recovery.yml
+++ b/.github/workflows/baemin-recovery.yml
@@ -1,0 +1,61 @@
+name: Baemin Recovery
+
+# 배민 공고 되살리기.
+#
+# 배민 상세페이지는 Next.js 클라이언트 렌더링이라 원본 HTML 에 공고명이 없다. batch 의 링크 점검은
+# "상세페이지 HTML 에 공고명이 있는가" 로 생존을 판정하므로 살아있는 배민 공고를 매일 아침 전부
+# 종료 처리한다(운영 실측: 07:30~08:21 사이에 10건 전부 end_date=어제 23:59:59).
+#
+# 제대로 된 자리는 두 곳인데 둘 다 운영에 못 올라간다:
+#   1. batch 의 BaeminLivenessChecker (2026-08-04) — 채용 API 로 판정해 애초에 종료 처리를 안 한다
+#   2. service 의 BaeminRecoveryScheduler (PR #218) — 09:00 에 재크롤
+# 둘 다 코드는 main 에 있고 도커 이미지도 푸시됐는데, CloudType 이 새 이미지를 컨테이너에
+# 반영하지 않는다. 판별법: GET /api/version 이 401 이면(=AllowedPaths 에 없음) PR #219 이전 코드다.
+#
+# 그래서 앱 안이 아니라 **여기서** 되살린다. Actions 는 정상 동작하고, /api/crawler 는 옛 빌드에도
+# 있으므로 컨테이너가 낡아 있어도 동작한다. 배포가 정상화되면 이 워크플로는 무해한 중복이 되니
+# 그때 지우면 된다.
+
+on:
+  schedule:
+    # UTC 00:00 = KST 09:00. 링크 점검(07:30~08:21)과 메일(08:23)이 끝난 뒤여야 한다.
+    # Actions cron 은 몇 분~십여 분 늦게 뜨지만, 다음 점검까지 22시간 여유가 있어 문제되지 않는다.
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  recover:
+    name: 배민 재크롤 + 결과 확인
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 배민 재크롤
+        env:
+          API_BASE: ${{ vars.API_BASE_URL || 'https://port-0-nklcbdty-service-m6qh1fte0c037b76.sel4.cloudtype.app' }}
+        run: |
+          echo "재크롤 요청"
+          out=$(curl -s -o /dev/null --max-time 300 \
+            -w '%{http_code} %{time_total}' "$API_BASE/api/crawler?company=baemin" || echo "000 0")
+          code=${out%% *}
+          echo "  HTTP $code (${out##* }s)"
+          if [ "$code" != "200" ]; then
+            echo "::error::배민 재크롤 실패 (HTTP $code)"
+            exit 1
+          fi
+
+      - name: 목록에 실제로 올라왔는지 확인
+        env:
+          API_BASE: ${{ vars.API_BASE_URL || 'https://port-0-nklcbdty-service-m6qh1fte0c037b76.sel4.cloudtype.app' }}
+        run: |
+          body=$(curl -s --max-time 120 "$API_BASE/api/list?company=BAEMIN" || echo "")
+          # 건수만 센다. jq 가 없는 러너는 없지만, 응답이 JSON 이 아닐 때도 죽지 않게 || 로 받는다.
+          count=$(printf '%s' "$body" | jq 'length' 2>/dev/null || echo "-1")
+          echo "BAEMIN 공고 $count 건"
+          if [ "$count" = "-1" ]; then
+            echo "::error::목록 응답을 해석할 수 없습니다: $(printf '%s' "$body" | head -c 200)"
+            exit 1
+          fi
+          if [ "$count" -lt 1 ]; then
+            echo "::error::재크롤 후에도 배민 공고가 0건입니다. 크롤 원본(career.woowahan.com) 또는 분류(subJobCdNm)를 확인하세요."
+            exit 1
+          fi


### PR DESCRIPTION
## 문제

배민 공고가 매일 아침 사라진다. 두 번 고쳤는데 **둘 다 운영에 올라가지 못했다.**

| 고친 곳 | 언제 | 상태 |
|---|---|---|
| batch `BaeminLivenessChecker` | 2026-08-04 | 이미지에 있음, 컨테이너에 없음 |
| service `BaeminRecoveryScheduler` (#218) | 2026-08-17 | 이미지에 있음, 컨테이너에 없음 |

도커 이미지는 정상적으로 푸시된다 — service `latest` 가 2026-08-18 09:08Z 에 갱신됐다.
**CloudType 이 그 이미지를 컨테이너에 반영하지 않는다.**

### 판별 근거

`AuthFilter` 는 `AllowedPaths` 에 없는 경로에 401 을 준다. 이걸 이용하면 떠 있는 빌드를 알 수 있다.

```
/api/nonexistent-xyz        → 401       (대조군: 없는 경로는 401)
/api/version                → 401       → AllowedPaths 에 없음 = #219 이전 코드
/api/jobs/999999999/content → 404, 본문 0바이트  = 2026-08-13 빌드는 떠 있음
```

`/api/jobs/**` 는 `AllowedPaths` 에 있어 필터를 통과한다. 거기서 **본문 없는 404** 가 오는 건
`JobContentController` 의 `ResponseEntity.notFound()` 다 — 매핑이 없으면 스프링의 JSON 404 가 온다.
즉 컨테이너는 8/13~8/14 어딘가에서 멈췄고, 그 뒤 머지 두 건이 반영되지 않았다.

## 수정

앱 안에서 되살리는 건 배포가 정상화될 때까지 통하지 않으므로 **밖에서** 한다.
Actions 는 정상 동작하고, `/api/crawler` 는 옛 빌드에도 있으니 컨테이너가 낡아 있어도 된다.
`cache-warmup.yml` 이 이미 같은 방식(외부에서 HTTP 로 앱을 때린다)을 쓰고 있고, 그 주석에
"앱 안의 `@Scheduled` 로 하지 않는 이유" 가 적혀 있다 — 같은 논리다.

- KST 09:00 (UTC 00:00) 에 `/api/crawler?company=baemin` 호출
  링크 점검(07:30~08:21)과 메일(08:23)이 끝난 뒤여야 한다
- 이어서 `/api/list?company=BAEMIN` 건수를 확인하고 **0건이면 실패로 알린다.**
  조용히 성공하면 지금까지처럼 며칠 뒤에야 알게 된다

## 검증

머지 후 `workflow_dispatch` 로 즉시 실행해 확인한다.
크롤 경로 자체는 운영에서 여러 번 확인했다 — 0건 → 9건, 소요 2~3초.

## 이건 우회다

배포가 정상화되면 #218 의 스케줄러와 중복이 되므로 이 워크플로를 지우면 된다.
근본 원인(CloudType 이 새 이미지를 안 가져감)은 콘솔에서 확인해야 하고, batch 는 여전히
2026-05-25 이전 코드로 돌고 있어 그 안의 8/3 메일 중복 fix 와 8/4 배민 fix 도 배포되지 못한 상태다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated daily process to refresh Baemin listings.
  * Added a manual option to trigger listing refreshes on demand.
  * Added validation to detect failed requests, invalid responses, or missing listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->