### PR TITLE
🐛 Fix: 마이페이지 구독 설정이 비어 보이던 문제 — 같은 이메일 계정 연동

### DIFF
--- a/src/main/java/com/nklcbdty/api/auth/service/LocalAuthService.java
+++ b/src/main/java/com/nklcbdty/api/auth/service/LocalAuthService.java
@@ -1,5 +1,6 @@
 package com.nklcbdty.api.auth.service;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.nklcbdty.api.auth.repository.LocalAccountRepository;
 import com.nklcbdty.api.auth.vo.LocalAccount;
 import com.nklcbdty.api.common.UtilityNklcb;
+import com.nklcbdty.api.user.repository.UserProfileRepository;
 import com.nklcbdty.common.user.repository.UserRepository;
 import com.nklcbdty.common.vo.UserVo;
 
@@ -23,6 +25,10 @@ import lombok.extern.slf4j.Slf4j;
  * 카카오 로그인(KakaoController)과 같은 토큰 체계를 쓴다:
  * userId 로 access/refresh JWT 를 발급하고 user 테이블에 프로필 행을 만든다.
  * 카카오 사용자는 "kakao@{id}", 자체 가입 사용자는 "local@{id}" userId 를 갖는다.
+ *
+ * <p>단, 이미 같은 이메일로 쓰던 계정(예: 카카오 로그인)이 있으면 새 userId 를 만들지 않고
+ * 그 계정에 비밀번호 자격증명만 붙인다. 그래야 구독 설정·캘린더가 로그인 방식에 따라 갈리지 않는다.
+ * (이메일 인증 절차가 없으므로, 남이 내 이메일로 가입해 계정을 이어받는 경로가 열려 있다는 점은 감수한 선택이다.)
  */
 @Slf4j
 @Service
