### PR TITLE
✨ Feat: 캘린더에 상시채용공고 저장 + 완료 버튼

### DIFF
--- a/src/main/java/com/nklcbdty/api/mycalendar/config/MyCalendarSchemaInitializer.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/config/MyCalendarSchemaInitializer.java
@@ -32,12 +32,26 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
     private static final Map<String, String> ENTRY_COLUMNS = new LinkedHashMap<>();
     static {
         ENTRY_COLUMNS.put("user_id", "VARCHAR(255) NOT NULL DEFAULT ''");
-        ENTRY_COLUMNS.put("apply_date", "DATE NOT NULL DEFAULT '2000-01-01'");
+        // 상시채용은 마감일이 없어 NULL 로 저장한다. 처음엔 NOT NULL 이었으므로 아래에서 풀어 준다.
+        ENTRY_COLUMNS.put("apply_date", "DATE NULL");
         ENTRY_COLUMNS.put("company_name", "VARCHAR(100) NOT NULL DEFAULT ''");
         ENTRY_COLUMNS.put("url", "VARCHAR(1000) NULL");
         ENTRY_COLUMNS.put("memo", "VARCHAR(2000) NULL");
+        ENTRY_COLUMNS.put("completed", "TINYINT(1) NOT NULL DEFAULT 0");
+        ENTRY_COLUMNS.put("completed_dts", "DATETIME NULL");
         ENTRY_COLUMNS.put("insert_dts", "DATETIME NULL");
         ENTRY_COLUMNS.put("update_dts", "DATETIME NULL");
+    }
+
+    /**
+     * 이미 있는 테이블에서 NOT NULL 을 풀어야 하는 컬럼. ADD COLUMN IF NOT EXISTS 는 이미 있는
+     * 컬럼을 손대지 않으므로, 상시채용을 쓰려면 apply_date 를 따로 MODIFY 해야 한다.
+     *
+     * <p>MODIFY 는 IF NOT EXISTS 같은 게 없지만 같은 정의로 여러 번 실행해도 결과가 같다.</p>
+     */
+    private static final Map<String, String> RELAXED_COLUMNS = new LinkedHashMap<>();
+    static {
+        RELAXED_COLUMNS.put("apply_date", "DATE NULL");
     }
 
     private final JdbcTemplate jdbcTemplate;
@@ -52,10 +66,13 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
             "CREATE TABLE IF NOT EXISTS my_calendar_entry (" +
             "  id BIGINT NOT NULL AUTO_INCREMENT," +
             "  user_id VARCHAR(255) NOT NULL," +
-            "  apply_date DATE NOT NULL," +
+            // NULL 이면 상시채용(마감일 없음). 달력 칸이 아니라 상시채용 목록에 뜬다.
+            "  apply_date DATE NULL," +
             "  company_name VARCHAR(100) NOT NULL," +
             "  url VARCHAR(1000) NULL," +
             "  memo VARCHAR(2000) NULL," +
+            "  completed TINYINT(1) NOT NULL DEFAULT 0," +
+            "  completed_dts DATETIME NULL," +
             "  insert_dts DATETIME NULL," +
             "  update_dts DATETIME NULL," +
             "  PRIMARY KEY (id)," +
@@ -74,6 +91,9 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
         // MariaDB 10.0+ 의 ADD COLUMN IF NOT EXISTS 라 여러 번 기동해도 안전하다.
         ENTRY_COLUMNS.forEach(this::addColumnIfMissing);
 
+        // 상시채용을 쓰기 전에 만들어진 테이블은 apply_date 가 NOT NULL 이다. 컬럼 추가로는 안 풀린다.
+        RELAXED_COLUMNS.forEach(this::relaxNotNull);
+
         verifySchema();
     }
 
@@ -84,6 +104,35 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
         } catch (Exception e) {
             log.error("[MyCalendar] my_calendar_entry.{} 컬럼 추가 실패: {}", column, e.getMessage(), e);
         }
