### PR TITLE
🚨 Fix: 스키마 마이그레이션이 조용히 넘어가거나 기동을 멈출 수 있었다

### DIFF
--- a/src/main/java/com/nklcbdty/api/mycalendar/config/MyCalendarSchemaInitializer.java
+++ b/src/main/java/com/nklcbdty/api/mycalendar/config/MyCalendarSchemaInitializer.java
@@ -1,5 +1,7 @@
 package com.nklcbdty.api.mycalendar.config;
 
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -7,6 +9,7 @@ import java.util.Map;
 
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.jdbc.core.ConnectionCallback;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
@@ -54,6 +57,10 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
         RELAXED_COLUMNS.put("apply_date", "DATE NULL");
     }
 
+    /** 락을 기다리다 기동을 멈추지 않도록 하는 상한. 짧게 잡고 다음 기동에 다시 시도한다. */
+    private static final int LOCK_WAIT_SECONDS = 10;
+    private static final int QUERY_TIMEOUT_SECONDS = 20;
+
     private final JdbcTemplate jdbcTemplate;
 
     public MyCalendarSchemaInitializer(JdbcTemplate jdbcTemplate) {
@@ -81,7 +88,7 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
             ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
 
         try {
-            jdbcTemplate.execute(ddl);
+            alterWithBoundedWait(ddl);
             log.info("[MyCalendar] my_calendar_entry 테이블 확인/생성 완료");
         } catch (Exception e) {
             log.error("[MyCalendar] my_calendar_entry 테이블 생성 실패: {}", e.getMessage(), e);
@@ -99,7 +106,7 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
 
     private void addColumnIfMissing(String column, String definition) {
         try {
-            jdbcTemplate.execute(
+            alterWithBoundedWait(
                 "ALTER TABLE my_calendar_entry ADD COLUMN IF NOT EXISTS " + column + " " + definition);
         } catch (Exception e) {
             log.error("[MyCalendar] my_calendar_entry.{} 컬럼 추가 실패: {}", column, e.getMessage(), e);
@@ -112,11 +119,10 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
      */
     private void relaxNotNull(String column, String definition) {
         try {
-            if (isNullable(column)) {
+            if (definitelyNullable(column)) {
                 return;
             }
-            jdbcTemplate.execute(
-                "ALTER TABLE my_calendar_entry MODIFY COLUMN " + column + " " + definition);
+            alterWithBoundedWait("ALTER TABLE my_calendar_entry MODIFY COLUMN " + column + " " + definition);
             log.info("[MyCalendar] my_calendar_entry.{} 를 NULL 허용으로 바꿨다 — 상시채용 저장 가능", column);
         } catch (Exception e) {
             // 실패하면 상시채용 저장이 500 이 난다. 원인을 바로 알 수 있게 남긴다.
@@ -125,14 +131,62 @@ public class MyCalendarSchemaInitializer implements ApplicationRunner {
         }
     }
 
-    /** 컬럼이 NULL 을 허용하는지. 컬럼이 없으면(=방금 추가됐다) 정의대로 NULL 허용이므로 true. */
-    private boolean isNullable(String column) {
-        final List<String> nullable = jdbcTemplate.queryForList(
-            "SELECT is_nullable FROM information_schema.columns "
-                + "WHERE table_schema = DATABASE() AND table_name = 'my_calendar_entry' "
-                + "  AND column_name = ?",
-            String.class, column);
-        return nullable.isEmpty() || "YES".equalsIgnoreCase(nullable.get(0));
+    /**
+     * DDL 을 <b>반드시 시간 안에 끝나게</b> 실행한다.
+     *
+     * <p>이 DB(travel 스키마)는 다른 프로젝트와 함께 쓴다. 남의 긴 트랜잭션이 이 테이블을 잡고 있으면
+     * ALTER 는 메타데이터 락을 기다리며 <b>예외도 없이 멈춘다</b>. 이 코드는 ApplicationRunner
+     * 안에서 돌기 때문에, 그대로 기다리면 기동이 끝나지 않고 컨테이너가 안 뜬다 —
+     * "재배포는 성공인데 앱이 안 뜬다" 가 이 프로젝트에서 이미 여러 번 있었다.</p>
+     *
+     * <p>그래서 두 겹으로 막는다. {@code lock_wait_timeout} 은 락 대기를, JDBC
+     * {@code queryTimeout} 은 그마저 안 통할 때를 자른다. 포기해도 다음 기동에서 다시 시도하므로
+     * 잃는 것이 없다(그때까지 상시채용 저장만 안 된다).</p>
+     *
+     * <p>두 문장이 <b>같은 커넥션</b>에서 돌아야 해서 ConnectionCallback 을 쓴다.
+     * {@code jdbcTemplate.execute(String)} 를 두 번 부르면 풀에서 다른 커넥션을 받아
+     * {@code SET SESSION} 이 ALTER 에 적용되지 않는다.</p>
+     */
+    private void alterWithBoundedWait(String ddl) {
+        jdbcTemplate.execute((ConnectionCallback<Void>) connection -> {
+            try (Statement statement = connection.createStatement()) {
+                // MySQL 5.5+/MariaDB 에만 있다. 없는 DB 라도 ALTER 는 시도해야 하므로 여기서 삼킨다.
+                try {
+                    statement.execute("SET SESSION lock_wait_timeout = " + LOCK_WAIT_SECONDS);
+                } catch (SQLException e) {
+                    log.debug("[MyCalendar] lock_wait_timeout 설정 실패(무시): {}", e.getMessage());
+                }
+                statement.setQueryTimeout(QUERY_TIMEOUT_SECONDS);
+                statement.execute(ddl);
+            }
+            return null;
+        });
+    }
+
+    /**
+     * 컬럼이 NULL 을 허용한다고 <b>확인된</b> 경우에만 true.
+     *
+     * <p>모르겠으면 false 다. "모르겠다" 를 "허용한다" 로 보면 ALTER 를 건너뛰는데, 실제로는
+     * NOT NULL 이었을 때 상시채용 저장이 500 이 나면서 <b>로그에 아무것도 남지 않는다</b>.
+     * ALTER 는 같은 정의로 여러 번 걸어도 결과가 같으니, 확신이 없으면 그냥 걸어 보는 쪽이 안전하다.</p>
+     *
+     * <p>{@code table_schema = DATABASE()} 로 지금 쓰는 스키마만 본다 — 이 DB 는 여러 프로젝트가
+     * 공유하므로 같은 이름의 테이블이 다른 스키마에 있을 수 있다.</p>
+     */
+    private boolean definitelyNullable(String column) {
+        try {
+            final List<String> nullable = jdbcTemplate.queryForList(
+                "SELECT is_nullable FROM information_schema.columns "
+                    + "WHERE table_schema = DATABASE() AND LOWER(table_name) = 'my_calendar_entry' "
+                    + "  AND LOWER(column_name) = ?",
+                String.class, column);
+            return !nullable.isEmpty() && "YES".equalsIgnoreCase(nullable.get(0));
+        } catch (Exception e) {
+            // 조회 자체가 안 되면 알 수 없다. ALTER 를 걸어 보고 그 결과로 판단하게 둔다.
+            log.debug("[MyCalendar] {} 컬럼 nullability 조회 실패 — ALTER 를 그대로 시도한다: {}",
+                column, e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/src/test/java/com/nklcbdty/api/mycalendar/config/MyCalendarSchemaInitializerTest.java
+++ b/src/test/java/com/nklcbdty/api/mycalendar/config/MyCalendarSchemaInitializerTest.java
@@ -1,0 +1,120 @@
+package com.nklcbdty.api.mycalendar.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+
+/**
+ * 스키마 초기화를 진짜 DB(H2, MySQL 모드) 에 대고 돌린다.
+ *
+ * <p>이 코드가 틀리면 앱은 뜨는데 캘린더 API 만 500 이 나거나, 최악의 경우 기동이 멈춘다.
+ * 눈으로 읽어서는 알 수 없는 부분이라(특히 "이미 NOT NULL 인 테이블" 경로) 실제로 실행해 본다.
+ * H2 는 MariaDB 가 아니므로 DDL 문법이 통하는지까지만 보증한다 — 락 동작은 흉내내지 못한다.</p>
+ */
+class MyCalendarSchemaInitializerTest {
+
+    private SingleConnectionDataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
+    private MyCalendarSchemaInitializer initializer;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트마다 새 인메모리 DB. MySQL 모드라야 MODIFY COLUMN 같은 문법이 통한다.
+        dataSource = new SingleConnectionDataSource(
+            "jdbc:h2:mem:mycal-" + System.nanoTime() + ";MODE=MySQL;DATABASE_TO_LOWER=TRUE", "sa", "", true);
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        initializer = new MyCalendarSchemaInitializer(jdbcTemplate);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataSource.destroy();
+    }
+
+    private String nullabilityOf(String column) {
+        final List<String> value = jdbcTemplate.queryForList(
+            "SELECT is_nullable FROM information_schema.columns "
+                + "WHERE LOWER(table_name) = 'my_calendar_entry' AND LOWER(column_name) = ?",
+            String.class, column);
+        return value.isEmpty() ? "(컬럼 없음)" : value.get(0);
+    }
+
+    @Test
+    @DisplayName("빈 DB 에서: 테이블을 만들고 상시채용(날짜 없는 행)이 저장된다")
+    void createsTableThatAcceptsOngoingRows() {
+        initializer.run(null);
+
+        assertThat(nullabilityOf("apply_date")).isEqualToIgnoringCase("YES");
+        assertThatCode(() -> jdbcTemplate.update(
+            "INSERT INTO my_calendar_entry (user_id, apply_date, company_name, completed) "
+                + "VALUES ('local@me', NULL, '카카오', 0)"))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("상시채용 이전에 만들어진 테이블(apply_date NOT NULL)의 NOT NULL 을 풀어 준다")
+    void relaxesNotNullOnAnExistingTable() {
+        // 이 기능 전의 스키마를 그대로 만든다 — completed 컬럼도 없다.
+        jdbcTemplate.execute(
+            "CREATE TABLE my_calendar_entry ("
+                + "  id BIGINT NOT NULL AUTO_INCREMENT,"
+                + "  user_id VARCHAR(255) NOT NULL,"
+                + "  apply_date DATE NOT NULL,"
+                + "  company_name VARCHAR(100) NOT NULL,"
+                + "  url VARCHAR(1000) NULL,"
+                + "  memo VARCHAR(2000) NULL,"
+                + "  insert_dts DATETIME NULL,"
+                + "  update_dts DATETIME NULL,"
+                + "  PRIMARY KEY (id))");
+        jdbcTemplate.update("INSERT INTO my_calendar_entry (user_id, apply_date, company_name) "
+            + "VALUES ('local@me', '2026-08-25', '네이버')");
+        assertThat(nullabilityOf("apply_date")).isEqualToIgnoringCase("NO");
+
+        initializer.run(null);
+
+        assertThat(nullabilityOf("apply_date")).isEqualToIgnoringCase("YES");
+        assertThat(nullabilityOf("completed")).isEqualToIgnoringCase("NO");
+        // 이미 있던 행이 살아 있어야 한다. 마이그레이션이 데이터를 날리면 안 된다.
+        assertThat(jdbcTemplate.queryForObject(
+            "SELECT company_name FROM my_calendar_entry WHERE id = 1", String.class)).isEqualTo("네이버");
+        // 그리고 이제 상시채용이 들어간다.
+        assertThatCode(() -> jdbcTemplate.update(
+            "INSERT INTO my_calendar_entry (user_id, apply_date, company_name, completed) "
+                + "VALUES ('local@me', NULL, '쿠팡', 0)"))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("여러 번 기동해도 안전하다 — 두 번째 실행은 아무것도 바꾸지 않는다")
+    void isSafeToRunTwice() {
+        initializer.run(null);
+
+        assertThatCode(() -> initializer.run(null)).doesNotThrowAnyException();
+        assertThat(nullabilityOf("apply_date")).isEqualToIgnoringCase("YES");
+    }
+
+    /**
+     * 기동을 멈추지 않는다는 것이 이 클래스의 가장 중요한 성질이다. DataSource 가 죽어 있어도
+     * 예외가 밖으로 나가면 ApplicationRunner 가 기동을 실패시킨다.
+     */
+    @Test
+    @DisplayName("DB 가 죽어 있어도 예외를 던지지 않는다 — 기동을 막으면 안 된다")
+    void neverThrowsEvenWhenTheDatabaseIsUnreachable() {
+        final DataSource broken = new SingleConnectionDataSource(
+            "jdbc:h2:mem:nope;IFEXISTS=TRUE", "sa", "", true);
+        final MyCalendarSchemaInitializer onBrokenDb =
+            new MyCalendarSchemaInitializer(new JdbcTemplate(broken));
+
+        assertThatCode(() -> onBrokenDb.run(null)).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
#221 로 들어간 `MyCalendarSchemaInitializer` 를 **진짜 DB(H2, MySQL 모드) 에 대고 돌려 봤다.** 눈으로 읽어서는 안 보이던 두 가지가 나왔다.

## 1. 마이그레이션이 조용히 넘어갈 수 있었다

`isNullable()` 은 nullability 조회가 **아무것도 못 찾으면 "NULL 허용"** 으로 봤다. 그러면 ALTER 를 건너뛰는데, 컬럼이 실제로는 NOT NULL 이면 상시채용 저장이 500 이 나면서 **로그에 아무 단서도 안 남는다.**

이제 "허용한다고 확인된" 경우에만 건너뛴다. ALTER 는 같은 정의로 여러 번 걸어도 결과가 같으니, 확신이 없으면 걸어 보는 쪽이 안전하다.

(H2 테스트에서 `table_schema = DATABASE()` 가 안 맞아 이 경로를 밟았다. MariaDB 에선 `DATABASE()` 가 곧 스키마라 정상 동작한다 — 즉 운영 버그는 아니었지만, 조회가 실패하는 날엔 똑같이 조용히 넘어간다.)

## 2. ALTER 가 기동을 멈출 수 있었다

`ALTER TABLE` 은 메타데이터 락을 기다리며 **예외도 없이 멈춘다.** 이 DB(travel)는 다른 프로젝트와 함께 쓰니 남의 긴 트랜잭션이 이 테이블을 잡을 수 있고, 이 코드는 `ApplicationRunner` 안이라 그대로 기다리면 **기동이 끝나지 않고 컨테이너가 안 뜬다.** 이 프로젝트에서 "재배포는 성공인데 앱이 안 뜬다" 는 이미 있었던 일이다.

`lock_wait_timeout`(10초) 과 JDBC `queryTimeout`(20초) 으로 두 겹으로 자른다. 포기해도 다음 기동에서 다시 시도하니 잃는 게 없다.

두 문장이 **같은 커넥션**에서 돌아야 해서 `ConnectionCallback` 을 쓴다. `jdbcTemplate.execute(String)` 를 두 번 부르면 풀에서 다른 커넥션을 받아 `SET SESSION` 이 ALTER 에 적용되지 않는다.

CREATE TABLE / ADD COLUMN 도 같은 위험이 있어 같은 경로로 보냈다.

## 테스트

`MyCalendarSchemaInitializerTest` 신규 — 4개 모두 실제 DB 에 대고 돈다.

- 빈 DB → 테이블 생성 + 날짜 없는 행이 저장된다
- **상시채용 이전 스키마(`apply_date NOT NULL`, `completed` 없음)** → NOT NULL 이 풀리고, `completed` 가 붙고, 기존 행이 살아 있고, 날짜 없는 행이 들어간다
- 두 번 돌려도 안전하다
- **DB 가 죽어 있어도 예외를 던지지 않는다** — 가장 중요하다. 예외가 `ApplicationRunner` 밖으로 나가면 앱이 아예 안 뜬다

두 번째 테스트는 수정 전 코드에서 **실제로 실패했다**(`apply_date` 가 `NO` 그대로). 그래서 이 PR 이 필요하다.

전체 225개 중 224개 통과. `NklcbdtyApplicationTests.contextLoads` 만 실패하는데 이 브랜치 이전부터 같이 실패한다(로컬에 DB 접속 정보 없음).

## 참고: 지금 운영 백엔드는 내려가 있다

2026-08-23 05:00 KST 경부터 `/api/*` 가 전부 404 다(앱이 떠 있으면 `AuthFilter` 가 401 을 준다). 머지(8/22 12:46Z)로부터 7시간 뒤이고 그 사이 배포 잡은 skip 되어 아무 배포도 없었다 — **원인은 확인하지 못했다.** 클라우드타입 로그를 봐야 한다. 이 PR 은 그 원인을 안다고 주장하는 게 아니라, 기동을 멈출 수 있는 경로를 하나 닫는 것이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database schema updates by applying bounded timeouts, preventing operations from hanging indefinitely.
  * Schema repair now proceeds when metadata checks fail, improving resilience during startup.
  * Existing calendar data is preserved while required schema adjustments are applied.
  * Application startup no longer fails when the database is temporarily unreachable.

* **Tests**
  * Added coverage for schema creation, upgrades, repeated initialization, nullable dates, and unavailable databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->