@@ -35,14 +41,17 @@ public class LocalAuthService {
 
     private final LocalAccountRepository localAccountRepository;
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
     private final TokenService tokenService;
     private final UtilityNklcb utilityNklcb;
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     public LocalAuthService(LocalAccountRepository localAccountRepository, UserRepository userRepository,
-                            TokenService tokenService, UtilityNklcb utilityNklcb) {
+                            UserProfileRepository userProfileRepository, TokenService tokenService,
+                            UtilityNklcb utilityNklcb) {
         this.localAccountRepository = localAccountRepository;
         this.userRepository = userRepository;
+        this.userProfileRepository = userProfileRepository;
         this.tokenService = tokenService;
         this.utilityNklcb = utilityNklcb;
     }
@@ -57,6 +66,11 @@ public class LocalAuthService {
 
         if (localAccountRepository.existsByEmail(normalizedEmail)) {
             throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+
+        String linkableUserId = findLinkableUserId(normalizedEmail);
+        if (linkableUserId != null) {
+            return linkToExistingAccount(linkableUserId, normalizedEmail, rawPassword);
         }
 
         LocalAccount account = new LocalAccount();
@@ -106,6 +120,47 @@ public class LocalAuthService {
         String nickname = user != null ? user.getUsername() : localPart(account.getEmail());
 
         return issueTokens(account.getUserId(), nickname);
+    }
+
+    /**
+     * 같은 이메일로 이미 쓰던 계정의 userId. 없으면 null.
+     *
+     * <p>local@ 로 시작하는 userId 는 자체 가입으로 만들어진 것이라 제외한다
+     * (같은 이메일이면 위쪽 existsByEmail 에서 이미 걸리고, 남아 있다면 정리 안 된 옛 데이터다).
+     */
+    private String findLinkableUserId(String email) {
+        List<UserVo> sameEmailUsers = userProfileRepository.findByEmailOrderByIdAsc(email);
+        for (UserVo user : sameEmailUsers) {
+            String userId = user.getUserId();
+            if (userId != null && !userId.startsWith(LocalAccount.USER_ID_PREFIX)) {
+                return userId;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 기존 계정에 이메일+비밀번호 자격증명만 추가한다. 프로필(user 행)은 그대로 두고 새로 만들지 않는다.
+     */
+    private AuthResult linkToExistingAccount(String userId, String normalizedEmail, String rawPassword) {
+        LocalAccount account = new LocalAccount();
+        account.setEmail(normalizedEmail);
+        account.setPasswordHash(passwordEncoder.encode(rawPassword));
+        account.setUserId(userId);
+        try {
+            localAccountRepository.saveAndFlush(account);
+        } catch (DataIntegrityViolationException e) {
+            // 같은 이메일 또는 같은 userId 로 동시에 가입 요청이 들어온 경우(UNIQUE 위반)
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+
+        UserVo user = userRepository.findByUserId(userId);
+        String nickname = user != null && user.getUsername() != null && !user.getUsername().isBlank()
+            ? user.getUsername()
+            : localPart(normalizedEmail);
+
+        log.info("[LocalAuth] 기존 계정에 자체 로그인 연동 userId={}", userId);
+        return issueTokens(userId, nickname);
     }
 
     /** 회원가입 화면의 중복 확인용 */

--- a/src/main/java/com/nklcbdty/api/auth/vo/LocalAccount.java
+++ b/src/main/java/com/nklcbdty/api/auth/vo/LocalAccount.java
@@ -17,13 +17,14 @@ import lombok.Data;
  * 프로필(닉네임/이메일)은 카카오 로그인과 공유하는 user 테이블(UserVo)에 있고,
  * 이 테이블은 로그인 자격증명(이메일, 비밀번호 해시)과 user.user_id 연결만 담당한다.
  * 카카오 사용자의 userId 가 "kakao@{id}" 이듯 자체 가입 사용자는 "local@{id}" 를 쓴다.
+ * 단 같은 이메일의 기존 계정에 연동된 경우에는 그 계정의 userId("kakao@{id}" 등)를 그대로 가리킨다.
  */
 @Entity
 @Table(name = "local_account")
 @Data
 public class LocalAccount {
 
-    /** userId 접두어. 최종 userId = local@{id} */
+    /** 새로 만드는 자체 가입 계정의 userId 접두어. 최종 userId = local@{id} */
     public static final String USER_ID_PREFIX = "local@";
 
     @Id
@@ -38,7 +39,7 @@ public class LocalAccount {
     @Column(nullable = false, length = 255)
     private String passwordHash;
 
-    /** user 테이블과 연결되는 값. "local@{id}" */
+    /** user 테이블과 연결되는 값. 새로 가입하면 "local@{id}", 기존 계정에 연동하면 그 계정의 userId. */
     @Column(nullable = false, unique = true, length = 100)
     private String userId;
 

--- a/src/main/java/com/nklcbdty/api/user/controller/UserController.java
+++ b/src/main/java/com/nklcbdty/api/user/controller/UserController.java
@@ -52,17 +52,9 @@ public class UserController {
             .filter(o -> "job".equals(o.getItemType()))
             .map(UserInterestResponseDto::getItemValue)
             .collect(Collectors.toList());
-        List<Integer> careerYears = interestItems.stream()
-            .filter(o -> "career_year".equals(o.getItemType()))
-            .map(UserInterestResponseDto::getItemValue)
-            .map(Integer::valueOf)
-            .toList();
+        Integer careerYear = userInterestService.findCareerYear(userId);
 
-        if (careerYears.isEmpty()) {
-            result.put("careerYear", 0);
-        } else {
-            result.put("careerYear", careerYears.get(careerYears.size() - 1));
-        }
+        result.put("careerYear", careerYear == null ? 0 : careerYear);
         result.put("subscribedServices", companys);
         result.put("selectedJobRoles", jobs);
 

--- a/src/main/java/com/nklcbdty/api/user/repository/UserInterestQueryRepository.java
+++ b/src/main/java/com/nklcbdty/api/user/repository/UserInterestQueryRepository.java
@@ -1,0 +1,23 @@
+package com.nklcbdty.api.user.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.nklcbdty.common.vo.UserInterestVo;
+
+/**
+ * user_interest 를 itemType 단위로 다루기 위한 리포지터리.
+ *
+ * <p>공통 모듈의 {@code UserInterestRepository} 에는 itemType 단위 삭제/정렬 조회가 없어서
+ * 같은 엔티티를 가리키는 리포지터리를 서비스 쪽에 하나 더 둔다.
+ */
+@Repository
+public interface UserInterestQueryRepository extends JpaRepository<UserInterestVo, Long> {
+
+    /** 오래된 것부터. "가장 최근 값" 을 골라야 할 때 순서를 보장한다. */
+    List<UserInterestVo> findByUserIdAndItemTypeOrderByIdAsc(String userId, String itemType);
+
+    void deleteByUserIdAndItemType(String userId, String itemType);
+}

--- a/src/main/java/com/nklcbdty/api/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/nklcbdty/api/user/repository/UserProfileRepository.java
@@ -1,0 +1,21 @@
+package com.nklcbdty.api.user.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.nklcbdty.common.vo.UserVo;
+
+/**
+ * user 테이블을 이메일로 조회하기 위한 리포지터리.
+ *
+ * <p>공통 모듈의 {@code UserRepository} 에는 이메일 조회가 없어서, 같은 엔티티를 가리키는
+ * 리포지터리를 서비스 쪽에 하나 더 둔다(공통 jar 을 올리지 않아도 되도록).
+ */
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserVo, Long> {
+
+    /** 같은 이메일을 쓰는 계정들. 먼저 만들어진 계정부터. */
+    List<UserVo> findByEmailOrderByIdAsc(String email);
+}

--- a/src/main/java/com/nklcbdty/api/user/service/UserInterestService.java
+++ b/src/main/java/com/nklcbdty/api/user/service/UserInterestService.java
@@ -14,16 +14,22 @@ import org.springframework.transaction.annotation.Transactional;
 import com.nklcbdty.api.user.dto.DeltaResult;
 import com.nklcbdty.api.user.dto.UserInterestResponseDto;
 import com.nklcbdty.api.user.dto.UserSettingsRequest;
+import com.nklcbdty.api.user.repository.UserInterestQueryRepository;
 import com.nklcbdty.common.user.repository.UserInterestRepository;
 import com.nklcbdty.common.vo.UserInterestVo;
 
 @Service
 public class UserInterestService {
+    /** 경력은 한 사람당 하나뿐인 값이라 다른 itemType 과 달리 항상 1건만 유지한다. */
+    private static final String ITEM_TYPE_CAREER_YEAR = "career_year";
+
     private final UserInterestRepository repository;
+    private final UserInterestQueryRepository queryRepository;
 
     @Autowired
-    public UserInterestService(UserInterestRepository repository) {
+    public UserInterestService(UserInterestRepository repository, UserInterestQueryRepository queryRepository) {
         this.repository = repository;
+        this.queryRepository = queryRepository;
     }
 
     public List<UserInterestResponseDto> findByUserId(String userId) {
@@ -58,9 +64,7 @@ public class UserInterestService {
         // 5. 데이터베이스 삽입 처리 (processInsertions 사용)
         processInsertions(userId, "company", companyDelta.getToInsert());
         processInsertions(userId, "job", jobDelta.getToInsert());
-        List<String> career_year = new ArrayList<>();
-        career_year.add(userSettings.getSelectedCareerYears());
-        processInsertions(userId, "career_year", career_year);
+        applyCareerYear(userId, userSettings.getSelectedCareerYears());
 
         // 6. 변경 없이 유지된 항목 식별
         Set<String> companysRetained = originCompanys.stream()
@@ -72,6 +76,50 @@ public class UserInterestService {
 
         // 7. 유지된 항목의 update_dts 업데이트 (processRetainedUpdates 사용)
         processRetainedUpdates(userId, companysRetained, jobsRetained);
+    }
+
+    /**
+     * 저장된 경력 연차를 돌려줍니다. 설정한 적이 없으면 null.
+     *
+     * <p>경력은 {@link #applyCareerYear} 로 항상 1건만 유지하지만, 저장할 때마다 INSERT 만 해서
+     * 쌓인 예전 행이 남아 있을 수 있어 가장 나중에 들어온 행을 쓴다. id 순서를 명시해 조회하므로
+     * (정렬 없는 findByUserId 와 달리) 어떤 값이 나올지 보장된다.
+     */
+    public Integer findCareerYear(String userId) {
+        List<UserInterestVo> rows =
+            queryRepository.findByUserIdAndItemTypeOrderByIdAsc(userId, ITEM_TYPE_CAREER_YEAR);
+
+        for (int i = rows.size() - 1; i >= 0; i--) {
+            Integer careerYear = parseCareerYear(rows.get(i).getItemValue());
+            if (careerYear != null) {
+                return careerYear;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 경력 연차를 1건만 남도록 저장합니다. 값이 넘어오지 않으면 기존 설정을 그대로 둡니다.
+     */
+    private void applyCareerYear(String userId, String selectedCareerYears) {
+        if (parseCareerYear(selectedCareerYears) == null) {
+            return;
+        }
+
+        queryRepository.deleteByUserIdAndItemType(userId, ITEM_TYPE_CAREER_YEAR);
+        processInsertions(userId, ITEM_TYPE_CAREER_YEAR, List.of(selectedCareerYears.trim()));
+    }
+
+    /** 숫자가 아닌 값(과거 데이터)이 섞여 있어도 조회가 깨지지 않도록 null 로 넘긴다. */
+    private Integer parseCareerYear(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/test/java/com/nklcbdty/api/auth/service/LocalAuthServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/auth/service/LocalAuthServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import com.nklcbdty.api.auth.repository.LocalAccountRepository;
 import com.nklcbdty.api.auth.vo.LocalAccount;
 import com.nklcbdty.api.common.UtilityNklcb;
+import com.nklcbdty.api.user.repository.UserProfileRepository;
 import com.nklcbdty.common.user.repository.UserRepository;
 import com.nklcbdty.common.vo.UserVo;
 
@@ -34,6 +36,9 @@ class LocalAuthServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
 
     @Mock
     private TokenService tokenService;
@@ -97,6 +102,57 @@ class LocalAuthServiceTest {
         LocalAuthService.AuthResult result = service.signup("hong@example.com", "password123", null);
 
         assertThat(result.nickname()).isEqualTo("hong");
+    }
+
+    @Test
+    void signup_같은이메일의_카카오계정이_있으면_새_userId_대신_그_계정에_연동한다() {
+        when(localAccountRepository.existsByEmail("test@example.com")).thenReturn(false);
+        when(userProfileRepository.findByEmailOrderByIdAsc("test@example.com")).thenReturn(List.of(
+            UserVo.builder().id(1L).userId("kakao@2614615415").username("엄지").email("test@example.com").build()
+        ));
+        when(localAccountRepository.saveAndFlush(any(LocalAccount.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(userRepository.findByUserId("kakao@2614615415"))
+            .thenReturn(UserVo.builder().userId("kakao@2614615415").username("엄지").build());
+        when(utilityNklcb.generateToken("kakao@2614615415", false)).thenReturn("access-token");
+        when(utilityNklcb.generateToken("kakao@2614615415", true)).thenReturn("refresh-token");
+
+        LocalAuthService.AuthResult result = service.signup("Test@Example.com", "password123", "새닉네임");
+
+        // 기존 계정의 userId 를 그대로 쓴다 = 구독 설정/캘린더가 그대로 보인다
+        assertThat(result.userId()).isEqualTo("kakao@2614615415");
+        assertThat(result.nickname()).isEqualTo("엄지");
+        verify(tokenService, times(1)).saveRefreshToken("kakao@2614615415", "refresh-token");
+
+        // 자격증명만 추가하고 프로필(user 행)은 새로 만들지 않는다
+        ArgumentCaptor<LocalAccount> accountCaptor = ArgumentCaptor.forClass(LocalAccount.class);
+        verify(localAccountRepository).saveAndFlush(accountCaptor.capture());
+        assertThat(accountCaptor.getValue().getUserId()).isEqualTo("kakao@2614615415");
+        assertThat(new BCryptPasswordEncoder().matches("password123", accountCaptor.getValue().getPasswordHash()))
+            .isTrue();
+        verify(userRepository, never()).save(any(UserVo.class));
+        verify(localAccountRepository, never()).save(any(LocalAccount.class));
+    }
+
+    @Test
+    void signup_같은이메일_계정이_local이면_연동하지않고_새로_만든다() {
+        when(localAccountRepository.existsByEmail("test@example.com")).thenReturn(false);
+        // 자격증명이 정리되지 않고 남은 local@ 프로필은 연동 대상이 아니다
+        when(userProfileRepository.findByEmailOrderByIdAsc("test@example.com")).thenReturn(List.of(
+            UserVo.builder().id(4L).userId("local@3").username("엄지용").email("test@example.com").build()
+        ));
+        when(localAccountRepository.saveAndFlush(any(LocalAccount.class))).thenAnswer(inv -> {
+            LocalAccount account = inv.getArgument(0);
+            account.setId(9L);
+            return account;
+        });
+        when(localAccountRepository.save(any(LocalAccount.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(utilityNklcb.generateToken("local@9", false)).thenReturn("a");
+        when(utilityNklcb.generateToken("local@9", true)).thenReturn("r");
+
+        LocalAuthService.AuthResult result = service.signup("test@example.com", "password123", "테스터");
+
+        assertThat(result.userId()).isEqualTo("local@9");
+        verify(userRepository).save(any(UserVo.class));
     }
 
     @Test

--- a/src/test/java/com/nklcbdty/api/user/service/UserInterestServiceTest.java
+++ b/src/test/java/com/nklcbdty/api/user/service/UserInterestServiceTest.java
@@ -1,0 +1,112 @@
+package com.nklcbdty.api.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.nklcbdty.api.user.dto.UserSettingsRequest;
+import com.nklcbdty.api.user.repository.UserInterestQueryRepository;
+import com.nklcbdty.common.user.repository.UserInterestRepository;
+import com.nklcbdty.common.vo.UserInterestVo;
+
+@ExtendWith(MockitoExtension.class)
+class UserInterestServiceTest {
+
+    private static final String USER_ID = "kakao@2614615415";
+
+    @Mock
+    private UserInterestRepository repository;
+
+    @Mock
+    private UserInterestQueryRepository queryRepository;
+
+    @InjectMocks
+    private UserInterestService service;
+
+    // ------------------------------------------------------------ 경력 조회
+
+    @Test
+    void findCareerYear_설정한적이_없으면_null() {
+        when(queryRepository.findByUserIdAndItemTypeOrderByIdAsc(USER_ID, "career_year")).thenReturn(List.of());
+
+        assertThat(service.findCareerYear(USER_ID)).isNull();
+    }
+
+    @Test
+    void findCareerYear_과거_중복행이_남아있으면_가장_나중에_들어온_값을_쓴다() {
+        when(queryRepository.findByUserIdAndItemTypeOrderByIdAsc(USER_ID, "career_year")).thenReturn(List.of(
+            interest(22L, "2"),
+            interest(23L, "3"),
+            interest(25L, "5")
+        ));
+
+        assertThat(service.findCareerYear(USER_ID)).isEqualTo(5);
+    }
+
+    @Test
+    void findCareerYear_숫자가_아닌_값이_섞여있어도_깨지지_않는다() {
+        when(queryRepository.findByUserIdAndItemTypeOrderByIdAsc(USER_ID, "career_year")).thenReturn(List.of(
+            interest(1L, "3"),
+            interest(2L, "몰라요")
+        ));
+
+        assertThat(service.findCareerYear(USER_ID)).isEqualTo(3);
+    }
+
+    // ------------------------------------------------------------ 경력 저장
+
+    @Test
+    void updateUserSettings_경력은_기존행을_지우고_1건만_남긴다() {
+        when(repository.findByUserId(USER_ID)).thenReturn(List.of());
+
+        service.updateUserSettings(USER_ID, request("3"));
+
+        verify(queryRepository).deleteByUserIdAndItemType(USER_ID, "career_year");
+
+        ArgumentCaptor<List<UserInterestVo>> captor = ArgumentCaptor.forClass(List.class);
+        verify(repository).saveAll(captor.capture());
+        assertThat(captor.getValue()).hasSize(1);
+        assertThat(captor.getValue().get(0).getItemType()).isEqualTo("career_year");
+        assertThat(captor.getValue().get(0).getItemValue()).isEqualTo("3");
+    }
+
+    @Test
+    void updateUserSettings_경력값이_없으면_기존_설정을_지우지_않는다() {
+        when(repository.findByUserId(USER_ID)).thenReturn(List.of());
+
+        service.updateUserSettings(USER_ID, request(null));
+
+        verify(queryRepository, never()).deleteByUserIdAndItemType(anyString(), anyString());
+        verify(repository, never()).saveAll(anyList());
+    }
+
+    // ------------------------------------------------------------------ 헬퍼
+
+    private UserInterestVo interest(Long id, String value) {
+        return UserInterestVo.builder()
+            .id(id)
+            .userId(USER_ID)
+            .itemType("career_year")
+            .itemValue(value)
+            .build();
+    }
+
+    private UserSettingsRequest request(String careerYear) {
+        UserSettingsRequest request = new UserSettingsRequest();
+        request.setSelectedCareerYears(careerYear);
+        return request;
+    }
+}


### PR DESCRIPTION
## 증상

마이페이지 → 내 정보에서 이전에 설정한 구독 설정(기업·직무·경력)이 하나도 체크되지 않은 상태로 보였다.

## 원인

코드 버그가 아니라 **계정이 두 개로 갈려 있었다.**

| user_id | username | email |
|---|---|---|
| `kakao@2614615415` | 엄지 | teran1024@naver.com |
| `local@3` | 엄지용 | teran1024@naver.com |

`user_interest` 의 구독 설정 15건은 전부 `kakao@2614615415` 에 달려 있었고 `local@3` 에는 0건.
같은 이메일로 자체 회원가입(2026-08-01)을 하면서 `LocalAuthService.signup` 이 기존 계정을 보지 않고
새 `local@{id}` 를 발급했기 때문이다. 화면에는 `local@3` 로 로그인한 상태였으니 빈 설정이 맞게 보인 것.

경력이 `0년` 으로 보인 것도 career_year 행이 없을 때 0을 내려주는 fallback 때문.

## 변경

**같은 이메일 계정 연동**
- `LocalAuthService.signup`: 같은 이메일의 기존 계정(`local@` 이 아닌 것)이 있으면 새 userId 를
  만들지 않고 그 계정에 비밀번호 자격증명만 붙인다. 프로필(`user` 행)은 새로 만들지 않고 기존 닉네임을 유지.
- 이메일 인증 절차가 없어서 **남이 내 이메일로 가입해 계정을 이어받는 경로가 열린다** — 알고 택한 트레이드오프.
- `UserProfileRepository`: `user` 테이블 이메일 조회용. 공통 jar 을 올리지 않아도 되도록 서비스 쪽에
  같은 엔티티를 보는 리포지터리를 하나 더 뒀다(`JobContentRepository` 와 같은 방식).

**함께 고친 career_year 버그**
- 저장 시 delta 계산 없이 매번 INSERT 만 해서 행이 쌓였고(운영에 3건 = 2, 3, 3),
  조회는 정렬 없는 `findByUserId` 목록의 **마지막 값**을 써서 어떤 값이 나올지 보장되지 않았다.
- 이제 저장 시 기존 행을 지우고 1건만 남기고, 조회는 `OrderByIdAsc` 로 가장 최근 값을 쓴다.
- 숫자가 아닌 값이 섞여 있어도 500 이 나지 않게 파싱을 감쌌고, 값이 안 넘어오면 기존 설정을 지우지 않는다
  (예전엔 `null` 행 INSERT 를 시도했다).

## 운영 데이터 정리 (이미 적용됨)

`local@3` → `kakao@2614615415` 로 병합. 적용 전 46행 백업.

| 작업 | 건수 |
|---|---|
| `my_calendar_entry` user_id 이전 | 9 |
| `local_account` 재연결 (email/password 로그인이 병합 계정을 가리키게) | 1 |
| `user` 닉네임 유지 (엄지 → 엄지용) | 1 |
| `user` 중복 프로필 삭제 (`local@3`) | 1 |
| `refresh_tokens` 무효화 (`local@3`) | 18 |
| `career_year` 중복 행 정리 | 2 |

병합 후: company 8건 / job 4건 / career_year 1건(3) / 캘린더 9건 모두 `kakao@2614615415` 아래.

**사용자 조치**: `local@3` 토큰이 무효화됐으니 한 번 로그아웃 후 다시 로그인해야 한다.
데이터 병합만으로 증상은 지금 배포된 빌드에서도 해소된다(재로그인 시 토큰 sub 가 `kakao@2614615415` 가 됨).
이 PR 의 코드 변경은 재발 방지 + career_year 버그 수정이므로 배포는 급하지 않다.

## 검증

- `./gradlew test` — 211 통과. `NklcbdtyApplicationTests` 1건 실패는 `DATASOURCE_URL` 환경변수를 요구하는
  기존 문제로 이 변경과 무관(CI 는 `bootJar` 만 실행).
- 새 테스트: 기존 카카오 계정 연동 / local@ 프로필은 연동 대상 아님 / career_year 조회·저장 5건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