+    }
+
+    /**
+     * NOT NULL 을 풀어 준다. 이미 NULL 을 허용하면 아무것도 하지 않는다 — 매 기동마다 MODIFY 를
+     * 던져도 되지만, 큰 테이블에서 헛되게 락을 잡을 이유가 없다.
+     */
+    private void relaxNotNull(String column, String definition) {
+        try {
+            if (isNullable(column)) {
+                return;
+            }
+            jdbcTemplate.execute(
+                "ALTER TABLE my_calendar_entry MODIFY COLUMN " + column + " " + definition);
+            log.info("[MyCalendar] my_calendar_entry.{} 를 NULL 허용으로 바꿨다 — 상시채용 저장 가능", column);
+        } catch (Exception e) {
+            // 실패하면 상시채용 저장이 500 이 난다. 원인을 바로 알 수 있게 남긴다.
+            log.error("[MyCalendar] my_calendar_entry.{} NOT NULL 해제 실패 — 상시채용(날짜 없는 일정) 저장이"
+                + " 실패한다: {}", column, e.getMessage(), e);
+        }
+    }
+
+    /** 컬럼이 NULL 을 허용하는지. 컬럼이 없으면(=방금 추가됐다) 정의대로 NULL 허용이므로 true. */
+    private boolean isNullable(String column) {
+        final List<String> nullable = jdbcTemplate.queryForList(
+            "SELECT is_nullable FROM information_schema.columns "
+                + "WHERE table_schema = DATABASE() AND table_name = 'my_calendar_entry' "
+                + "  AND column_name = ?",
+            String.class, column);
+        return nullable.isEmpty() || "YES".equalsIgnoreCase(nullable.get(0));
     }
 
     /**

--- a/src/main/java/com/nklcbdty/api/mycalendar/controller/MyCalendarController.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/controller/MyCalendarController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nklcbdty.api.mycalendar.dto.MyCalendarCompleteRequest;
 import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryDto;
 import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryRequest;
 import com.nklcbdty.api.mycalendar.dto.MyCalendarMonthDto;
@@ -33,9 +34,14 @@ import jakarta.servlet.http.HttpServletRequest;
  *   <li>GET    /api/my-calendar/entries?year=&month=  : 그 달에 적어 둔 일정</li>
  *   <li>POST   /api/my-calendar/entries               : 등록</li>
  *   <li>PUT    /api/my-calendar/entries/{entryId}     : 수정</li>
+ *   <li>PUT    /api/my-calendar/entries/{entryId}/complete : 완료 표시(되돌리기 포함)</li>
  *   <li>DELETE /api/my-calendar/entries/{entryId}     : 삭제</li>
  *   <li>GET    /api/my-calendar/company-name?url=     : URL 로 회사명 추측(입력 도우미)</li>
  * </ul>
+ *
+ * <p>완료 표시는 PATCH 가 더 어울리지만 PUT 으로 둔다 — {@code WebConfig} 의 CORS 허용 메서드에
+ * PATCH 가 없어서, PATCH 로 만들면 브라우저 preflight 에서 막힌다. 상태를 그대로 지정하는
+ * 멱등 요청이라 PUT 으로도 의미가 어긋나지 않는다.</p>
  *
  * <p>이 경로는 {@code AllowedPaths} 에 <b>없다</b>. 그래서 {@code AuthFilter} 가 유효한 토큰을
  * 요구하고, 토큰이 없으면 컨트롤러까지 오지도 못한다(401). 사용자 구분은 필터가 넣어 둔
@@ -79,6 +85,20 @@ public class MyCalendarController {
         HttpServletRequest httpRequest
     ) {
         return ResponseEntity.ok(myCalendarService.update(userId(httpRequest), entryId, request));
+    }
+
+    /**
+     * 완료 표시. 상시채용은 마감일이 없어 목록에서 저절로 내려가지 않으므로 손으로 끝냈다고 적는다.
+     * 본문을 비워 보내면 완료로 보고, 되돌릴 때만 {@code {"completed": false}} 를 보낸다.
+     */
+    @PutMapping("/entries/{entryId}/complete")
+    public ResponseEntity<MyCalendarEntryDto> complete(
+        @PathVariable Long entryId,
+        @RequestBody(required = false) MyCalendarCompleteRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        final boolean completed = request == null || !Boolean.FALSE.equals(request.getCompleted());
+        return ResponseEntity.ok(myCalendarService.setCompleted(userId(httpRequest), entryId, completed));
     }
 
     @DeleteMapping("/entries/{entryId}")

--- a/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarCompleteRequest.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarCompleteRequest.java
@@ -1,0 +1,15 @@
+package com.nklcbdty.api.mycalendar.dto;
+
+import lombok.Data;
+
+/**
+ * 완료 표시 요청. {@code completed} 를 그대로 지정하므로 같은 요청을 두 번 보내도 결과가 같다
+ * (토글로 만들면 응답을 놓쳤을 때 완료가 풀린다).
+ *
+ * <p>값을 안 보내면 완료로 본다 — 되돌릴 때만 {@code false} 를 명시하면 된다.</p>
+ */
+@Data
+public class MyCalendarCompleteRequest {
+
+    private Boolean completed;
+}

--- a/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarEntryDto.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarEntryDto.java
@@ -4,22 +4,30 @@ import com.nklcbdty.api.mycalendar.vo.MyCalendarEntry;
 
 import lombok.Getter;
 
-/** 달력 한 칸에 들어가는 내 일정 1건. */
+/** 달력 한 칸(또는 상시채용 목록)에 들어가는 내 일정 1건. */
 @Getter
 public class MyCalendarEntryDto {
 
     private final Long id;
-    /** yyyy-MM-dd */
+    /** yyyy-MM-dd. 상시채용이면 null. */
     private final String applyDate;
+    /** 마감일이 없는 상시채용인지. {@code applyDate} 가 없다는 뜻이라 따로 저장하지 않고 여기서 만든다. */
+    private final boolean ongoing;
     private final String companyName;
     private final String url;
     private final String memo;
+    private final boolean completed;
+    /** 완료로 표시한 시각. 완료가 아니면 null. */
+    private final String completedAt;
 
     public MyCalendarEntryDto(MyCalendarEntry entry) {
         this.id = entry.getId();
-        this.applyDate = entry.getApplyDate().toString();
+        this.applyDate = entry.getApplyDate() != null ? entry.getApplyDate().toString() : null;
+        this.ongoing = entry.getApplyDate() == null;
         this.companyName = entry.getCompanyName();
         this.url = entry.getUrl();
         this.memo = entry.getMemo();
+        this.completed = entry.isCompleted();
+        this.completedAt = entry.getCompletedDts() != null ? entry.getCompletedDts().toString() : null;
     }
 }

