### PR TITLE
✅ Test: 메일 홈페이지 링크 회귀 방지 + CI 에서 테스트 실행

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,11 +26,14 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew  # gradlew에 실행 권한 부여
 
-      - name: Build with Gradle(without tests)
+      # 테스트를 안 돌리던 시절엔 nklcbdty-common 의 수정이 반영 안 된 채(옛 버전 pin)
+      # 배포돼도 아무도 몰랐다. 자격증명이 필요한 @SpringBootTest 는 스스로 skip 되므로
+      # 여기서 도는 건 DB/네트워크 없이 끝나는 단위 테스트뿐이다.
+      - name: Build with Gradle
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew clean bootJar
+        run: ./gradlew clean test bootJar
         working-directory: ./  # 루트 디렉토리로 설정
 
       - name: Log in to Docker Hub

--- a/src/test/java/com/nklcbdty/api/NklcbdtyApplicationTests.java
+++ b/src/test/java/com/nklcbdty/api/NklcbdtyApplicationTests.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -24,6 +25,10 @@ import com.nklcbdty.common.vo.Job_mst;
 
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest
+// 앱 전체 컨텍스트를 띄우는 테스트라 운영 DB/Redis/OAuth 자격증명이 환경변수로 있어야
+// 통과한다. 그게 없는 환경(로컬·CI)에서는 항상 실패해서, 이 한 건 때문에
+// ./gradlew test 를 CI 에 걸지 못하고 있었다. 자격증명이 있을 때만 돌린다.
+@EnabledIfEnvironmentVariable(named = "DATASOURCE_URL", matches = ".+")
 class NklcbdtyApplicationTests {
 
     @Mock

--- a/src/test/java/com/nklcbdty/api/email/service/JobMailHomepageLinkTest.java
+++ b/src/test/java/com/nklcbdty/api/email/service/JobMailHomepageLinkTest.java
@@ -1,0 +1,48 @@
+package com.nklcbdty.api.email.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.nklcbdty.common.dto.JobPosting;
+import com.nklcbdty.common.email.JobEmailContentBuilder;
+
+// 메일 본문의 "더 많은 채용 공고를 보시려면 ..." 안내 링크는 nklcbdty-common 의
+// JobEmailContentBuilder 가 만든다. 예전에 이 링크가 DNS 조차 잡혀 있지 않은
+// nklcb.co.kr 을 가리켰고, common 에서 고친 뒤에도 이 저장소는 옛 버전을 물고
+// 있어서 실제 발송된 메일은 한동안 죽은 링크 그대로였다.
+// 검증 대상이 "빌드가 실제로 해석한 common jar 의 출력" 이므로, 링크가 되돌아가도
+// 의존 버전이 낮은 쪽으로 내려가도 여기서 잡힌다.
+class JobMailHomepageLinkTest {
+
+    private static final String HOMEPAGE_URL = "https://nklcb.netlify.app";
+
+    @Test
+    @DisplayName("메일 본문은 운영 홈페이지(nklcb.netlify.app)로 링크한다")
+    void html_linksToLiveHomepage() {
+        String html = JobEmailContentBuilder.generateHtml("backend", List.of(posting()));
+
+        assertThat(html).contains("href=\"" + HOMEPAGE_URL + "\"");
+    }
+
+    @Test
+    @DisplayName("DNS 가 잡히지 않는 nklcb.co.kr 은 메일 본문에 남아있지 않다")
+    void html_hasNoDeadDomain() {
+        String html = JobEmailContentBuilder.generateHtml("backend", List.of(posting()));
+
+        assertThat(html).doesNotContain("nklcb.co.kr");
+    }
+
+    private JobPosting posting() {
+        JobPosting posting = new JobPosting();
+        posting.setTitle("백엔드 개발자");
+        posting.setCompany("naver");
+        posting.setUrl("https://recruit.navercorp.com/1");
+        posting.setJobType("Backend");
+        posting.setEndDate("2999-12-31 23:59:59");
+        return posting;
+    }
+}


### PR DESCRIPTION
#222 후속. **왜 죽은 링크가 6일이나 그대로 나갔는지**를 막는 변경입니다.

## 원인 두 가지

1. 메일 링크를 검증하는 테스트가 없었다
2. 있었어도 안 돌았다 — CI 가 `./gradlew clean bootJar` 만 실행

## 변경

**`JobMailHomepageLinkTest` 추가**
- 빌드가 실제로 해석한 common jar 의 메일 HTML 을 검사합니다
- `https://nklcb.netlify.app` 로 링크하는지 / `nklcb.co.kr` 이 안 남았는지
- 링크가 되돌아가도, 의존 버전이 낮은 쪽으로 내려가도 잡힙니다 (batch 쪽에서 실제로 옛 커밋 기준으로 돌려보니 바로 실패했습니다)

**`NklcbdtyApplicationTests` 를 조건부 실행으로**
- 운영 DB/Redis/OAuth 자격증명이 환경변수로 있어야만 통과하는 `@SpringBootTest` 라, 자격증명이 없는 환경에서는 100% 실패했습니다
- 이 한 건 때문에 CI 에 `test` 를 걸 수 없었습니다
- `@EnabledIfEnvironmentVariable(named = "DATASOURCE_URL", ...)` 로 자격증명이 있을 때만 실행

**CI: `clean bootJar` → `clean test bootJar`**
- 남는 건 DB·네트워크 없이 끝나는 단위 테스트뿐이라 파이프라인이 느려지지 않습니다

## 확인

- `./gradlew test` → BUILD SUCCESSFUL (204 통과, contextLoads 1건 skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)