--- a/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarEntryRequest.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarEntryRequest.java
@@ -5,14 +5,22 @@ import lombok.Data;
 /**
  * 일정 등록·수정 요청.
  *
- * <p>필수는 {@code applyDate}(어느 칸인지)와 {@code companyName} 뿐이다.
- * URL·메모는 나중에 채워 넣을 수 있게 비워 둘 수 있다.</p>
+ * <p>필수는 {@code companyName} 뿐이다. URL·메모는 나중에 채워 넣을 수 있게 비워 둘 수 있고,
+ * {@code ongoing} 이 참이면 날짜도 필요 없다(상시채용).</p>
+ *
+ * <p>완료 여부는 여기에 없다 — 전용 API({@code PUT /entries/{id}/complete}) 로만 바꾼다.</p>
  */
 @Data
 public class MyCalendarEntryRequest {
 
-    /** yyyy-MM-dd */
+    /** yyyy-MM-dd. {@code ongoing} 이 참이면 무시한다. */
     private String applyDate;
+
+    /**
+     * 상시채용인지. 마감일이 없는 공고라 달력 칸에 찍지 않고 상시채용 목록에 담는다.
+     * 예전 프론트가 안 보낼 수 있어 {@code Boolean} 으로 받고, 없으면 거짓으로 본다.
+     */
+    private Boolean ongoing;
 
     private String companyName;
 

--- a/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarMonthDto.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/dto/MyCalendarMonthDto.java
@@ -11,6 +11,10 @@ import lombok.Getter;
  *
  * <p>달의 칸 배치를 {@code firstDayOfWeek}/{@code lengthOfMonth} 로 프론트가 계산하는 것까지
  * 공개 채용 캘린더({@code CalendarMonthDto})와 같다.</p>
+ *
+ * <p>{@code ongoingEntries} 는 마감일이 없는 상시채용이라 <b>어느 달을 조회해도 같다</b>.
+ * 달마다 다시 내려주는 게 중복 같아 보이지만, 달을 넘길 때 상시채용 목록이 사라지지 않아야 하고
+ * 프론트가 요청을 하나만 보내면 되므로 이쪽이 낫다.</p>
  */
 @Getter
 public class MyCalendarMonthDto {
@@ -21,11 +25,15 @@ public class MyCalendarMonthDto {
     private final int firstDayOfWeek;
     /** 그 달의 일수 */
     private final int lengthOfMonth;
-    /** 이 달에 적어 둔 일정 총 건수 */
+    /** 이 달에 적어 둔 일정 총 건수. 상시채용은 특정 달의 것이 아니라 여기에 넣지 않는다. */
     private final int totalCount;
     private final List<MyCalendarDayDto> days;
+    /** 날짜 없이 적어 둔 상시채용. 아직 완료하지 않은 것이 먼저 온다. */
+    private final List<MyCalendarEntryDto> ongoingEntries;
+    private final int ongoingCount;
 
-    public MyCalendarMonthDto(YearMonth yearMonth, int totalCount, List<MyCalendarDayDto> days) {
+    public MyCalendarMonthDto(YearMonth yearMonth, int totalCount, List<MyCalendarDayDto> days,
+                              List<MyCalendarEntryDto> ongoingEntries) {
         this.year = yearMonth.getYear();
         this.month = yearMonth.getMonthValue();
         final LocalDate firstDay = yearMonth.atDay(1);
@@ -33,5 +41,7 @@ public class MyCalendarMonthDto {
         this.lengthOfMonth = yearMonth.lengthOfMonth();
         this.totalCount = totalCount;
         this.days = days;
+        this.ongoingEntries = ongoingEntries;
+        this.ongoingCount = ongoingEntries.size();
     }
 }

--- a/src/main/java/com/nklcbdty/api/mycalendar/repository/MyCalendarEntryRepository.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/repository/MyCalendarEntryRepository.java
@@ -10,9 +10,20 @@ import com.nklcbdty.api.mycalendar.vo.MyCalendarEntry;
 
 public interface MyCalendarEntryRepository extends JpaRepository<MyCalendarEntry, Long> {
 
-    /** 그 달에 적어 둔 내 일정. 날짜 오름차순, 같은 날은 등록순. */
+    /**
+     * 그 달에 적어 둔 내 일정. 날짜 오름차순, 같은 날은 등록순.
+     *
+     * <p>{@code BETWEEN} 은 {@code NULL} 에 걸리지 않으므로 상시채용(날짜 없음)은 여기서 빠진다.
+     * 상시채용은 {@link #findByUserIdAndApplyDateIsNullOrderByCompletedAscIdAsc} 로 따로 읽는다.</p>
+     */
     List<MyCalendarEntry> findByUserIdAndApplyDateBetweenOrderByApplyDateAscIdAsc(
         String userId, LocalDate from, LocalDate to);
+
+    /**
+     * 마감일이 없는 상시채용. 아직 안 끝낸 것이 위로 오고(completed=false 가 먼저), 그 안에서는 등록순이다 —
+     * 달을 넘겨도 같은 목록이 계속 보이므로 끝낸 것이 위에 쌓이면 눈에 거슬린다.
+     */
+    List<MyCalendarEntry> findByUserIdAndApplyDateIsNullOrderByCompletedAscIdAsc(String userId);
 
     /**
      * 수정·삭제 전 소유자 확인용. id 만으로 찾으면 남의 일정을 건드릴 수 있어

--- a/src/main/java/com/nklcbdty/api/mycalendar/service/MyCalendarService.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/service/MyCalendarService.java
@@ -93,9 +93,15 @@ public class MyCalendarService {
     @Transactional
     public MyCalendarEntryDto setCompleted(String userId, Long entryId, boolean completed) {
         final MyCalendarEntry entry = mine(userId, entryId);
+        if (!completed) {
+            // 되돌리면 시각도 지운다. 남겨 두면 "완료 아님 + 완료 시각 있음" 이라는 앞뒤 안 맞는 값이 된다.
+            entry.setCompletedDts(null);
+        } else if (!entry.isCompleted() || entry.getCompletedDts() == null) {
+            // 이미 완료였으면 처음 끝낸 시각을 그대로 둔다 — 두 번 눌렀다고 "언제 지원했나" 가
+            // 오늘로 밀려나면 안 된다. 시각이 비어 있는 옛 데이터만 지금으로 채운다.
+            entry.setCompletedDts(LocalDateTime.now());
+        }
         entry.setCompleted(completed);
-        // 되돌리면 시각도 지운다. 남겨 두면 "완료 아님 + 완료 시각 있음" 이라는 앞뒤 안 맞는 값이 된다.
-        entry.setCompletedDts(completed ? LocalDateTime.now() : null);
         return new MyCalendarEntryDto(entryRepository.save(entry));
     }
 

--- a/src/main/java/com/nklcbdty/api/mycalendar/service/MyCalendarService.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/service/MyCalendarService.java
@@ -1,6 +1,7 @@
 package com.nklcbdty.api.mycalendar.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -22,6 +23,10 @@ import com.nklcbdty.api.mycalendar.vo.MyCalendarEntry;
 /**
  * 나의 채용 캘린더. 내가 지원할 회사를 달력에 적어 두는 개인 메모다.
  *
+ * <p>일정은 두 종류다. 마감일이 있는 일정은 그 날짜 칸에 찍히고, 마감일이 없는 상시채용은
+ * {@code applyDate} 를 비운 채로 저장해 달력 아래 목록에 모인다. 상시채용은 저절로 사라지지
+ * 않으므로 완료 표시({@link #setCompleted})로 끝냈다고 적을 수 있다.</p>
+ *
  * <p>모든 메서드가 {@code userId} 를 첫 인자로 받고 저장소 조회에도 반드시 함께 건다.
  * 이 API 는 캐싱하지 않는다 — 사람마다 다른 데이터라 캐시가 섞이면 남의 일정이 보인다.</p>
  */
@@ -39,7 +44,10 @@ public class MyCalendarService {
         this.entryRepository = entryRepository;
     }
 
-    /** 그 달에 적어 둔 내 일정을 날짜별로 모아 준다. */
+    /**
+     * 그 달에 적어 둔 내 일정을 날짜별로 모아 준다. 상시채용은 특정 달에 속하지 않으므로
+     * 어느 달을 조회하든 같은 목록을 함께 담아 준다.
+     */
     @Transactional(readOnly = true)
     public MyCalendarMonthDto getMonth(String userId, YearMonth yearMonth) {
         final List<MyCalendarEntry> entries =
@@ -58,7 +66,7 @@ public class MyCalendarService {
             days.add(new MyCalendarDayDto(day.getKey(), day.getValue()));
         }
 
-        return new MyCalendarMonthDto(yearMonth, entries.size(), days);
+        return new MyCalendarMonthDto(yearMonth, entries.size(), days, ongoingEntries(userId));
     }
 
     @Transactional
@@ -76,6 +84,21 @@ public class MyCalendarService {
         return new MyCalendarEntryDto(entryRepository.save(entry));
     }
 
+    /**
+     * 완료 표시를 켜고 끈다. 이미 같은 상태여도 그대로 성공시킨다 — 달력 칸과 상시채용 목록
+     * 두 곳에서 같은 일정을 누를 수 있어 두 번 눌리는 일이 실제로 생긴다.
+     *
+     * @param completed {@code false} 면 완료를 되돌린다(잘못 눌렀을 때 필요하다).
+     */
+    @Transactional
+    public MyCalendarEntryDto setCompleted(String userId, Long entryId, boolean completed) {
+        final MyCalendarEntry entry = mine(userId, entryId);
+        entry.setCompleted(completed);
+        // 되돌리면 시각도 지운다. 남겨 두면 "완료 아님 + 완료 시각 있음" 이라는 앞뒤 안 맞는 값이 된다.
+        entry.setCompletedDts(completed ? LocalDateTime.now() : null);
+        return new MyCalendarEntryDto(entryRepository.save(entry));
+    }
+
     @Transactional
     public void delete(String userId, Long entryId) {
         entryRepository.delete(mine(userId, entryId));
@@ -86,25 +109,51 @@ public class MyCalendarService {
         return CompanyNameGuesser.guess(url);
     }
 
+    /** 날짜 없이 적어 둔 상시채용. 정렬(안 끝낸 것 먼저, 그 안에서 등록순)은 저장소 쿼리가 맡는다. */
+    private List<MyCalendarEntryDto> ongoingEntries(String userId) {
+        final List<MyCalendarEntryDto> ongoing = new ArrayList<>();
+        for (MyCalendarEntry entry
+                : entryRepository.findByUserIdAndApplyDateIsNullOrderByCompletedAscIdAsc(userId)) {
+            ongoing.add(new MyCalendarEntryDto(entry));
+        }
+        return ongoing;
+    }
+
     private MyCalendarEntry mine(String userId, Long entryId) {
         return entryRepository.findByIdAndUserId(entryId, userId)
                               .orElseThrow(MyCalendarNotFoundException::new);
     }
 
-    /** 요청값을 검증해서 엔티티에 옮긴다. 등록·수정이 같은 규칙을 쓰도록 한 곳에 모았다. */
+    /**
+     * 요청값을 검증해서 엔티티에 옮긴다. 등록·수정이 같은 규칙을 쓰도록 한 곳에 모았다.
+     *
+     * <p>완료 여부는 일부러 건드리지 않는다 — 폼이 그 값을 들고 다니지 않아도 메모만 고쳤을 때
+     * 완료가 풀리지 않아야 한다. 완료는 {@link #setCompleted} 만 바꾼다.</p>
+     */
     private void apply(MyCalendarEntry entry, MyCalendarEntryRequest request) {
         if (request == null) {
             throw new IllegalArgumentException("요청 내용이 비어 있습니다.");
         }
-        entry.setApplyDate(parseDate(request.getApplyDate()));
+        entry.setApplyDate(resolveApplyDate(request));
         entry.setCompanyName(requireCompanyName(request.getCompanyName()));
         entry.setUrl(normalizeUrl(request.getUrl()));
         entry.setMemo(trimToNull(request.getMemo(), MAX_MEMO_LENGTH, "메모"));
     }
 
+    /**
+     * 상시채용이면 날짜를 비운다. 날짜 입력을 지우지 않고 상시채용으로 바꾸는 일이 흔하므로
+     * 같이 온 날짜는 오류로 보지 않고 그냥 버린다.
+     */
+    private LocalDate resolveApplyDate(MyCalendarEntryRequest request) {
+        if (Boolean.TRUE.equals(request.getOngoing())) {
+            return null;
+        }
+        return parseDate(request.getApplyDate());
+    }
+
     private LocalDate parseDate(String applyDate) {
         if (isBlank(applyDate)) {
-            throw new IllegalArgumentException("날짜를 선택해 주세요.");
+            throw new IllegalArgumentException("날짜를 선택하거나 상시채용으로 저장해 주세요.");
         }
         try {
             return LocalDate.parse(applyDate.trim());

--- a/src/main/java/com/nklcbdty/api/mycalendar/vo/MyCalendarEntry.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/vo/MyCalendarEntry.java
@@ -36,8 +36,14 @@ public class MyCalendarEntry {
     @Column(nullable = false)
     private String userId;
 
-    /** 달력에서 이 일정이 찍히는 날 */
-    @Column(nullable = false)
+    /**
+     * 달력에서 이 일정이 찍히는 날. <b>{@code null} 이면 상시채용</b>이다 — 마감일이 없어 어느 칸에도
+     * 못 찍으므로 달력 아래 상시채용 목록에 따로 모아 보여준다.
+     *
+     * <p>마감일 대신 {@code 2000-01-01} 같은 표식을 넣지 않는다. {@code job_mst.end_date} 가 그렇게
+     * 쓰이는데, 실제 날짜와 구분이 안 돼서 공고가 사라진 원인을 찾는 데 한참 걸렸다.</p>
+     */
+    @Column(nullable = true)
     private LocalDate applyDate;
 
     /** 유일한 필수 입력값 */
@@ -50,6 +56,20 @@ public class MyCalendarEntry {
 
     @Column(nullable = true, length = 2000)
     private String memo;
+
+    /**
+     * 지원을 마쳤는지. 상시채용은 마감일이 없어 언제까지고 목록에 남으므로, 손으로 끝냈다고
+     * 표시할 수 있어야 한다. 날짜가 있는 일정에도 같이 쓴다.
+     *
+     * <p>등록·수정({@code apply})은 이 값을 건드리지 않는다. 완료 표시는 전용 API 만 바꾼다 —
+     * 그러지 않으면 완료한 일정의 메모만 고쳐도 완료가 풀린다.</p>
+     */
+    @Column(nullable = false)
+    private boolean completed;
+
+    /** 완료로 표시한 시각. 완료를 되돌리면 다시 {@code null} 이 된다. */
+    @Column(nullable = true)
+    private LocalDateTime completedDts;
 
     @CreationTimestamp
     private LocalDateTime insertDts;

--- a/src/test/java/com/nklcbdty/api/mycalendar/controller/MyCalendarControllerTest.java
+++ b/src/test/java/com/nklcbdty/api/mycalendar/controller/MyCalendarControllerTest.java
@@ -1,0 +1,153 @@
+package com.nklcbdty.api.mycalendar.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryDto;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarEntryRequest;
+import com.nklcbdty.api.mycalendar.dto.MyCalendarMonthDto;
+import com.nklcbdty.api.mycalendar.service.MyCalendarService;
+import com.nklcbdty.api.mycalendar.vo.MyCalendarEntry;
+
+/**
+ * 프론트가 의지하는 경로·JSON 모양을 고정한다. 특히 완료 표시는 PUT 이어야 한다 —
+ * PATCH 로 바꾸면 CORS 허용 메서드에 없어 브라우저에서만 조용히 막힌다.
+ */
+class MyCalendarControllerTest {
+
+    private static final String ME = "local@me";
+
+    private MyCalendarService myCalendarService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        myCalendarService = mock(MyCalendarService.class);
+        mockMvc = standaloneSetup(new MyCalendarController(myCalendarService)).build();
+    }
+
+    private static MyCalendarEntry entry(Long id, LocalDate applyDate, String company) {
+        MyCalendarEntry entry = new MyCalendarEntry();
+        entry.setId(id);
+        entry.setUserId(ME);
+        entry.setApplyDate(applyDate);
+        entry.setCompanyName(company);
+        return entry;
+    }
+
+    @Test
+    @DisplayName("GET /entries: 상시채용은 ongoingEntries 로, applyDate 는 null 로 내려간다")
+    void entries_returnsOngoingSeparately() throws Exception {
+        MyCalendarMonthDto month = new MyCalendarMonthDto(
+            YearMonth.of(2026, 9), 0, List.of(),
+            List.of(new MyCalendarEntryDto(entry(2L, null, "네이버"))));
+        when(myCalendarService.getMonth(eq(ME), eq(YearMonth.of(2026, 9)))).thenReturn(month);
+
+        mockMvc.perform(get("/api/my-calendar/entries?year=2026&month=9").requestAttr("userId", ME))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.ongoingCount").value(1))
+            .andExpect(jsonPath("$.ongoingEntries[0].companyName").value("네이버"))
+            .andExpect(jsonPath("$.ongoingEntries[0].ongoing").value(true))
+            .andExpect(jsonPath("$.ongoingEntries[0].applyDate").isEmpty())
+            .andExpect(jsonPath("$.ongoingEntries[0].completed").value(false));
+    }
+
+    @Test
+    @DisplayName("POST /entries: ongoing 을 그대로 서비스에 넘긴다")
+    void create_passesOngoingThrough() throws Exception {
+        when(myCalendarService.create(eq(ME), any()))
+            .thenReturn(new MyCalendarEntryDto(entry(1L, null, "카카오")));
+
+        mockMvc.perform(post("/api/my-calendar/entries")
+                .requestAttr("userId", ME)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"ongoing\":true,\"companyName\":\"카카오\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.ongoing").value(true));
+
+        ArgumentCaptor<MyCalendarEntryRequest> sent =
+            ArgumentCaptor.forClass(MyCalendarEntryRequest.class);
+        verify(myCalendarService).create(eq(ME), sent.capture());
+        assertThat(sent.getValue().getOngoing()).isTrue();
+    }
+
+    @Test
+    @DisplayName("PUT /entries/{id}/complete: 완료로 표시한다")
+    void complete_marksDone() throws Exception {
+        MyCalendarEntry done = entry(7L, null, "카카오");
+        done.setCompleted(true);
+        when(myCalendarService.setCompleted(ME, 7L, true)).thenReturn(new MyCalendarEntryDto(done));
+
+        mockMvc.perform(put("/api/my-calendar/entries/7/complete")
+                .requestAttr("userId", ME)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"completed\":true}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.completed").value(true));
+
+        verify(myCalendarService).setCompleted(ME, 7L, true);
+    }
+
+    @Test
+    @DisplayName("PUT /entries/{id}/complete: completed=false 면 완료를 되돌린다")
+    void complete_canBeUndone() throws Exception {
+        when(myCalendarService.setCompleted(ME, 7L, false))
+            .thenReturn(new MyCalendarEntryDto(entry(7L, null, "카카오")));
+
+        mockMvc.perform(put("/api/my-calendar/entries/7/complete")
+                .requestAttr("userId", ME)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"completed\":false}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.completed").value(false));
+
+        verify(myCalendarService).setCompleted(ME, 7L, false);
+    }
+
+    @Test
+    @DisplayName("PUT /entries/{id}/complete: 본문 없이 부르면 완료로 본다")
+    void complete_defaultsToDone() throws Exception {
+        MyCalendarEntry done = entry(7L, null, "카카오");
+        done.setCompleted(true);
+        when(myCalendarService.setCompleted(ME, 7L, true)).thenReturn(new MyCalendarEntryDto(done));
+
+        mockMvc.perform(put("/api/my-calendar/entries/7/complete").requestAttr("userId", ME))
+            .andExpect(status().isOk());
+
+        verify(myCalendarService).setCompleted(ME, 7L, true);
+    }
+
+    @Test
+    @DisplayName("로그인 사용자를 알 수 없으면 완료 표시도 401 — 남의 일정을 건드리면 안 된다")
+    void complete_requiresLogin() throws Exception {
+        mockMvc.perform(put("/api/my-calendar/entries/7/complete")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"completed\":true}"))
+            .andExpect(status().isUnauthorized());
+
+        verify(myCalendarService, never()).setCompleted(any(), any(), anyBoolean());
+    }
+}

--- a/src/test/java/com/nklcbdty/api/mycalendar/service/MyCalendarServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/mycalendar/service/MyCalendarServiceTest.java
@@ -301,16 +301,34 @@ class MyCalendarServiceTest {
     }
 
     @Test
-    @DisplayName("같은 완료 요청을 두 번 보내도 결과가 같다 — 두 곳에서 눌릴 수 있다")
+    @DisplayName("같은 완료 요청을 두 번 보내도 결과가 같다 — 완료 시각도 그대로다")
     void completingTwiceIsHarmless() {
         MyCalendarEntry mine = entry(7L, ME, null, "카카오");
         when(entryRepository.findByIdAndUserId(7L, ME)).thenReturn(Optional.of(mine));
         when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
 
-        service.setCompleted(ME, 7L, true);
+        MyCalendarEntryDto first = service.setCompleted(ME, 7L, true);
         MyCalendarEntryDto again = service.setCompleted(ME, 7L, true);
 
         assertThat(again.isCompleted()).isTrue();
+        // 두 번 눌렀다고 "언제 지원했나" 가 지금으로 밀려나면 안 된다.
+        assertThat(again.getCompletedAt()).isEqualTo(first.getCompletedAt());
+    }
+
+    @Test
+    @DisplayName("완료를 되돌린 뒤 다시 완료하면 시각은 새로 찍힌다 — 다시 지원한 것이다")
+    void recompletingAfterUndoStampsAgain() {
+        MyCalendarEntry mine = entry(7L, ME, null, "카카오");
+        mine.setCompleted(true);
+        mine.setCompletedDts(LocalDateTime.of(2026, 8, 20, 10, 0));
+        when(entryRepository.findByIdAndUserId(7L, ME)).thenReturn(Optional.of(mine));
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        service.setCompleted(ME, 7L, false);
+        MyCalendarEntryDto redone = service.setCompleted(ME, 7L, true);
+
+        assertThat(redone.getCompletedAt()).isNotNull()
+                                           .isNotEqualTo("2026-08-20T10:00");
     }
 
     @Test

--- a/src/test/java/com/nklcbdty/api/mycalendar/service/MyCalendarServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/mycalendar/service/MyCalendarServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
@@ -47,6 +48,13 @@ class MyCalendarServiceTest {
         request.setCompanyName(company);
         request.setUrl(url);
         request.setMemo(memo);
+        return request;
+    }
+
+    /** 마감일 없는 상시채용 등록 요청. 날짜를 같이 넘겨 "그래도 버리는지" 를 볼 수 있게 해 둔다. */
+    private static MyCalendarEntryRequest ongoingRequest(String date, String company) {
+        MyCalendarEntryRequest request = request(date, company, null, null);
+        request.setOngoing(true);
         return request;
     }
 
@@ -99,10 +107,12 @@ class MyCalendarServiceTest {
     }
 
     @Test
-    @DisplayName("날짜가 없거나 형식이 틀리면 400")
+    @DisplayName("상시채용이 아닌데 날짜가 없거나 형식이 틀리면 400")
     void applyDateMustBeValid() {
         assertThatThrownBy(() -> service.create(ME, request(null, "카카오", null, null)))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(IllegalArgumentException.class)
+            // 날짜를 비우는 방법(상시채용)을 알려 줘야 사용자가 막히지 않는다.
+            .hasMessageContaining("상시채용");
         assertThatThrownBy(() -> service.create(ME, request("2026/09/01", "카카오", null, null)))
             .isInstanceOf(IllegalArgumentException.class);
 
@@ -201,5 +211,131 @@ class MyCalendarServiceTest {
 
         verify(entryRepository).findByIdAndUserId(7L, ME);
         verify(entryRepository, never()).findById(anyLong());
+    }
+
+    // --------------------------------------------------------------------- 상시채용
+
+    @Test
+    @DisplayName("상시채용은 날짜 없이 저장된다")
+    void ongoingEntryIsSavedWithoutDate() {
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        MyCalendarEntryDto created = service.create(ME, ongoingRequest(null, "카카오"));
+
+        assertThat(created.isOngoing()).isTrue();
+        assertThat(created.getApplyDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("상시채용으로 저장하면 함께 온 날짜는 버린다 — 표식 날짜를 남기지 않는다")
+    void ongoingEntryDropsTheDate() {
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        service.create(ME, ongoingRequest("2026-09-01", "카카오"));
+
+        ArgumentCaptor<MyCalendarEntry> saved = ArgumentCaptor.forClass(MyCalendarEntry.class);
+        verify(entryRepository).save(saved.capture());
+        assertThat(saved.getValue().getApplyDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("날짜 있는 일정을 상시채용으로 바꿀 수 있다")
+    void updateCanTurnADatedEntryIntoOngoing() {
+        MyCalendarEntry mine = entry(7L, ME, LocalDate.of(2026, 9, 1), "카카오");
+        when(entryRepository.findByIdAndUserId(7L, ME)).thenReturn(Optional.of(mine));
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        MyCalendarEntryDto updated = service.update(ME, 7L, ongoingRequest("2026-09-01", "카카오"));
+
+        assertThat(updated.isOngoing()).isTrue();
+        assertThat(updated.getApplyDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("상시채용은 어느 달을 조회해도 함께 온다 — 특정 달의 일정이 아니다")
+    void ongoingEntriesComeWithEveryMonth() {
+        when(entryRepository.findByUserIdAndApplyDateBetweenOrderByApplyDateAscIdAsc(
+            ME, LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 30)))
+            .thenReturn(List.of(entry(1L, ME, LocalDate.of(2026, 9, 3), "카카오")));
+        when(entryRepository.findByUserIdAndApplyDateIsNullOrderByCompletedAscIdAsc(ME))
+            .thenReturn(List.of(entry(2L, ME, null, "네이버"), entry(3L, ME, null, "토스")));
+
+        MyCalendarMonthDto month = service.getMonth(ME, YearMonth.of(2026, 9));
+
+        assertThat(month.getOngoingCount()).isEqualTo(2);
+        assertThat(month.getOngoingEntries()).extracting(MyCalendarEntryDto::getCompanyName)
+                                             .containsExactly("네이버", "토스");
+        // 상시채용은 그 달의 일정 건수에 섞이지 않는다 — "9월에 적어 둔 일정 N건" 이 틀리면 안 된다.
+        assertThat(month.getTotalCount()).isEqualTo(1);
+        assertThat(month.getDays()).hasSize(1);
+    }
+
+    // ------------------------------------------------------------------- 완료 표시
+
+    @Test
+    @DisplayName("완료로 표시하면 완료 시각이 남는다")
+    void completingStampsTheTime() {
+        when(entryRepository.findByIdAndUserId(7L, ME))
+            .thenReturn(Optional.of(entry(7L, ME, null, "카카오")));
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        MyCalendarEntryDto completed = service.setCompleted(ME, 7L, true);
+
+        assertThat(completed.isCompleted()).isTrue();
+        assertThat(completed.getCompletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("완료를 되돌리면 완료 시각도 지운다 — 앞뒤 안 맞는 값을 남기지 않는다")
+    void uncompletingClearsTheTime() {
+        MyCalendarEntry mine = entry(7L, ME, null, "카카오");
+        mine.setCompleted(true);
+        mine.setCompletedDts(LocalDateTime.of(2026, 8, 20, 10, 0));
+        when(entryRepository.findByIdAndUserId(7L, ME)).thenReturn(Optional.of(mine));
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        MyCalendarEntryDto reopened = service.setCompleted(ME, 7L, false);
+
+        assertThat(reopened.isCompleted()).isFalse();
+        assertThat(reopened.getCompletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("같은 완료 요청을 두 번 보내도 결과가 같다 — 두 곳에서 눌릴 수 있다")
+    void completingTwiceIsHarmless() {
+        MyCalendarEntry mine = entry(7L, ME, null, "카카오");
+        when(entryRepository.findByIdAndUserId(7L, ME)).thenReturn(Optional.of(mine));
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        service.setCompleted(ME, 7L, true);
+        MyCalendarEntryDto again = service.setCompleted(ME, 7L, true);
+
+        assertThat(again.isCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("일정을 수정해도 완료 표시는 풀리지 않는다")
+    void updateKeepsTheCompletedFlag() {
+        MyCalendarEntry mine = entry(7L, ME, null, "카카오");
+        mine.setCompleted(true);
+        mine.setCompletedDts(LocalDateTime.of(2026, 8, 20, 10, 0));
+        when(entryRepository.findByIdAndUserId(7L, ME)).thenReturn(Optional.of(mine));
+        when(entryRepository.save(any())).thenAnswer(call -> call.getArgument(0));
+
+        MyCalendarEntryDto updated = service.update(ME, 7L, ongoingRequest(null, "카카오"));
+
+        assertThat(updated.isCompleted()).isTrue();
+        assertThat(updated.getCompletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("남의 일정은 완료로 표시할 수 없다")
+    void completeOnlyTouchesMyOwnEntry() {
+        when(entryRepository.findByIdAndUserId(7L, SOMEONE_ELSE)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.setCompleted(SOMEONE_ELSE, 7L, true))
+            .isInstanceOf(MyCalendarNotFoundException.class);
+
+        verify(entryRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## 왜

마감일이 없는 상시채용 공고는 달력 칸에 찍을 날짜가 없어서 지금까지 나의 캘린더에 저장할 수 없었다. 그리고 상시채용은 저절로 마감되지 않으니, 목록에서 내리려면 "다 했다" 고 표시할 방법이 있어야 한다.

## 무엇

- `apply_date` 를 비워 저장할 수 있게 하고(=상시채용), 월 응답에 `ongoingEntries` / `ongoingCount` 로 따로 담는다. 어느 달을 조회해도 같은 목록이 온다 — 특정 달의 일정이 아니라서 `totalCount` 엔 섞지 않는다.
- `PUT /api/my-calendar/entries/{id}/complete` — 완료 표시를 켜고 끈다. 켤지 끌지를 그대로 받으므로 같은 요청이 두 번 가도 결과가 같다.
- 등록·수정은 `completed` 를 건드리지 않는다. 그러지 않으면 완료한 일정의 메모만 고쳐도 완료가 풀린다.

## 판단한 것들

- **표식 날짜를 쓰지 않았다.** `2000-01-01` 같은 값을 넣는 방법도 있지만, `job_mst.end_date` 가 그렇게 쓰이는데 실제 날짜와 구분이 안 돼서 공고가 0건이 된 원인을 찾는 데 한참 걸렸다. 같은 함정을 또 파지 않았다.
- **`ongoing` 컬럼을 따로 두지 않았다.** `apply_date IS NULL` 과 뜻이 겹쳐서 두 값이 어긋날 수 있다. 응답 DTO 의 `ongoing` 은 날짜가 없다는 걸 프론트가 읽기 쉽게 만들어 주는 값이다.
- **PATCH 가 아니라 PUT.** `WebConfig` 의 CORS 허용 메서드에 PATCH 가 없어서, PATCH 로 만들면 서버 테스트는 통과하는데 브라우저에서만 preflight 에서 막힌다. 상태를 그대로 지정하는 멱등 요청이라 PUT 으로도 뜻이 어긋나지 않는다.
- **이미 만들어진 테이블의 `apply_date` 는 NOT NULL 이다.** `ADD COLUMN IF NOT EXISTS` 로는 안 풀려서 초기화 코드가 `MODIFY` 로 NULL 허용으로 바꾼다. 이미 풀려 있으면 건너뛰고, 실패하면 상시채용 저장이 500 이 나므로 원인을 알 수 있게 로그를 남긴다.

## 확인

- `MyCalendarServiceTest` 에 상시채용·완료 케이스 추가, `MyCalendarControllerTest` 신규 — 프론트가 의지하는 경로와 JSON 모양(특히 완료가 PUT 인 것)을 고정한다.
- 전체 220개 중 219개 통과. `NklcbdtyApplicationTests.contextLoads` 만 실패하는데, 이 브랜치 변경 전에도 같이 실패한다(로컬에 DB 접속 정보가 없어 `URL must start with 'jdbc'`).
- 프론트를 실제로 빌드해 이 계약대로 응답하는 스텁 서버에 붙여 눌러 봤다: 상시채용 등록(`ongoing:true` 로 POST) → 목록에 뜸, 완료 클릭 → 서버 반영 + 완료 안 한 것이 위로 정렬, 달을 넘겨도 상시채용 목록 유지.

프론트 PR: kingle1024/nklcbdty-ui

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ongoing recruitment entries without application deadlines.
  * Ongoing entries appear across relevant monthly calendar views.
  * Added completion tracking with completion timestamps.
  * Added an API to mark entries complete or reopen them.
* **Improvements**
  * Clarified entry requirements and date validation guidance.
  * Safely displays entries with missing application dates.
  * Completion status can be updated without changing entry details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->